### PR TITLE
Implement firmware update functionality

### DIFF
--- a/miio/__init__.py
+++ b/miio/__init__.py
@@ -20,3 +20,4 @@ from miio.airconditioningcompanion import AirConditioningCompanion
 from miio.yeelight import Yeelight
 from miio.device import Device, DeviceException
 from miio.discovery import Discovery
+from miio.updater import Updater

--- a/miio/__init__.py
+++ b/miio/__init__.py
@@ -20,4 +20,3 @@ from miio.airconditioningcompanion import AirConditioningCompanion
 from miio.yeelight import Yeelight
 from miio.device import Device, DeviceException
 from miio.discovery import Discovery
-from miio.updater import Updater

--- a/miio/device.py
+++ b/miio/device.py
@@ -282,6 +282,23 @@ class Device:
         and harware and software versions."""
         return DeviceInfo(self.send("miIO.info", []))
 
+    def update(self, url: str, md5: str):
+        """Start an OTA update."""
+        payload = {
+            "mode": "normal",
+            "install": "1",
+            "app_url": url,
+            "file_md5": md5,
+            "proc": "dlnd install"
+        }
+        return self.send("miIO.ota", payload)
+
+    def update_progress(self):
+        return self.send("miIO.get_ota_progress", [])
+
+    def update_state(self):
+        return self.send("miIO.get_ota_state", [])
+
     @property
     def _id(self) -> int:
         """Increment and return the sequence id."""

--- a/miio/updater.py
+++ b/miio/updater.py
@@ -1,0 +1,66 @@
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import hashlib
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class UpdateServer(BaseHTTPRequestHandler):
+    """A simplified handler just returning the contents of a single file."""
+    def __init__(self, request, client_address, server):
+        self.payload = server.payload
+        self.server = server
+
+        super().__init__(request, client_address, server)
+
+    def handle_one_request(self):
+        self.server.got_request = True
+        self.raw_requestline = self.rfile.readline()
+
+        if not self.parse_request():
+            print("unable to parse request")
+            return
+
+        print("got %s for %s" % (self.command, self.path))
+
+        self.send_response(200)
+        self.send_header('Content-type', 'application/octet-stream')
+        self.end_headers()
+        self.wfile.write(self.payload)
+
+
+class Updater:
+    """A simple HTTP server for serving an update file.
+
+    The server will be started in an emphemeral port, and will only accept
+    a single request to keep it simple."""
+    def __init__(self, file, interface=None):
+        addr = ('', 0)
+        self.server = HTTPServer(addr, UpdateServer)
+        self.server.got_request = False
+        _, self.port = self.server.server_address
+        _LOGGER.info("Serving on port %s" % self.port)
+        self.server.timeout = 10
+
+        with open(file, 'rb') as f:
+            self.payload = f.read()
+            self.server.payload = self.payload
+            self.md5 = hashlib.md5(self.payload).hexdigest()
+            _LOGGER.info("Using local %s (md5: %s)" % (file, self.md5))
+
+    def serve_once(self):
+        self.server.handle_request()
+        if self.server.got_request:
+            _LOGGER.info("Got a request, serving the file hopefully")
+        else:
+            _LOGGER.error("No request was made..")
+            return
+
+
+if __name__ == "__main__":
+    import netifaces
+    ifaces_without_lo = [x for x in netifaces.interfaces() if not x.startswith("lo")]
+    # print(ifaces_without_lo)
+    logging.basicConfig(level=logging.DEBUG)
+    upd = Updater("/tmp/test")
+    upd.serve_once()

--- a/miio/updater.py
+++ b/miio/updater.py
@@ -37,7 +37,7 @@ class Updater:
     def __init__(self, file, interface=None):
         addr = ('', 0)
         self.server = HTTPServer(addr, UpdateServer)
-        self.server.got_request = False
+        setattr(self.server, "got_request", False)
         _, self.port = self.server.server_address
         _LOGGER.info("Serving on port %s" % self.port)
         self.server.timeout = 10
@@ -50,7 +50,8 @@ class Updater:
 
     def serve_once(self):
         self.server.handle_request()
-        if self.server.got_request:
+        print(getattr(self.server, "got_request"))
+        if getattr(self.server, "got_request"):
             _LOGGER.info("Got a request, serving the file hopefully")
         else:
             _LOGGER.error("No request was made..")

--- a/miio/updater.py
+++ b/miio/updater.py
@@ -1,12 +1,14 @@
 from http.server import HTTPServer, BaseHTTPRequestHandler
 import hashlib
 import logging
+import netifaces
+from os.path import basename
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class OneShotHandler(BaseHTTPRequestHandler):
-    """A simplified handler just returning the contents of a single file."""
+class SingleFileHandler(BaseHTTPRequestHandler):
+    """A simplified handler just returning the contents of a buffer."""
     def __init__(self, request, client_address, server):
         self.payload = server.payload
         self.server = server
@@ -18,13 +20,12 @@ class OneShotHandler(BaseHTTPRequestHandler):
         self.raw_requestline = self.rfile.readline()
 
         if not self.parse_request():
-            print("unable to parse request")
+            _LOGGER.error("unable to parse request: %s" % self.raw_requestline)
             return
-
-        print("got %s for %s" % (self.command, self.path))
 
         self.send_response(200)
         self.send_header('Content-type', 'application/octet-stream')
+        self.send_header('Content-Length', len(self.payload))
         self.end_headers()
         self.wfile.write(self.payload)
 
@@ -36,32 +37,55 @@ class OneShotServer:
     a single request to keep it simple."""
     def __init__(self, file, interface=None):
         addr = ('', 0)
