### PR TITLE
Air Purifier Pro second motor speed

### DIFF
--- a/miio/airpurifier.py
+++ b/miio/airpurifier.py
@@ -153,6 +153,11 @@ class AirPurifierStatus:
         return self.data["motor1_speed"]
 
     @property
+    def motor2_speed(self) -> Optional[int]:
+        """Speed of the 2nd motor."""
+        return self.data["motor2_speed"]
+
+    @property
     def volume(self) -> Optional[int]:
         """Volume of sound notifications [0-100]."""
         return self.data["volume"]
@@ -175,6 +180,7 @@ class AirPurifierStatus:
             "use_time=%s, " \
             "purify_volume=%s, " \
             "motor_speed=%s, " \
+            "motor2_speed=%s, " \
             "volume=%s>" % \
             (self.power,
              self.aqi,
@@ -193,6 +199,7 @@ class AirPurifierStatus:
              self.use_time,
              self.purify_volume,
              self.motor_speed,
+             self.motor2_speed,
              self.volume)
         return s
 
@@ -205,10 +212,11 @@ class AirPurifier(Device):
 
         properties = ['power', 'aqi', 'average_aqi', 'humidity', 'temp_dec',
                       'mode', 'favorite_level', 'filter1_life', 'f1_hour_used',
-                      'use_time', 'motor1_speed', 'purify_volume', 'f1_hour',
+                      'use_time', 'motor1_speed', 'motor2_speed',
+                      'purify_volume',
                       # Second request
-                      'led', 'led_b', 'bright', 'buzzer', 'child_lock',
-                      'volume', ]
+                      'f1_hour', 'led', 'led_b', 'bright', 'buzzer',
+                      'child_lock', 'volume', ]
 
         # A single request is limited to 16 properties. Therefore the
         # properties are divided in two groups here. The second group contains

--- a/miio/airpurifier.py
+++ b/miio/airpurifier.py
@@ -285,17 +285,12 @@ class AirPurifier(Device):
                       'act_sleep']
 
         # A single request is limited to 16 properties. Therefore the
-        # properties are divided in two groups here. The second group contains
-        # some infrequent and independent updated properties.
-        values = self.send(
-            "get_prop",
-            properties[0:13]
-        )
-
-        values.extend(self.send(
-            "get_prop",
-            properties[13:]
-        ))
+        # properties are divided into multiple requests
+        _props = properties.copy()
+        values = []
+        while _props:
+            values.extend(self.send("get_prop", _props[:13]))
+            _props[:] = _props[13:]
 
         properties_count = len(properties)
         values_count = len(values)

