### PR TITLE
Add a more helpful error message when info() fails with an empty payload

### DIFF
--- a/miio/vacuum_cli.py
+++ b/miio/vacuum_cli.py
@@ -393,10 +393,14 @@ def map(vac: miio.Vacuum):
 @pass_dev
 def info(vac: miio.Vacuum):
     """Return device information."""
-    res = vac.info()
+    try:
+        res = vac.info()
 
-    click.echo("%s" % res)
-    _LOGGER.debug("Full response: %s", pf(res.raw))
+        click.echo("%s" % res)
+        _LOGGER.debug("Full response: %s", pf(res.raw))
+    except TypeError:
+        click.echo("Unable to fetch info, this can happen when the vacuum "
+                   "is not connected to the Xiaomi cloud.")
 
 
 @cli.command()


### PR DESCRIPTION
This happens always when the vacuum has not been in contact with
xiaomi's servers and there's nothing else we can do about it

Fixes #156