### PR TITLE
Revise error handling to be more consistent for library users

### DIFF
--- a/miio/ceil_cli.py
+++ b/miio/ceil_cli.py
@@ -2,16 +2,10 @@
 import logging
 import click
 import sys
-import ipaddress
-
-if sys.version_info < (3, 4):
-    print("To use this script you need python 3.4 or newer, got %s" %
-          sys.version_info)
-    sys.exit(1)
-
-import miio  # noqa: E402
 from miio.click_common import (ExceptionHandlerGroup, validate_ip,
                                validate_token)
+import miio  # noqa: E402
+
 
 _LOGGER = logging.getLogger(__name__)
 pass_dev = click.make_pass_decorator(miio.Ceil)

--- a/miio/ceil_cli.py
+++ b/miio/ceil_cli.py
@@ -10,6 +10,8 @@ if sys.version_info < (3, 4):
     sys.exit(1)
 
 import miio  # noqa: E402
+from miio.click_common import (ExceptionHandlerGroup, validate_ip,
+                               validate_token)
 
 _LOGGER = logging.getLogger(__name__)
 pass_dev = click.make_pass_decorator(miio.Ceil)
@@ -36,22 +38,7 @@ def validate_scene(ctx, param, value):
     return value
 
 
-def validate_ip(ctx, param, value):
-    try:
-        ipaddress.ip_address(value)
-        return value
-    except ValueError as ex:
-        raise click.BadParameter("Invalid IP: %s" % ex)
-
-
-def validate_token(ctx, param, value):
-    token_len = len(value)
-    if token_len != 32:
-        raise click.BadParameter("Token length != 32 chars: %s" % token_len)
-    return value
-
-
-@click.group(invoke_without_command=True)
+@click.group(invoke_without_command=True, cls=ExceptionHandlerGroup)
 @click.option('--ip', envvar="DEVICE_IP", callback=validate_ip)
 @click.option('--token', envvar="DEVICE_TOKEN", callback=validate_token)
 @click.option('-d', '--debug', default=False, count=True)

--- a/miio/click_common.py
+++ b/miio/click_common.py
@@ -2,6 +2,12 @@
 
 This file contains common functions for cli tools.
 """
+import sys
+if sys.version_info < (3, 4):
+    print("To use this script you need python 3.4 or newer, got %s" %
+          sys.version_info)
+    sys.exit(1)
+
 import click
 import ipaddress
 import miio

--- a/miio/click_common.py
+++ b/miio/click_common.py
@@ -33,6 +33,12 @@ def validate_token(ctx, param, value):
 
 
 class ExceptionHandlerGroup(click.Group):
+    """Add a simple group for catching the miio-related exceptions.
+
+    This simplifies catching the exceptions from different click commands.
+
+    Idea from https://stackoverflow.com/a/44347763
+    """
     def __call__(self, *args, **kwargs):
         try:
             return self.main(*args, **kwargs)

--- a/miio/click_common.py
+++ b/miio/click_common.py
@@ -1,0 +1,35 @@
+"""Click commons.
+
+This file contains common functions for cli tools.
+"""
+import click
+import ipaddress
+import miio
+import logging
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def validate_ip(ctx, param, value):
+    try:
+        ipaddress.ip_address(value)
+        return value
+    except ValueError as ex:
+        raise click.BadParameter("Invalid IP: %s" % ex)
+
+
+def validate_token(ctx, param, value):
+    token_len = len(value)
+    if token_len != 32:
+        raise click.BadParameter("Token length != 32 chars: %s" % token_len)
+    return value
+
+
+class ExceptionHandlerGroup(click.Group):
+    def __call__(self, *args, **kwargs):
+        try:
+            return self.main(*args, **kwargs)
+        except miio.DeviceException as ex:
+            _LOGGER.debug("Exception: %s", ex, exc_info=True)
+            click.echo(click.style("Error: %s" % ex, fg='red', bold=True))

--- a/miio/click_common.py
+++ b/miio/click_common.py
@@ -7,7 +7,6 @@ if sys.version_info < (3, 4):
     print("To use this script you need python 3.4 or newer, got %s" %
           sys.version_info)
     sys.exit(1)
-
 import click
 import ipaddress
 import miio

--- a/miio/device.py
+++ b/miio/device.py
@@ -266,7 +266,7 @@ class Device:
                                 "retries left: %s", retry_count)
                 self.__id += 100
                 return self.send(command, parameters, retry_count - 1)
-            raise DeviceException from ex
+            raise DeviceException("No response from the device") from ex
 
     def raw_command(self, cmd, params):
         """Send a raw command to the device.

--- a/miio/philips_eyecare_cli.py
+++ b/miio/philips_eyecare_cli.py
@@ -10,6 +10,8 @@ if sys.version_info < (3, 4):
     sys.exit(1)
 
 import miio  # noqa: E402
+from miio.click_common import (ExceptionHandlerGroup, validate_ip,
+                               validate_token)
 
 _LOGGER = logging.getLogger(__name__)
 pass_dev = click.make_pass_decorator(miio.PhilipsEyecare)
@@ -36,22 +38,7 @@ def validate_scene(ctx, param, value):
     return value
 
 
-def validate_ip(ctx, param, value):
-    try:
-        ipaddress.ip_address(value)
-        return value
-    except ValueError as ex:
-        raise click.BadParameter("Invalid IP: %s" % ex)
-
-
-def validate_token(ctx, param, value):
-    token_len = len(value)
-    if token_len != 32:
-        raise click.BadParameter("Token length != 32 chars: %s" % token_len)
-    return value
-
-
-@click.group(invoke_without_command=True)
+@click.group(invoke_without_command=True, cls=ExceptionHandlerGroup)
 @click.option('--ip', envvar="DEVICE_IP", callback=validate_ip)
 @click.option('--token', envvar="DEVICE_TOKEN", callback=validate_token)
 @click.option('-d', '--debug', default=False, count=True)

