### PR TITLE
Reset consumable by name

### DIFF
--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -21,11 +21,13 @@ class TimerState(enum.Enum):
     On = "on"
     Off = "off"
 
+
 class Consumable(enum.Enum):
     MainBrush = "main_brush_work_time"
     SideBrush = "side_brush_work_time"
     Filter = "filter_work_time"
     SensorDirty = "sensor_dirty_time"
+
 
 class Vacuum(Device):
     """Main class representing the vacuum."""

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -110,10 +110,10 @@ class Vacuum(Device):
         """Return information about consumables."""
         return ConsumableStatus(self.send("get_consumable")[0])
 
-    def consumable_reset(self):
+    def consumable_reset(self, name):
         """Reset consumable information."""
-        raise NotImplementedError("unknown parameters")
-        # self.send("reset_consumable", ["unknown"])
+        # name = ["main_brush_work_time", "side_brush_work_time", "sensor_dirty_time" or "filter_work_time"]
+        return self.send("reset_consumable", [name])
 
     def map(self):
         """Return map token."""

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -21,6 +21,12 @@ class TimerState(enum.Enum):
     On = "on"
     Off = "off"
 
+class Consumable(enum.Enum):
+    MainBrush = "main_brush_work_time"
+    SideBrush = "side_brush_work_time"
+    Filter = "filter_work_time"
+    SensorDirty = "sensor_dirty_time"
+
 class Vacuum(Device):
     """Main class representing the vacuum."""
 
@@ -110,10 +116,9 @@ class Vacuum(Device):
         """Return information about consumables."""
         return ConsumableStatus(self.send("get_consumable")[0])
 
-    def consumable_reset(self, name):
+    def consumable_reset(self, consumable: Consumable):
         """Reset consumable information."""
-        # name = ["main_brush_work_time", "side_brush_work_time", "sensor_dirty_time" or "filter_work_time"]
-        return self.send("reset_consumable", [name])
+        return self.send("reset_consumable", [consumable.value])
 
     def map(self):
         """Return map token."""

--- a/miio/vacuum_cli.py
+++ b/miio/vacuum_cli.py
@@ -148,7 +148,10 @@ def consumables(vac: miio.Vacuum):
 @click.argument('name', type=str, required=True)
 @pass_dev
 def reset_consumable(vac: miio.Vacuum, name):
-    """Reset consumable."""
+    """Reset consumable state
+
+    Allowed values: main_brush, side_brush, filter, sensor_dirty
+    """
     from miio.vacuum import Consumable
     if name == 'main_brush':
         consumable = Consumable.MainBrush
@@ -159,6 +162,7 @@ def reset_consumable(vac: miio.Vacuum, name):
     elif name == 'sensor_dirty':
         consumable = Consumable.SensorDirty
     else:
+        click.echo("Allowed values: main_brush, side_brush, filter, sensor_dirty")
         return
 
     click.echo("Resetting consumable '%s': %s" % (

--- a/miio/vacuum_cli.py
+++ b/miio/vacuum_cli.py
@@ -148,9 +148,20 @@ def consumables(vac: miio.Vacuum):
 @click.argument('name', type=str, required=True)
 @pass_dev
 def reset_consumable(vac: miio.Vacuum, name):
-    """Query and reset consumable."""
-    click.echo("Reset consumable %s" % name)
-    vac.consumable_reset(name)
+    """Reset consumable."""
+    from miio.vacuum import Consumable
+    if name == 'main_brush':
+        consumable = Consumable.MainBrush
+    elif name == 'side_brush':
+        consumable = Consumable.SideBrush
+    elif name == 'filter':
+        consumable = Consumable.Filter
+    elif name == 'sensor_dirty':
+        consumable = Consumable.SensorDirty
+    else:
+        return
+
+    click.echo("Resetting consumable '%s': %s" % (name, vac.consumable_reset(consumable)))
 
 
 @cli.command()
@@ -454,6 +465,6 @@ def raw_command(vac: miio.Vacuum, cmd, parameters):
     click.echo("Sending cmd %s with params %s" % (cmd, params))
     click.echo(vac.raw_command(cmd, params))
 
-
+cli()
 if __name__ == "__main__":
     cli()

--- a/miio/vacuum_cli.py
+++ b/miio/vacuum_cli.py
@@ -145,6 +145,15 @@ def consumables(vac: miio.Vacuum):
 
 
 @cli.command()
+@click.argument('name', type=str, required=True)
+@pass_dev
+def reset_consumable(vac: miio.Vacuum, name):
+    """Query and reset consumable."""
+    click.echo("Reset consumable %s" % name)
+    vac.consumable_reset(name)
+
+
+@cli.command()
 @pass_dev
 def start(vac: miio.Vacuum):
     """Start cleaning."""

--- a/miio/vacuum_cli.py
+++ b/miio/vacuum_cli.py
@@ -465,6 +465,6 @@ def raw_command(vac: miio.Vacuum, cmd, parameters):
     click.echo("Sending cmd %s with params %s" % (cmd, params))
     click.echo(vac.raw_command(cmd, params))
 
-cli()
+
 if __name__ == "__main__":
     cli()

--- a/miio/vacuum_cli.py
+++ b/miio/vacuum_cli.py
@@ -161,7 +161,8 @@ def reset_consumable(vac: miio.Vacuum, name):
     else:
         return
 
-    click.echo("Resetting consumable '%s': %s" % (name, vac.consumable_reset(consumable)))
+    click.echo("Resetting consumable '%s': %s" % (name,
+                                                  vac.consumable_reset(consumable)))
 
 
 @cli.command()

--- a/miio/vacuum_cli.py
+++ b/miio/vacuum_cli.py
@@ -161,8 +161,10 @@ def reset_consumable(vac: miio.Vacuum, name):
     else:
         return
 
-    click.echo("Resetting consumable '%s': %s" % (name,
-                                                  vac.consumable_reset(consumable)))
+    click.echo("Resetting consumable '%s': %s" % (
+        name,
+        vac.consumable_reset(consumable)
+    ))
 
 
 @cli.command()

--- a/miio/vacuum_cli.py
+++ b/miio/vacuum_cli.py
@@ -148,7 +148,7 @@ def consumables(vac: miio.Vacuum):
 @click.argument('name', type=str, required=True)
 @pass_dev
 def reset_consumable(vac: miio.Vacuum, name):
-    """Reset consumable state
+    """Reset consumable state.
 
     Allowed values: main_brush, side_brush, filter, sensor_dirty
     """
@@ -162,7 +162,7 @@ def reset_consumable(vac: miio.Vacuum, name):
     elif name == 'sensor_dirty':
         consumable = Consumable.SensorDirty
     else:
-        click.echo("Allowed values: main_brush, side_brush, filter, sensor_dirty")
+        click.echo("Unexpected state name: %s" % name)
         return
 
     click.echo("Resetting consumable '%s': %s" % (


### PR DESCRIPTION
Available consumable names:
- main_brush_work_time
- side_brush_work_time
- sensor_dirty_time
- filter_work_time

CLI example:
`miio reset_consumable sensor_dirty_time`

Tested with my robot.