### PR TITLE
Construct related, strict check for version equality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This is a bugfix release which provides improved stability and compatibility.
 **Merged pull requests:**
 
 - Proper handling of the device\_id representation [\#228](https://github.com/rytilahti/python-miio/pull/228) ([syssi](https://github.com/syssi))
-- construct-code uptodate [\#226](https://github.com/rytilahti/python-miio/pull/226) ([arekbulski](https://github.com/arekbulski))
+- Construct related, support upto 2.9.31 [\#226](https://github.com/rytilahti/python-miio/pull/226) ([arekbulski](https://github.com/arekbulski))
 
 ## [0.3.6](https://github.com/rytilahti/python-miio/tree/0.3.6)
 

--- a/miio/protocol.py
+++ b/miio/protocol.py
@@ -21,12 +21,16 @@ from pprint import pprint as pp  # noqa: F401
 from construct import (Struct, Bytes, Const, Int16ub, Int32ub, GreedyBytes,
                        Adapter, Checksum, RawCopy, Rebuild, IfThenElse,
                        Default, Pointer, Hex, Probe)
+import construct
 
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import padding
 
 _LOGGER = logging.getLogger(__name__)
+
+# needs to be maintained in sync with setup.py and requirements.txt
+assert construct.version_string == "2.9.31"
 
 
 class Utils:

--- a/setup.py
+++ b/setup.py
@@ -42,16 +42,19 @@ setup(
     packages=["miio", "mirobo"],
 
     python_requires='>=3.4',
-    install_requires=['construct==2.9.31',
-                      'click',
-                      'cryptography',
-                      'pretty_cron',
-                      'typing; python_version < "3.5"',
-                      'zeroconf',
-                      'attrs',
-                      'android_backup',
-                      'pytz',
-                      'appdirs'],
+
+    install_requires=[
+        'construct==2.9.31',
+        'click',
+        'cryptography',
+        'pretty_cron',
+        'typing; python_version < "3.5"',
+        'zeroconf',
+        'attrs',
+        'android_backup',
+        'pytz',
+        'appdirs',
+    ],
 
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This way it fails if pip installs multiple versions or whatnot. No need to ask users for logs.