### PR TITLE
update fan speed list for HK

### DIFF
--- a/miio/airpurifier.py
+++ b/miio/airpurifier.py
@@ -18,7 +18,6 @@ class OperationMode(enum.Enum):
     Auto = 'auto'
 
 
-
 class LedBrightness(enum.Enum):
     Bright = 0
     Dim = 1

--- a/miio/airpurifier.py
+++ b/miio/airpurifier.py
@@ -12,10 +12,11 @@ class AirPurifierException(Exception):
 
 
 class OperationMode(enum.Enum):
-    Auto = 'auto'
+    Idle = 'idle'
     Silent = 'silent'
     Favorite = 'favorite'
-    Idle = 'idle'
+    Auto = 'auto'
+
 
 
 class LedBrightness(enum.Enum):


### PR DESCRIPTION
In the HA-HB plug, the impact speed_list operating experience, this plug-in, the generation of HA to homekit FAN apparatus, the slider homekit, The slider automatically corresponds to speed_list ,speed_list order of 0% is 'off' or 'idle' and 33% slient, 66% is the favorite , 100% is auto,
Modification here is the least amount of change and impact, can be more perfect
https://github.com/home-assistant/homebridge-homeassistant/blob/master/accessories/fan.js