### PR TITLE
Air Purifier Pro: support for sound volume level and fix for bright propery

### DIFF
--- a/miio/airpurifier.py
+++ b/miio/airpurifier.py
@@ -100,11 +100,12 @@ class AirPurifierStatus:
         if self.data["led_b"] is not None:
             return LedBrightness(self.data["led_b"])
 
-        # This is the property name of the Air Purifier Pro
-        if self.data["bright"] is not None:
-            return LedBrightness(self.data["bright"])
-
         return None
+
+    @property
+    def brightness(self) -> Optional[int]:
+        """Environment brightness level"""
+        return self.data["bright"]
 
     @property
     def buzzer(self) -> bool:
@@ -161,6 +162,7 @@ class AirPurifierStatus:
             "mode=%s," \
             "led=%s," \
             "led_brightness=%s," \
+            "brightness=%s," \
             "buzzer=%s, " \
             "child_lock=%s," \
             "favorite_level=%s," \
@@ -178,6 +180,7 @@ class AirPurifierStatus:
              self.mode,
              self.led,
              self.led_brightness,
+             self.brightness,
              self.buzzer,
              self.child_lock,
              self.favorite_level,

--- a/miio/airpurifier.py
+++ b/miio/airpurifier.py
@@ -155,17 +155,17 @@ class AirPurifierStatus:
 
     def __repr__(self) -> str:
         s = "<AirPurifierStatus power=%s, " \
-            "aqi=%s," \
-            "average_aqi=%s," \
+            "aqi=%s, " \
+            "average_aqi=%s, " \
             "temperature=%s, " \
-            "humidity=%s%%," \
-            "mode=%s," \
-            "led=%s," \
-            "led_brightness=%s," \
-            "brightness=%s," \
+            "humidity=%s%%, " \
+            "mode=%s, " \
+            "led=%s, " \
+            "led_brightness=%s, " \
+            "brightness=%s, " \
             "buzzer=%s, " \
-            "child_lock=%s," \
-            "favorite_level=%s," \
+            "child_lock=%s, " \
+            "favorite_level=%s, " \
             "filter_life_remaining=%s, " \
             "filter_hours_used=%s, " \
             "use_time=%s, " \

--- a/miio/airpurifier.py
+++ b/miio/airpurifier.py
@@ -147,6 +147,11 @@ class AirPurifierStatus:
         """Speed of the motor."""
         return self.data["motor1_speed"]
 
+    @property
+    def volume(self) -> int:
+        """Volume of sound notifications"""
+        return self.data["volume"]
+
     def __repr__(self) -> str:
         s = "<AirPurifierStatus power=%s, " \
             "aqi=%s," \
@@ -163,7 +168,8 @@ class AirPurifierStatus:
             "filter_hours_used=%s, " \
             "use_time=%s, " \
             "purify_volume=%s, " \
-            "motor_speed=%s>" % \
+            "motor_speed=%s, " \
+            "volume=%s>" % \
             (self.power,
              self.aqi,
              self.average_aqi,
@@ -179,7 +185,8 @@ class AirPurifierStatus:
              self.filter_hours_used,
              self.use_time,
              self.purify_volume,
-             self.motor_speed)
+             self.motor_speed,
+             self.volume)
         return s
 
 
@@ -193,7 +200,8 @@ class AirPurifier(Device):
                       'mode', 'favorite_level', 'filter1_life', 'f1_hour_used',
                       'use_time', 'motor1_speed', 'purify_volume', 'f1_hour',
                       # Second request
-                      'led', 'led_b', 'bright', 'buzzer', 'child_lock', ]
+                      'led', 'led_b', 'bright', 'buzzer', 'child_lock',
+                      'volume', ]
 
         # A single request is limited to 16 properties. Therefore the
         # properties are divided in two groups here. The second group contains
@@ -264,3 +272,7 @@ class AirPurifier(Device):
             return self.send("set_child_lock", ["on"])
         else:
             return self.send("set_child_lock", ["off"])
+
+    def set_volume(self, volume: int):
+        """Set volume of sound notifications"""
+        return self.send("set_volume", [volume])

--- a/miio/airpurifier.py
+++ b/miio/airpurifier.py
@@ -103,8 +103,8 @@ class AirPurifierStatus:
         return None
 
     @property
-    def brightness(self) -> Optional[int]:
-        """Environment brightness level"""
+    def illuminance(self) -> Optional[int]:
+        """Environment illuminance level"""
         return self.data["bright"]
 
     @property
@@ -162,7 +162,7 @@ class AirPurifierStatus:
             "mode=%s, " \
             "led=%s, " \
             "led_brightness=%s, " \
-            "brightness=%s, " \
+            "illuminance=%s, " \
             "buzzer=%s, " \
             "child_lock=%s, " \
             "favorite_level=%s, " \
@@ -180,7 +180,7 @@ class AirPurifierStatus:
              self.mode,
              self.led,
              self.led_brightness,
-             self.brightness,
+             self.illuminance,
              self.buzzer,
              self.child_lock,
              self.favorite_level,

--- a/miio/airpurifier.py
+++ b/miio/airpurifier.py
@@ -104,7 +104,8 @@ class AirPurifierStatus:
 
     @property
     def illuminance(self) -> Optional[int]:
-        """Environment illuminance level"""
+        """Environment illuminance level in lux [0-200].
+        Sensor value is updated only when device is turned on."""
         return self.data["bright"]
 
     @property
@@ -150,7 +151,7 @@ class AirPurifierStatus:
 
     @property
     def volume(self) -> int:
-        """Volume of sound notifications"""
+        """Volume of sound notifications [0-100]."""
         return self.data["volume"]
 
     def __repr__(self) -> str:
@@ -277,5 +278,5 @@ class AirPurifier(Device):
             return self.send("set_child_lock", ["off"])
 
     def set_volume(self, volume: int):
-        """Set volume of sound notifications"""
+        """Set volume of sound notifications [0-100]."""
         return self.send("set_volume", [volume])


### PR DESCRIPTION
The Air Purifier Pro has a property controlling the volume level of sound notifications, which are used when any command is sent to it. I've added support for the property and a method to set it's value. The range is from 0 (mute) to 100 (full volume). I don't know if Air Purifier 2 also has this property or not.

There's a photosensitive element on top of the Air Purifier Pro (right next to the power/mode selection button). It's value is held in the bright property, which has been improperly used as a LED brightness for this model. Air Purifier Pro display probably doesn't support changing brightness. The value for the bright property changes from 0 (no light detected) up to 200. I don't know what's the unit it is given in. I've got 200 when I've used my phone's LED flashlight directly on the sensor.