--- a/miio/philips_eyecare_cli.py
+++ b/miio/philips_eyecare_cli.py
@@ -2,16 +2,10 @@
 import logging
 import click
 import sys
-import ipaddress
-
-if sys.version_info < (3, 4):
-    print("To use this script you need python 3.4 or newer, got %s" %
-          sys.version_info)
-    sys.exit(1)
-
-import miio  # noqa: E402
 from miio.click_common import (ExceptionHandlerGroup, validate_ip,
                                validate_token)
+import miio  # noqa: E402
+
 
 _LOGGER = logging.getLogger(__name__)
 pass_dev = click.make_pass_decorator(miio.PhilipsEyecare)

--- a/miio/plug_cli.py
+++ b/miio/plug_cli.py
@@ -4,15 +4,10 @@ import click
 import ast
 import sys
 from typing import Any  # noqa: F401
-
-if sys.version_info < (3, 4):
-    print("To use this script you need python 3.4 or newer, got %s" %
-          sys.version_info)
-    sys.exit(1)
-
-import miio  # noqa: E402
 from miio.click_common import (ExceptionHandlerGroup, validate_ip,
                                validate_token)
+import miio  # noqa: E402
+
 
 _LOGGER = logging.getLogger(__name__)
 pass_dev = click.make_pass_decorator(miio.Plug)

--- a/miio/plug_cli.py
+++ b/miio/plug_cli.py
@@ -3,7 +3,6 @@ import logging
 import click
 import ast
 import sys
-import ipaddress
 from typing import Any  # noqa: F401
 
 if sys.version_info < (3, 4):
@@ -12,27 +11,14 @@ if sys.version_info < (3, 4):
     sys.exit(1)
 
 import miio  # noqa: E402
+from miio.click_common import (ExceptionHandlerGroup, validate_ip,
+                               validate_token)
 
 _LOGGER = logging.getLogger(__name__)
 pass_dev = click.make_pass_decorator(miio.Plug)
 
 
-def validate_ip(ctx, param, value):
-    try:
-        ipaddress.ip_address(value)
-        return value
-    except ValueError as ex:
-        raise click.BadParameter("Invalid IP: %s" % ex)
-
-
-def validate_token(ctx, param, value):
-    token_len = len(value)
-    if token_len != 32:
-        raise click.BadParameter("Token length != 32 chars: %s" % token_len)
-    return value
-
-
-@click.group(invoke_without_command=True)
+@click.group(invoke_without_command=True, cls=ExceptionHandlerGroup)
 @click.option('--ip', envvar="DEVICE_IP", callback=validate_ip)
 @click.option('--token', envvar="DEVICE_TOKEN", callback=validate_token)
 @click.option('-d', '--debug', default=False, count=True)

--- a/miio/vacuum_cli.py
+++ b/miio/vacuum_cli.py
@@ -10,16 +10,9 @@ import pathlib
 from appdirs import user_cache_dir
 from pprint import pformat as pf
 from typing import Any  # noqa: F401
-
-
-if sys.version_info < (3, 4):
-    print("To use this script you need python 3.4 or newer, got %s" %
-          sys.version_info)
-    sys.exit(1)
-
-import miio  # noqa: E402
 from miio.click_common import (ExceptionHandlerGroup, validate_ip,
                                validate_token)
+import miio  # noqa: E402
 
 _LOGGER = logging.getLogger(__name__)
 pass_dev = click.make_pass_decorator(miio.Device, ensure=True)

--- a/miio/vacuum_cli.py
+++ b/miio/vacuum_cli.py
@@ -5,7 +5,6 @@ import pretty_cron
 import ast
 import sys
 import json
-import ipaddress
 import time
 import pathlib
 from appdirs import user_cache_dir
@@ -19,31 +18,14 @@ if sys.version_info < (3, 4):
     sys.exit(1)
 
 import miio  # noqa: E402
+from miio.click_common import (ExceptionHandlerGroup, validate_ip,
+                               validate_token)
 
 _LOGGER = logging.getLogger(__name__)
 pass_dev = click.make_pass_decorator(miio.Device, ensure=True)
 
 
-def validate_ip(ctx, param, value):
-    if value is None:
-        return value
-    try:
-        ipaddress.ip_address(value)
-        return value
-    except ValueError as ex:
-        raise click.BadParameter("Invalid IP: %s" % ex)
-
-
-def validate_token(ctx, param, value):
-    if value is None:
-        return value
-    token_len = len(value)
-    if token_len != 32:
-        raise click.BadParameter("Token length != 32 chars: %s" % token_len)
-    return value
-
-
-@click.group(invoke_without_command=True)
+@click.group(invoke_without_command=True, cls=ExceptionHandlerGroup)
 @click.option('--ip', envvar="MIROBO_IP", callback=validate_ip)
 @click.option('--token', envvar="MIROBO_TOKEN", callback=validate_token)
 @click.option('-d', '--debug', default=False, count=True)


### PR DESCRIPTION
Users of the library can catch `miio.DeviceException` for catching both communication errors as well as errors reported by the devices (which are of type `miio.DeviceError` extending from `DeviceException`).

* Wrap errors coming from the device inside DeviceError exception, raise DeviceException for invalid tokens / checksum errors
* All client tools are modified to handle device errors