--- a/miio/airpurifier.py
+++ b/miio/airpurifier.py
@@ -34,18 +34,18 @@ class AirPurifierStatus:
         {'power': 'off', 'aqi': 7, 'average_aqi': 18, 'humidity': 45,
          'temp_dec': 234, 'mode': 'auto', 'favorite_level': 17,
          'filter1_life': 52, 'f1_hour_used': 1664, 'use_time': 2642700,
-         'motor1_speed': 0, 'purify_volume': 62180, 'f1_hour': 3500,
-         'led': 'on', 'led_b': None, 'bright': 83, 'buzzer': None,
-         'child_lock': 'off', 'volume': 50}
+         'motor1_speed': 0, 'motor2_speed': 800, 'purify_volume': 62180,
+         'f1_hour': 3500, 'led': 'on', 'led_b': None, 'bright': 83,
+         'buzzer': None, 'child_lock': 'off', 'volume': 50}
 
         Response of a Air Purifier 2 (zhimi.airpurifier.m1):
 
         {'power': 'on, 'aqi': 10, 'average_aqi': 8, 'humidity': 62,
          'temp_dec': 186, 'mode': 'auto', 'favorite_level': 10,
         'filter1_life': 80, 'f1_hour_used': 682, 'use_time': 2457000,
-        'motor1_speed': 354, 'purify_volume': 25262, 'f1_hour': 3500,
-        'led': 'off', 'led_b': 2, 'bright': None, 'buzzer': 'off',
-        'child_lock': 'off', 'volume': None}
+        'motor1_speed': 354, 'motor2_speed': None, 'purify_volume': 25262,
+        'f1_hour': 3500, 'led': 'off', 'led_b': 2, 'bright': None,
+        'buzzer': 'off', 'child_lock': 'off', 'volume': None}
 
         A request is limited to 16 properties.
         """

--- a/miio/tests/test_airpurifier.py
+++ b/miio/tests/test_airpurifier.py
@@ -19,6 +19,7 @@ class DummyAirPurifier(DummyDevice, AirPurifier):
             'f1_hour_used': 682,
             'use_time': 2457000,
             'motor1_speed': 354,
+            'motor2_speed': 800,
             'purify_volume': 25262,
             'f1_hour': 3500,
             'led': 'off',
@@ -87,6 +88,7 @@ class TestAirPurifier(TestCase):
         assert self.state().filter_hours_used == self.device.start_state["f1_hour_used"]
         assert self.state().use_time == self.device.start_state["use_time"]
         assert self.state().motor_speed == self.device.start_state["motor1_speed"]
+        assert self.state().motor2_speed == self.device.start_state["motor2_speed"]
         assert self.state().purify_volume == self.device.start_state["purify_volume"]
 
         assert self.state().led == (self.device.start_state["led"] == 'on')

--- a/miio/tests/test_airpurifier.py
+++ b/miio/tests/test_airpurifier.py
@@ -1,6 +1,8 @@
 from unittest import TestCase
 from miio import AirPurifier
-from miio.airpurifier import OperationMode, LedBrightness, AirPurifierException
+from miio.airpurifier import (
+    OperationMode, LedBrightness, FilterType, AirPurifierException
+)
 from .dummies import DummyDevice
 import pytest
 
@@ -28,6 +30,9 @@ class DummyAirPurifier(DummyDevice, AirPurifier):
             'buzzer': 'off',
             'child_lock': 'off',
             'volume': 50,
+            'rfid_product_id': '0:0:41:30',
+            'rfid_tag': '10:20:30:40:50:60:7',
+            'act_sleep': 'close',
         }
         self.return_values = {
             'get_prop': self._get_state,
@@ -40,6 +45,11 @@ class DummyAirPurifier(DummyDevice, AirPurifier):
                 lambda x: self._set_state("favorite_level", x),
             'set_led_b': lambda x: self._set_state("led_b", x),
             'set_volume': lambda x: self._set_state("volume", x),
+            'set_act_sleep': lambda x: self._set_state("act_sleep", x),
+            'reset_filter1': lambda x: (
+                self._set_state('f1_hour_used', [0]),
+                self._set_state('filter1_life', [100])
+            )
         }
         super().__init__(args, kwargs)
 
@@ -97,6 +107,8 @@ class TestAirPurifier(TestCase):
         assert self.state().child_lock == (self.device.start_state["child_lock"] == 'on')
         assert self.state().illuminance == self.device.start_state["bright"]
         assert self.state().volume == self.device.start_state["volume"]
+        assert self.state().filter_rfid_product_id == self.device.start_state["rfid_product_id"]
+        assert self.state().filter_rfid_tag == self.device.start_state["rfid_tag"]
 
     def test_set_mode(self):
         def mode():
@@ -191,6 +203,30 @@ class TestAirPurifier(TestCase):
         with pytest.raises(AirPurifierException):
             self.device.set_volume(101)
 
+    def test_set_learn_mode(self):
+        def learn_mode():
+            return self.device.status().learn_mode
+
+        self.device.set_learn_mode(True)
+        assert learn_mode() is True
+
+        self.device.set_learn_mode(False)
+        assert learn_mode() is False
+
+    def test_reset_filter(self):
+        def filter_hours_used():
+            return self.device.status().filter_hours_used
+
+        def filter_life_remaining():
+            return self.device.status().filter_life_remaining
+
+        self.device._reset_state()
+        assert filter_hours_used() != 0
+        assert filter_life_remaining() != 100
+        self.device.reset_filter()
+        assert filter_hours_used() == 0
+        assert filter_life_remaining() == 100
+
     def test_status_without_volume(self):
         self.device._reset_state()
 
@@ -221,3 +257,28 @@ class TestAirPurifier(TestCase):
         # The Air Purifier Pro doesn't provide the buzzer property
         self.device.state["buzzer"] = None
         assert self.state().buzzer is None
+
+    def test_status_without_filter_rfid_tag(self):
+        self.device._reset_state()
+        self.device.state["rfid_tag"] = None
+        assert self.state().filter_rfid_tag is None
+        assert self.state().filter_type is None
+
+    def test_status_with_filter_rfid_tag_zeros(self):
+        self.device._reset_state()
+        self.device.state["rfid_tag"] = '0:0:0:0:0:0:0'
+        assert self.state().filter_type is FilterType.Unknown
+
+    def test_status_without_filter_rfid_product_id(self):
+        self.device._reset_state()
+        self.device.state["rfid_product_id"] = None
+        assert self.state().filter_type is FilterType.Regular
+
+    def test_status_filter_rfid_product_ids(self):
+        self.device._reset_state()
+        self.device.state["rfid_product_id"] = '0:0:30:31'
+        assert self.state().filter_type is FilterType.AntiFormaldehyde
+        self.device.state["rfid_product_id"] = '0:0:30:32'
+        assert self.state().filter_type is FilterType.Regular
+        self.device.state["rfid_product_id"] = '0:0:41:30'
+        assert self.state().filter_type is FilterType.AntiBacterial

--- a/miio/tests/test_airpurifier.py
+++ b/miio/tests/test_airpurifier.py
@@ -258,6 +258,12 @@ class TestAirPurifier(TestCase):
         self.device.state["buzzer"] = None
         assert self.state().buzzer is None
 
+    def test_status_without_motor2_speed(self):
+        self.device._reset_state()
+        # The Air Purifier Pro doesn't provide the buzzer property
+        self.device.state["motor2_speed"] = None
+        assert self.state().motor2_speed is None
+
     def test_status_without_filter_rfid_tag(self):
         self.device._reset_state()
         self.device.state["rfid_tag"] = None


### PR DESCRIPTION
Air Purifier Pro has a motor2_speed property which actually holds the speed of the main fan motor. The motor1_speed seems to indicate the speed of a small fan which probably sucks air into the laser PM2.5 detector on the back.
Maybe someone with Air Purifier 2 could verify if this property is also available in that model. Depending on the result I'll update the docstrings for both motor speed properties.