-        self.server = HTTPServer(addr, OneShotHandler)
+        self.server = HTTPServer(addr, SingleFileHandler)
         setattr(self.server, "got_request", False)
-        _, self.port = self.server.server_address
-        _LOGGER.info("Serving on port %s" % self.port)
+
+        self.addr, self.port = self.server.server_address
         self.server.timeout = 10
 
+        _LOGGER.info("Serving on %s:%s, timeout %s" % (self.addr, self.port,
+                                                       self.server.timeout))
+
+        self.file = basename(file)
         with open(file, 'rb') as f:
             self.payload = f.read()
             self.server.payload = self.payload
             self.md5 = hashlib.md5(self.payload).hexdigest()
             _LOGGER.info("Using local %s (md5: %s)" % (file, self.md5))
 
+    @staticmethod
+    def find_local_ip():
+        ifaces_without_lo = [x for x in netifaces.interfaces()
+                             if not x.startswith("lo")]
+        _LOGGER.debug("available interfaces: %s" % ifaces_without_lo)
+
+        for iface in ifaces_without_lo:
+            addresses = netifaces.ifaddresses(iface)
+            if netifaces.AF_INET not in addresses:
+                _LOGGER.debug("%s has no ipv4 addresses, skipping" % iface)
+                continue
+            for entry in addresses[netifaces.AF_INET]:
+                _LOGGER.debug("Got addr: %s" % entry['addr'])
+                return entry['addr']
+
+    def url(self, ip=None):
+        if ip is None:
+            ip = OneShotServer.find_local_ip()
+
+        url = "http://%s:%s/%s" % (ip, self.port, self.file)
+        return url
+
     def serve_once(self):
         self.server.handle_request()
-        print(getattr(self.server, "got_request"))
         if getattr(self.server, "got_request"):
-            _LOGGER.info("Got a request, serving the file hopefully")
+            _LOGGER.info("Got a request, shold be downloading now.")
+            return True
         else:
             _LOGGER.error("No request was made..")
-            return
+            return False
 
 
 if __name__ == "__main__":
-    import netifaces
-    ifaces_without_lo = [x for x in netifaces.interfaces() if not x.startswith("lo")]
-    # print(ifaces_without_lo)
     logging.basicConfig(level=logging.DEBUG)
-    upd = Updater("/tmp/test")
+    upd = OneShotServer("/tmp/test")
     upd.serve_once()

--- a/miio/updater.py
+++ b/miio/updater.py
@@ -5,7 +5,7 @@ import logging
 _LOGGER = logging.getLogger(__name__)
 
 
-class UpdateServer(BaseHTTPRequestHandler):
+class OneShotHandler(BaseHTTPRequestHandler):
     """A simplified handler just returning the contents of a single file."""
     def __init__(self, request, client_address, server):
         self.payload = server.payload
@@ -29,14 +29,14 @@ class UpdateServer(BaseHTTPRequestHandler):
         self.wfile.write(self.payload)
 
 
-class Updater:
+class OneShotServer:
     """A simple HTTP server for serving an update file.
 
     The server will be started in an emphemeral port, and will only accept
     a single request to keep it simple."""
     def __init__(self, file, interface=None):
         addr = ('', 0)
