### PR TITLE
Load power of the PowerStrip fixed and removed from the Plug

### DIFF
--- a/miio/plug.py
+++ b/miio/plug.py
@@ -27,20 +27,10 @@ class PlugStatus:
         """Return temperature."""
         return self.data["temperature"]
 
-    @property
-    def load_power(self) -> Optional[float]:
-        """Return current load power."""
-        if self.data["current"] is not None:
-            # The constant of 110V is used intentionally. The current was
-            # calculated with a wrong reference voltage already.
-            return self.data["current"] * 110
-        return None
-
     def __str__(self) -> str:
-        s = "<PlugStatus power=%s, temperature=%s, load_power=%s>" % \
+        s = "<PlugStatus power=%s, temperature=%s>" % \
             (self.power,
-             self.temperature,
-             self.load_power)
+             self.temperature)
         return s
 
 
@@ -49,7 +39,7 @@ class Plug(Device):
 
     def status(self) -> PlugStatus:
         """Retrieve properties."""
-        properties = ['power', 'temperature', 'current']
+        properties = ['power', 'temperature']
         values = self.send(
             "get_prop",
             properties

--- a/miio/powerstrip.py
+++ b/miio/powerstrip.py
@@ -65,7 +65,8 @@ class PowerStrip(Device):
 
     def status(self) -> PowerStripStatus:
         """Retrieve properties."""
-        properties = ['power', 'temperature', 'current', 'mode', 'power_consume_rate']
+        properties = ['power', 'temperature', 'current', 'mode',
+                      'power_consume_rate']
         values = self.send(
             "get_prop",
             properties

--- a/miio/powerstrip.py
+++ b/miio/powerstrip.py
@@ -40,10 +40,8 @@ class PowerStripStatus:
     @property
     def load_power(self) -> Optional[float]:
         """Current power load, if available."""
-        if self.data["current"] is not None:
-            # The constant of 110V is used intentionally. The current was
-            # calculated with a wrong reference voltage already.
-            return self.data["current"] * 110
+        if self.data["power_consume_rate"] is not None:
+            return self.data["power_consume_rate"]
         return None
 
     @property
@@ -53,10 +51,11 @@ class PowerStripStatus:
 
     def __str__(self) -> str:
         s = "<PowerStripStatus power=%s, temperature=%s, " \
-            "load_power=%s mode=%s>" % \
+            "load_power=%s, current=%s, mode=%s>" % \
             (self.power,
              self.temperature,
              self.load_power,
+             self.current,
              self.mode)
         return s
 
@@ -66,7 +65,7 @@ class PowerStrip(Device):
 
     def status(self) -> PowerStripStatus:
         """Retrieve properties."""
-        properties = ['power', 'temperature', 'current', 'mode']
+        properties = ['power', 'temperature', 'current', 'mode', 'power_consume_rate']
         values = self.send(
             "get_prop",
             properties

--- a/miio/tests/test_powerstrip.py
+++ b/miio/tests/test_powerstrip.py
@@ -8,6 +8,7 @@ class DummyPowerStrip(DummyDevice, PowerStrip):
     def __init__(self, *args, **kwargs):
         self.state = {
             'power': 'on',
+            'mode': 'normal',
             'temperature': 32.5,
             'current': 123,
             'power_consume_rate': 12.5,

--- a/miio/tests/test_powerstrip.py
+++ b/miio/tests/test_powerstrip.py
@@ -54,8 +54,10 @@ class TestPowerStrip(TestCase):
         self.device._reset_state()
 
         assert self.is_on() is True
-        assert self.state().temperature == self.device.start_state["temperature"]
-        assert self.state().load_power == self.device.start_state["power_consume_rate"]
+        assert self.state().temperature == \
+               self.device.start_state["temperature"]
+        assert self.state().load_power == \
+               self.device.start_state["power_consume_rate"]
 
     def test_status_without_power_consume_rate(self):
         del self.device.state["power_consume_rate"]

--- a/miio/tests/test_powerstrip.py
+++ b/miio/tests/test_powerstrip.py
@@ -1,14 +1,16 @@
 from unittest import TestCase
-from miio import Plug
+from miio import PowerStrip
 from .dummies import DummyDevice
 import pytest
 
 
-class DummyPlug(DummyDevice, Plug):
+class DummyPowerStrip(DummyDevice, PowerStrip):
     def __init__(self, *args, **kwargs):
         self.state = {
             'power': 'on',
             'temperature': 32,
+            'current': 123,
+            'power_consume_rate': 123,
         }
         self.return_values = {
             'get_prop': self._get_state,
@@ -18,13 +20,13 @@ class DummyPlug(DummyDevice, Plug):
 
 
 @pytest.fixture(scope="class")
-def plug(request):
-    request.cls.device = DummyPlug()
+def powerstrip(request):
+    request.cls.device = DummyPowerStrip()
     # TODO add ability to test on a real device
 
 
-@pytest.mark.usefixtures("plug")
-class TestPlug(TestCase):
+@pytest.mark.usefixtures("powerstrip")
+class TestPowerStrip(TestCase):
     def is_on(self):
         return self.device.status().is_on
 
@@ -52,3 +54,9 @@ class TestPlug(TestCase):
 
         assert self.is_on() is True
         assert self.state().temperature == self.device.start_state["temperature"]
+        assert self.state().load_power == self.device.start_state["power_consume_rate"]
+
+    def test_status_without_power_consume_rate(self):
+        del self.device.state["power_consume_rate"]
+
+        assert self.state().load_power is None

--- a/miio/tests/test_powerstrip.py
+++ b/miio/tests/test_powerstrip.py
@@ -8,9 +8,9 @@ class DummyPowerStrip(DummyDevice, PowerStrip):
     def __init__(self, *args, **kwargs):
         self.state = {
             'power': 'on',
-            'temperature': 32,
+            'temperature': 32.5,
             'current': 123,
-            'power_consume_rate': 123,
+            'power_consume_rate': 12.5,
         }
         self.return_values = {
             'get_prop': self._get_state,

--- a/miio/tests/test_powerstrip.py
+++ b/miio/tests/test_powerstrip.py
@@ -54,10 +54,8 @@ class TestPowerStrip(TestCase):
         self.device._reset_state()
 
         assert self.is_on() is True
-        assert self.state().temperature == \
-               self.device.start_state["temperature"]
-        assert self.state().load_power == \
-               self.device.start_state["power_consume_rate"]
+        assert self.state().temperature == self.device.start_state["temperature"]
+        assert self.state().load_power == self.device.start_state["power_consume_rate"]
 
     def test_status_without_power_consume_rate(self):
         del self.device.state["power_consume_rate"]


### PR DESCRIPTION

- Property load_power removed from the plug. It's a feature of the PowerStrip. The Xiaomi plug doesn't provide load. 
- Load power workaround of the PowerStrip replaced by a property called "power_consume_rate" which provides the same values as the android app.