### PR TITLE
Add ability to read IP and token from config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,14 @@ export MIROBO_IP=192.168.1.2
 export MIROBO_TOKEN=476e6b70343055483230644c53707a12
 ```
 
+Otherwise, you can create a config file at `~/.config/mirobo.cfg` with the ip and token as contents:
+
+```
+[mirobo]
+ip = 192.168.1.2
+token = 476e6b70343055483230644c53707a12
+```
+
 After that verify that the connection is working by running the command without parameters,
 you should be presented a status report from the vacuum.
 

--- a/miio/vacuum_cli.py
+++ b/miio/vacuum_cli.py
@@ -1,14 +1,21 @@
 # -*- coding: UTF-8 -*-
-import logging
-import click
-import pretty_cron
 import ast
-import sys
-import json
 import ipaddress
+import json
+import logging
+import os
+import sys
 from pprint import pformat as pf
 from typing import Any  # noqa: F401
 
+import click
+import miio  # noqa: E402
+import pretty_cron
+
+try:
+    import ConfigParser
+except ImportError:
+    import configparser as ConfigParser
 
 if sys.version_info < (3, 4):
     print("To use this script you need python 3.4 or newer, got %s" %
@@ -62,8 +69,15 @@ def cli(ctx, ip: str, token: str, debug: int, id_file: str):
         return
 
     if ip is None or token is None:
-        click.echo("You have to give ip and token!")
-        sys.exit(-1)
+        config = ConfigParser.SafeConfigParser()
+        config.read([os.path.expanduser('~/.config/mirobo.cfg')])
+        try:
+            config = dict(config.items("mirobo"))
+            ip = config["ip"]
+            token = config["token"]
+        except:
+            click.echo("You have to give ip and token!")
+            sys.exit(-1)
 
     start_id = manual_seq = 0
     try:


### PR DESCRIPTION
I don't like env vars, so I added a simple config file using ConfigParser. The script will prefer the vars (or command line options) as usual, but it will read the config file as a last resort.