-        self.server = HTTPServer(addr, UpdateServer)
+        self.server = HTTPServer(addr, OneShotHandler)
         setattr(self.server, "got_request", False)
         _, self.port = self.server.server_address
         _LOGGER.info("Serving on port %s" % self.port)

--- a/miio/vacuum_cli.py
+++ b/miio/vacuum_cli.py
@@ -504,6 +504,7 @@ def configure_wifi(vac: miio.Vacuum, ssid: str, password: str,
     click.echo("Configuring wifi to SSID: %s" % ssid)
     click.echo(vac.configure_wifi(ssid, password, uid, timezone))
 
+
 @cli.command()
 @pass_dev
 def update_status(vac: miio.Vacuum):
@@ -513,6 +514,7 @@ def update_status(vac: miio.Vacuum):
 
     if update_state == UpdateState.Downloading:
         click.echo("Update progress: %s" % vac.update_progress())
+
 
 @cli.command()
 @click.argument('url', required=True)
@@ -554,7 +556,7 @@ def update_firmware(vac: miio.Vacuum, url: str, md5: str):
             try:
                 state = vac.update_state()
                 progress = vac.update_progress()
-            except: # we may not get our messages through during upload
+            except:  # we may not get our messages through during upload
                 continue
 
             if state == UpdateState.Installing:

--- a/miio/vacuum_cli.py
+++ b/miio/vacuum_cli.py
@@ -482,6 +482,31 @@ def configure_wifi(vac: miio.Vacuum, ssid: str, password: str,
 
 
 @cli.command()
+@click.argument('file', required=True)
+@click.option('md5', required=False, default=None)
+@pass_dev
+def update_firmware(vac: miio.Vacuum, file: str, md5: str):
+    """Update device firmware.
+
+    If `file` starts with http* it is expected to be an URL.
+     In that case --md5 has to be given."""
+
+    url = None
+    if file.lower().startswith("http"):
+        if md5 is None:
+            click.echo("You need to pass --md5 when using URL for updating..")
+            return
+
+        click.echo("Using %s (md5: %s)" % (file, md5))
+    else:
+        pass
+        #Updater()
+
+    click.echo("Updating firmware image..")
+    vac.update(url, md5)
+
+
+@cli.command()
 @click.argument('cmd', required=True)
 @click.argument('parameters', required=False)
 @pass_dev

--- a/miio/vacuumcontainers.py
+++ b/miio/vacuumcontainers.py
@@ -522,8 +522,8 @@ class SoundInstallStatus:
     @property
     def is_installing(self) -> bool:
         """True if install is in progress."""
-        return self.state == SoundInstallState.Downloading or \
-               self.state == SoundInstallState.Installing
+        return (self.state == SoundInstallState.Downloading or
+                self.state == SoundInstallState.Installing)
 
     @property
     def is_errored(self) -> bool:

--- a/miio/vacuumcontainers.py
+++ b/miio/vacuumcontainers.py
@@ -522,7 +522,13 @@ class SoundInstallStatus:
     @property
     def is_installing(self) -> bool:
         """True if install is in progress."""
-        return self.sid != 0 and self.progress < 100 and self.error == 0
+        return self.state == SoundInstallState.Downloading or \
+               self.state == SoundInstallState.Installing
+
+    @property
+    def is_errored(self) -> bool:
+        """True if the state has an error, use `error`to access it."""
+        return self.state == SoundInstallState.Error
 
     def __repr__(self) -> str:
         return "<SoundInstallStatus sid: %s (state: %s, error: %s)" \


### PR DESCRIPTION
Add ability to perform firmware updates on the device.
Works either by passing an URL with md5sum for the firmware image,
or alternatively by passing a local filename.
In case of the input is a local filename, its md5sum will be calculated automatically,
and the update will be delivered by the built-in web server.

```
mirobo update_firmware http://10.10.10.150/v11_003094.pkg <md5sum>
```
or
```
mirobo update_firmware v11_003094.pkg
```

The `install_sound` functionality is also extended to use the builtin web-server class, so installing sound packages is as simple as calling `mirobo install_sound <soundfile.pkg>`.

For more details & archive of firmware updates see https://github.com/dgiese/dustcloud .

Thanks for exploring the device in-depth goes to the dustcloud project,
which also describes how to build own, custom firmwares.