### PR TITLE
Fixes for the API change of construct v2.9.30

### DIFF
--- a/miio/chuangmi_ir.py
+++ b/miio/chuangmi_ir.py
@@ -130,10 +130,10 @@ class ChuangmiIr(Device):
 
 
 class ProntoPulseAdapter(Adapter):
-    def _decode(self, obj, context):
+    def _decode(self, obj, context, path):
         return int(obj * context._.modulation_period)
 
-    def _encode(self, obj, context):
+    def _encode(self, obj, context, path):
         raise RuntimeError('Not implemented')
 
 

--- a/miio/protocol.py
+++ b/miio/protocol.py
@@ -130,16 +130,16 @@ class Utils:
 
 class TimeAdapter(Adapter):
     """Adapter for timestamp conversion."""
-    def _encode(self, obj, context):
+    def _encode(self, obj, context, path):
         return calendar.timegm(obj.timetuple())
 
-    def _decode(self, obj, context):
+    def _decode(self, obj, context, path):
         return datetime.datetime.utcfromtimestamp(obj)
 
 
 class EncryptionAdapter(Adapter):
     """Adapter to handle communication encryption."""
-    def _encode(self, obj, context):
+    def _encode(self, obj, context, path):
         """Encrypt the given payload with the token stored in the context.
 
         :param obj: JSON object to encrypt"""
@@ -147,7 +147,7 @@ class EncryptionAdapter(Adapter):
         return Utils.encrypt(json.dumps(obj).encode('utf-8') + b'\x00',
                              context['_']['token'])
 
-    def _decode(self, obj, context):
+    def _decode(self, obj, context, path):
         """Decrypts the given payload with the token stored in the context.
 
         :return str: JSON object"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 click
 cryptography
 pretty_cron
-construct>=2.9.23
+construct==2.9.30
 zeroconf
 attrs
 typing  # for py3.4 support

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     packages=["miio", "mirobo"],
 
     python_requires='>=3.4',
-    install_requires=['construct>=2.9.23',
+    install_requires=['construct==2.9.30',
                       'click',
                       'cryptography',
                       'pretty_cron',


### PR DESCRIPTION
Pinning (construct==2.9.30) must be the consequence for the present. As long as construct hasn't a stable api no pinning will be brinkmanship. :rage:

Fixes #217.