### PR TITLE
construct-code uptodate

### DIFF
--- a/miio/chuangmi_ir.py
+++ b/miio/chuangmi_ir.py
@@ -130,10 +130,10 @@ class ChuangmiIr(Device):
 
 
 class ProntoPulseAdapter(Adapter):
-    def _decode(self, obj, context, *args, **kwargs):
+    def _decode(self, obj, context, path):
         return int(obj * context._.modulation_period)
 
-    def _encode(self, obj, context, *args, **kwargs):
+    def _encode(self, obj, context, path):
         raise RuntimeError('Not implemented')
 
 

--- a/miio/device.py
+++ b/miio/device.py
@@ -3,6 +3,7 @@ import datetime
 import socket
 import logging
 import construct
+import binascii
 from typing import Any, List, Optional  # noqa: F401
 
 from .protocol import Message
@@ -133,7 +134,7 @@ class Device:
         :raises DeviceException: if the device could not be discovered."""
         m = Device.discover(self.ip)
         if m is not None:
-            self._device_id = m.header.value.device_id
+            self._device_id = binascii.hexlify(m.header.value.device_id)
             self._device_ts = m.header.value.ts
             self._discovered = True
             if self.debug > 1:
@@ -184,7 +185,7 @@ class Device:
                 if addr[0] not in seen_addrs:
                     _LOGGER.info("  IP %s (ID: %s) - token: %s",
                                  addr[0],
-                                 m.header.value.device_id.decode(),
+                                 binascii.hexlify(m.header.value.device_id).decode(),
                                  codecs.encode(m.checksum, 'hex'))
                     seen_addrs.append(addr[0])
             except socket.timeout:

--- a/miio/protocol.py
+++ b/miio/protocol.py
@@ -20,10 +20,7 @@ from pprint import pprint as pp  # noqa: F401
 
 from construct import (Struct, Bytes, Const, Int16ub, Int32ub, GreedyBytes,
                        Adapter, Checksum, RawCopy, Rebuild, IfThenElse,
-                       Default, Pointer, Hex)
-
-# for debugging parsing
-# from construct import Probe
+                       Default, Pointer, Hex, Probe)
 
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.backends import default_backend
@@ -130,16 +127,16 @@ class Utils:
 
 class TimeAdapter(Adapter):
     """Adapter for timestamp conversion."""
-    def _encode(self, obj, context, *args, **kwargs):
+    def _encode(self, obj, context, path):
         return calendar.timegm(obj.timetuple())
 
-    def _decode(self, obj, context, *args, **kwargs):
+    def _decode(self, obj, context, path):
         return datetime.datetime.utcfromtimestamp(obj)
 
 
 class EncryptionAdapter(Adapter):
     """Adapter to handle communication encryption."""
-    def _encode(self, obj, context, *args, **kwargs):
+    def _encode(self, obj, context, path):
         """Encrypt the given payload with the token stored in the context.
 
         :param obj: JSON object to encrypt"""
@@ -147,7 +144,7 @@ class EncryptionAdapter(Adapter):
         return Utils.encrypt(json.dumps(obj).encode('utf-8') + b'\x00',
                              context['_']['token'])
 
-    def _decode(self, obj, context, *args, **kwargs):
+    def _decode(self, obj, context, path):
         """Decrypts the given payload with the token stored in the context.
 
         :return str: JSON object"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 click
 cryptography
 pretty_cron
-construct>=2.9.23,<=2.9.30
+construct>=2.9.30,<=2.9.31
 zeroconf
 attrs
 typing  # for py3.4 support

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     packages=["miio", "mirobo"],
 
     python_requires='>=3.4',
-    install_requires=['construct>=2.9.23,<=2.9.30',
+    install_requires=['construct>=2.9.30,<=2.9.31',
                       'click',
                       'cryptography',
                       'pretty_cron',


### PR DESCRIPTION
This brings construct-related code uptodate, but it requires 2.9.31 which will be shipped within a day. 
https://pypi.org/project/construct/

The 2 lines referring to "device_id" are fixed but I am not entirely sure about what should be in those fields (bytes or unicode) so please double check that. 

Supercedes #223  and fixes #224 .