### PR TITLE
Fix 'mirobo discover' without --ip and --token

### DIFF
--- a/miio/click_common.py
+++ b/miio/click_common.py
@@ -17,6 +17,8 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def validate_ip(ctx, param, value):
+    if value == None:
+        return '192.168.8.1'
     try:
         ipaddress.ip_address(value)
         return value
@@ -25,7 +27,10 @@ def validate_ip(ctx, param, value):
 
 
 def validate_token(ctx, param, value):
-    token_len = len(value)
+    try:
+        token_len = len(value)
+    except TypeError as e:
+        return None
     if token_len != 32:
         raise click.BadParameter("Token length != 32 chars: %s" % token_len)
     return value

--- a/miio/tests/test_click.py
+++ b/miio/tests/test_click.py
@@ -1,0 +1,7 @@
+from miio.click_common import *
+
+def test_validate_token_empty():
+    assert not validate_token(None, None, None)
+
+def test_validate_ip_empty():
+    assert validate_ip(None, None, None) == '192.168.8.1'


### PR DESCRIPTION
This patch fixes cli parameter validation for `discover` command:

* by returning a default ip if `None` is passed to `validate_ip`
* by catching the TypeError if `None` is passed to `validate_token`

without this patch I get the following errors

```
...:~/prj/python-miio/miio> mirobo discover --handshake 1
Usage: mirobo [OPTIONS] COMMAND [ARGS]...

Error: Invalid value for "--ip": Invalid IP: None does not appear to be an IPv4 or IPv6 address
```

and

```
...:~/prj/python-miio/miio> mirobo --ip 192.168.8.1 discover --handshake 1
Traceback (most recent call last):
  File "/usr/bin/mirobo", line 11, in <module>
    load_entry_point('python-miio==0.3.4', 'console_scripts', 'mirobo')()
  File "/usr/lib/python3.6/site-packages/miio/click_common.py", line 43, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 696, in main
    with self.make_context(prog_name, args, **extra) as ctx:
  File "/usr/lib/python3.6/site-packages/click/core.py", line 621, in make_context
    self.parse_args(ctx, args)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 1018, in parse_args
    rest = Command.parse_args(self, ctx, args)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 880, in parse_args
    value, args = param.handle_parse_result(ctx, opts, args)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 1404, in handle_parse_result
    self.callback, ctx, self, value)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 78, in invoke_param_callback
    return callback(ctx, param, value)
  File "/usr/lib/python3.6/site-packages/miio/click_common.py", line 28, in validate_token
    token_len = len(value)
TypeError: object of type 'NoneType' has no len()
```