### PR TITLE
Philips Bulb crashs if _id is 0

### DIFF
--- a/miio/device.py
+++ b/miio/device.py
@@ -287,7 +287,7 @@ class Device:
         """Increment and return the sequence id."""
         self.__id += 1
         if self.__id >= 9999:
-            self.__id = 0
+            self.__id = 1
         return self.__id
 
     @property


### PR DESCRIPTION
The range [1,9999] and wrap around works fine.

@rytilahti Could you verify this change works for your vacuum too? Just manipulate the ~/.cache/python-miio/python-mirobo.seq (seq=9998) and try a few "get_prop" requests.