### PR TITLE
Add the ability to define a timezone for configure_wifi

### DIFF
--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -3,6 +3,8 @@ import math
 import time
 from typing import List
 import enum
+import datetime
+import pytz
 
 from .vacuumcontainers import (VacuumStatus, ConsumableStatus, DNDStatus,
                                CleaningSummary, CleaningDetails, Timer)
@@ -202,9 +204,15 @@ class Vacuum(Device):
         """Set the timezone."""
         return self.send("set_timezone", [new_zone])[0] == 'ok'
 
-    def configure_wifi(self, ssid, password, uid=0):
+    def configure_wifi(self, ssid, password, uid=0, timezone=None):
         """Configure the wifi settings."""
         params = {"ssid": ssid, "passwd": password, "uid": uid}
+        if timezone is not None:
+            now = datetime.datetime.now(pytz.timezone(timezone))
+            offset_as_float = now.utcoffset().total_seconds() / 60 / 60
+            params["tz"] = timezone
+            params["gmt_offset"] = offset_as_float
+
         return self.send("miIO.config_router", params)[0]
 
     def raw_command(self, cmd, params):

--- a/miio/vacuum_cli.py
+++ b/miio/vacuum_cli.py
@@ -421,11 +421,16 @@ def timezone(vac: miio.Vacuum, tz=None):
 @click.argument('ssid', required=True)
 @click.argument('password', required=True)
 @click.argument('uid', type=int, required=False)
+@click.option('--timezone', type=str, required=False, default=None)
 @pass_dev
-def configure_wifi(vac: miio.Vacuum, ssid: str, password: str, uid: int):
-    """Configure the wifi settings."""
+def configure_wifi(vac: miio.Vacuum, ssid: str, password: str,
+                   uid: int, timezone: str):
+    """Configure the wifi settings.
+
+    Note that some newer firmwares may expect you to define the timezone
+    by using --timezone."""
     click.echo("Configuring wifi to SSID: %s" % ssid)
-    click.echo(vac.configure_wifi(ssid, password, uid))
+    click.echo(vac.configure_wifi(ssid, password, uid, timezone))
 
 
 @cli.command()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ zeroconf
 pycrypto #  for miio-extract-tokens
 attrs
 typing  # for py3.4 support
+pytz  # for tz offset in vacuum

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,9 @@ setup(
     packages=["miio", "mirobo"],
 
     python_requires='>=3.4',
-    install_requires=['construct', 'click', 'cryptography', 'pretty_cron', 'typing', 'zeroconf', 'pycrypto', 'attrs'],
+    install_requires=['construct', 'click', 'cryptography', 'pretty_cron',
+                      'typing', 'zeroconf', 'pycrypto', 'attrs', 'pytz'],
+
     entry_points={
         'console_scripts': [
             'mirobo=miio.vacuum_cli:cli',


### PR DESCRIPTION
This will allow passing the timezone to vacuums running
newer firmware versions, as mentioned in PR #105

Thanks to @marcelrv  for pointing this out.