### PR TITLE
Depend on specific construct version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 click
 cryptography
 pretty_cron
-construct>=2.9.23
+construct==2.9.23
 zeroconf
 attrs
 typing  # for py3.4 support


### PR DESCRIPTION
This protects against breaking changes in construct API as
encountered in #217.