### PR TITLE
Replace PyCrypto with PyCryptoDome

### DIFF
--- a/miio/extract_tokens.py
+++ b/miio/extract_tokens.py
@@ -2,7 +2,7 @@ import logging
 import click
 import tempfile
 import sqlite3
-from Crypto.Cipher import AES
+from Cryptodome.Cipher import AES
 from pprint import pformat as pf
 import attr
 from android_backup import AndroidBackup

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cryptography
 pretty_cron
 construct
 zeroconf
-pycrypto #  for miio-extract-tokens
+pycryptodomex #  for miio-extract-tokens
 attrs
 typing  # for py3.4 support
 pytz  # for tz offset in vacuum

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
                       'pretty_cron',
                       'typing',
                       'zeroconf',
-                      'pycrypto',
+                      'pycryptodomex',
                       'attrs',
                       'android_backup',
                       'pytz'],


### PR DESCRIPTION
First of all, thanks for this great package!

I’m using Arch Linux, and after some tinkering, I now got `python-miio` to work properly 😃.

One issue that I stumbled upon is that Arch Linux doesn’t provide PyCrypto packages anymore. The background is that PyCrypto is [unsafe (it has security vulnerabilities and is no longer actively maintained)](https://blog.sqreen.io/stop-using-pycrypto-use-pycryptodome/), [outdated (the last release was in 2013)](https://github.com/dlitz/pycrypto/releases), and now superseded by [PyCryptoDome](https://www.pycryptodome.org/en/latest/src/introduction.html).

For this reason, I believe it would be best to replace PyCrypto with PyCryptoDome, which is what this pull request does.