### PR TITLE
Update for Rock Robot (Mi Robot gen 2)

### DIFF
--- a/miio/discovery.py
+++ b/miio/discovery.py
@@ -14,6 +14,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DEVICE_MAP = {
     "rockrobo-vacuum-v1": Vacuum,
+    "roborock-vacuum-s5": Vacuum,
     "chuangmi-plug-m1": Plug,
     "chuangmi-plug-v2": Plug,
     "chuangmi-plug-v1": PlugV1,


### PR DESCRIPTION
Add version string
Tested on my device and it should work as excepted.

ps. The new version using string `roborock` instead of `rockrobo`.