### PR TITLE
Don’t require typing with Python 3.5 and newer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
                       'click',
                       'cryptography',
                       'pretty_cron',
-                      'typing',
+                      'typing; python_version < "3.5"',
                       'zeroconf',
                       'pycrypto',
                       'attrs',


### PR DESCRIPTION
Python 3.5 and newer ship with [built-in typing support](https://lwn.net/Articles/640359/). For this reason, there is no need to require the `typing` package starting from Python 3.5.

On Arch Linux, this requirement caused trouble, because Arch Linux doesn’t provide the `typing` package anymore, as it is deemed unnecessary now. For this reason, `python-miio` complains about the missing `typing` dependency without this adjustment.