### PR TITLE
Fix for a breaking change of construct 2.8.22

### DIFF
--- a/miio/protocol.py
+++ b/miio/protocol.py
@@ -176,7 +176,7 @@ Message = Struct(
     # for building we need data before anything else.
     "data" / Pointer(32, RawCopy(EncryptionAdapter(GreedyBytes))),
     "header" / RawCopy(Struct(
-        Const(Int16ub, 0x2131),
+        Const(0x2131, Int16ub),
         "length" / Rebuild(Int16ub, Utils.get_length),
         "unknown" / Default(Int32ub, 0x00000000),
         "device_id" / Hex(Bytes(4)),


### PR DESCRIPTION
Const parameters are reorder now. cp. https://github.com/construct/construct/commit/561fede583f2e96ca6a614c6291a0b887539bc8d.