### PR TITLE
Make vacuum robot wifi settings configurable via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ wifi network, especially if you block its internet access.
 The token does not change by configuring wifi. All subsequent commands must be sent to
 the IP that the robot obtains via DHCP from your router.
 
+*Note, that this only works on devices from which you have obtained a token beforehand and therefore rules out e.g. vacuums with firmware 3.3.9_003077 or higher.* Any ideas for extracting the token on newer devices without using the official app and extracting them from the database are appreciated!
+
 ### Setting the fanspeed
 
 ```

--- a/README.md
+++ b/README.md
@@ -222,6 +222,9 @@ OK
 It may take a few minutes before the robot responds to commands after it connected to the
 wifi network, especially if you block its internet access.
 
+The token does not change by configuring wifi. All subsequent commands must be sent to
+the IP that the robot obtains via DHCP from your router.
+
 ### Setting the fanspeed
 
 ```

--- a/README.md
+++ b/README.md
@@ -211,6 +211,17 @@ $ mirobo home
 Requesting return to home: 0
 ```
 
+### Configure wifi settings (WPA2)
+
+```
+$ mirobo configure_wifi "My SSID" "My Wifi password"
+Configuring wifi to SSID: My SSID
+OK
+```
+
+It may take a few minutes before the robot responds to commands after it connected to the
+wifi network, especially if you block its internet access.
+
 ### Setting the fanspeed
 
 ```

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -202,6 +202,10 @@ class Vacuum(Device):
         """Set the timezone."""
         return self.send("set_timezone", [new_zone])[0] == 'ok'
 
+    def configure_wifi(self, ssid, password, uid=0):
+        """Configure the wifi settings."""
+        return self.send("miIO.config_router", { "ssid": ssid, "passwd": password, "uid": uid })[0]
+
     def raw_command(self, cmd, params):
         """Send a raw command to the robot."""
         return self.send(cmd, params)

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -204,7 +204,8 @@ class Vacuum(Device):
 
     def configure_wifi(self, ssid, password, uid=0):
         """Configure the wifi settings."""
-        return self.send("miIO.config_router", { "ssid": ssid, "passwd": password, "uid": uid })[0]
+        params = {"ssid": ssid, "passwd": password, "uid": uid}
+        return self.send("miIO.config_router", params)[0]
 
     def raw_command(self, cmd, params):
         """Send a raw command to the robot."""

--- a/miio/vacuum_cli.py
+++ b/miio/vacuum_cli.py
@@ -418,6 +418,18 @@ def timezone(vac: miio.Vacuum, tz=None):
 
 
 @cli.command()
+@click.argument('ssid', required=True)
+@click.argument('password', required=True)
+@click.argument('uid', type=int, required=False)
+@pass_dev
+def configure_wifi(vac: miio.Vacuum, ssid: str,
+        password: str, uid: int):
+    """Configure the wifi settings."""
+    click.echo("Configuring wifi to SSID: %s" % ssid)
+    click.echo(vac.configure_wifi(ssid, password, uid))
+
+
+@cli.command()
 @click.argument('cmd', required=True)
 @click.argument('parameters', required=False)
 @pass_dev

--- a/miio/vacuum_cli.py
+++ b/miio/vacuum_cli.py
@@ -422,8 +422,7 @@ def timezone(vac: miio.Vacuum, tz=None):
 @click.argument('password', required=True)
 @click.argument('uid', type=int, required=False)
 @pass_dev
-def configure_wifi(vac: miio.Vacuum, ssid: str,
-        password: str, uid: int):
+def configure_wifi(vac: miio.Vacuum, ssid: str, password: str, uid: int):
     """Configure the wifi settings."""
     click.echo("Configuring wifi to SSID: %s" % ssid)
     click.echo(vac.configure_wifi(ssid, password, uid))


### PR DESCRIPTION
These changes allow you to configure the wifi of the Xiaomi vacuum cleaner without needing the Mi Home smartphone app.

It is now effectively possible to use python-miio with the robot in your home wifi network without a Xiaomi account and their app.

Reference:
https://github.com/OpenMiHome/mihome-binary-protocol/blob/master/doc/PROTOCOL.md#payloads

The document mentions that the 'id' field must be a Unix timestamp. This seems to be nonsense. Works perfectly fine with the sequential id. I assumed that it might be used to set the clock of the rebot, but it is not. (It uses NTP.)

I am not sure what the 'uid' field is. Probably the Xiaomi account id that allows them to connect your robot to your account. This should be pretty useless if you don't set the robot up with their app. Hence, I made it an optional parameter.