### PR TITLE
Added Air Purifier 2S to supported devices

### DIFF
--- a/miio/discovery.py
+++ b/miio/discovery.py
@@ -23,6 +23,7 @@ DEVICE_MAP = {
     "zimi-powerstrip-v2": PowerStrip,
     "zhimi-airpurifier-m1": AirPurifier,
     "zhimi-airpurifier-m2": AirPurifier,
+    "zhimi-airpurifier-ma2": AirPurifier,
     "zhimi-airpurifier-v1": AirPurifier,
     "zhimi-airpurifier-v2": AirPurifier,
     "zhimi-airpurifier-v3": AirPurifier,


### PR DESCRIPTION
I'm not 100% familiar with this library but I found that it can't properly discover my Air Purifier 2S. I hope this will help.