### PR TITLE
Powerstrip support improved

### DIFF
--- a/miio/powerstrip.py
+++ b/miio/powerstrip.py
@@ -20,10 +20,13 @@ class PowerStripStatus:
     """Container for status reports from the power strip."""
 
     def __init__(self, data: Dict[str, Any]) -> None:
-        # Device model: qmi.powerstrip.v1, zimi.powerstrip.v2
-        #
-        # {'power': 'on', 'temperature': 48.11,
-        # 'current': 0.06, 'mode': 'green'}
+        """
+        Supported device models: qmi.powerstrip.v1, zimi.powerstrip.v2
+
+        Response of a Power Strip 2 (zimi.powerstrip.v2):
+        {'power','on', 'temperature': 48.7, 'current': 0.05, 'mode': None,
+         'power_consume_rate': 4.09, 'wifi_led': 'on', 'power_price': 49}
+        """
         self.data = data
 
     @property
@@ -68,7 +71,7 @@ class PowerStripStatus:
         return self.data["wifi_led"] == "on"
 
     @property
-    def power_price(self) -> Optional[float]:
+    def power_price(self) -> Optional[int]:
         """The stored power price, if available."""
         if self.data["power_price"] is not None:
             return self.data["power_price"]
@@ -136,7 +139,7 @@ class PowerStrip(Device):
         else:
             return self.send("set_wifi_led", ["off"])
 
-    def set_power_price(self, price: float):
+    def set_power_price(self, price: int):
         """Set the power price."""
         if price < 0:
             raise PowerStripException("Invalid power price: %s" % price)

--- a/miio/powerstrip.py
+++ b/miio/powerstrip.py
@@ -65,7 +65,7 @@ class PowerStripStatus:
     @property
     def wifi_led(self) -> bool:
         """True if the wifi led is turned on."""
-        return self.wifi_led == "on"
+        return self.data["wifi_led"] == "on"
 
     @property
     def power_price(self) -> Optional[float]:
@@ -129,9 +129,9 @@ class PowerStrip(Device):
         # green, normal
         return self.send("set_power_mode", [mode.value])
 
-    def set_wifi_led(self, wifi_led: bool):
+    def set_wifi_led(self, led: bool):
         """Set the wifi led on/off."""
-        if wifi_led:
+        if led:
             return self.send("set_wifi_led", ["on"])
         else:
             return self.send("set_wifi_led", ["off"])

--- a/miio/powerstrip.py
+++ b/miio/powerstrip.py
@@ -2,9 +2,13 @@ import logging
 import enum
 from typing import Dict, Any, Optional
 from collections import defaultdict
-from .device import Device
+from .device import Device, DeviceException
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class PowerStripException(DeviceException):
+    pass
 
 
 class PowerMode(enum.Enum):
@@ -134,4 +138,7 @@ class PowerStrip(Device):
 
     def set_power_price(self, price: float):
         """Set the power price."""
+        if price < 0:
+            raise PowerStripException("Invalid power price: %s" % price)
+
         return self.send("set_power_price", [price])

--- a/miio/powerstrip.py
+++ b/miio/powerstrip.py
@@ -141,7 +141,7 @@ class PowerStrip(Device):
 
     def set_power_price(self, price: int):
         """Set the power price."""
-        if price < 0:
+        if price < 0 or price > 999:
             raise PowerStripException("Invalid power price: %s" % price)
 
         return self.send("set_power_price", [price])

--- a/miio/powerstrip.py
+++ b/miio/powerstrip.py
@@ -58,14 +58,33 @@ class PowerStripStatus:
             return PowerMode(self.data["mode"])
         return None
 
+    @property
+    def wifi_led(self) -> bool:
+        """True if the wifi led is turned on."""
+        return self.wifi_led == "on"
+
+    @property
+    def power_price(self) -> Optional[float]:
+        """The stored power price, if available."""
+        if self.data["power_price"] is not None:
+            return self.data["power_price"]
+        return None
+
     def __repr__(self) -> str:
-        s = "<PowerStripStatus power=%s, temperature=%s, " \
-            "load_power=%s, current=%s, mode=%s>" % \
+        s = "<PowerStripStatus power=%s, " \
+            "temperature=%s, " \
+            "load_power=%s, " \
+            "current=%s, " \
+            "mode=%s, " \
+            "wifi_led=%s, " \
+            "power_price=%s>" % \
             (self.power,
              self.temperature,
              self.load_power,
              self.current,
-             self.mode)
+             self.mode,
+             self.wifi_led,
+             self.power_price)
         return s
 
 
@@ -75,7 +94,7 @@ class PowerStrip(Device):
     def status(self) -> PowerStripStatus:
         """Retrieve properties."""
         properties = ['power', 'temperature', 'current', 'mode',
-                      'power_consume_rate']
+                      'power_consume_rate', 'wifi_led', 'power_price', ]
         values = self.send(
             "get_prop",
             properties
@@ -101,7 +120,18 @@ class PowerStrip(Device):
         return self.send("set_power", ["off"])
 
     def set_power_mode(self, mode: PowerMode):
-        """Set mode."""
+        """Set the power mode."""
 
         # green, normal
         return self.send("set_power_mode", [mode.value])
+
+    def set_wifi_led(self, wifi_led: bool):
+        """Set the wifi led on/off."""
+        if wifi_led:
+            return self.send("set_wifi_led", ["on"])
+        else:
+            return self.send("set_wifi_led", ["off"])
+
+    def set_power_price(self, price: float):
+        """Set the power price."""
+        return self.send("set_power_price", [price])

--- a/miio/tests/test_powerstrip.py
+++ b/miio/tests/test_powerstrip.py
@@ -117,6 +117,9 @@ class TestPowerStrip(TestCase):
         with pytest.raises(PowerStripException):
             self.device.set_power_price(-1)
 
+        with pytest.raises(PowerStripException):
+            self.device.set_power_price(1000)
+
     def test_status_without_power_price(self):
         self.device._reset_state()
 

--- a/miio/tests/test_powerstrip.py
+++ b/miio/tests/test_powerstrip.py
@@ -80,6 +80,7 @@ class TestPowerStrip(TestCase):
     def test_status_without_mode(self):
         self.device._reset_state()
 
+        # The Power Strip  2 doesn't support power modes
         self.device.state["mode"] = None
         assert self.state().mode is None
 
@@ -91,13 +92,6 @@ class TestPowerStrip(TestCase):
         assert mode() == PowerMode.Eco
         self.device.set_power_mode(PowerMode.Normal)
         assert mode() == PowerMode.Normal
-
-    def test_status_without_mode(self):
-        self.device._reset_state()
-
-        # The Power Strip  2 doesn't support power modes
-        self.device.state["mode"] = None
-        assert self.state().mode is None
 
     def test_set_wifi_led(self):
         def wifi_led():

--- a/miio/tests/test_powerstrip.py
+++ b/miio/tests/test_powerstrip.py
@@ -13,7 +13,7 @@ class DummyPowerStrip(DummyDevice, PowerStrip):
             'temperature': 32.5,
             'current': 25.5,
             'power_consume_rate': 12.5,
-            'wifi_led': 'on',
+            'wifi_led': 'off',
             'power_price': 12.5,
         }
         self.return_values = {

--- a/miio/tests/test_powerstrip.py
+++ b/miio/tests/test_powerstrip.py
@@ -14,7 +14,7 @@ class DummyPowerStrip(DummyDevice, PowerStrip):
             'current': 25.5,
             'power_consume_rate': 12.5,
             'wifi_led': 'off',
-            'power_price': 12.5,
+            'power_price': 49,
         }
         self.return_values = {
             'get_prop': self._get_state,
@@ -92,6 +92,13 @@ class TestPowerStrip(TestCase):
         self.device.set_power_mode(PowerMode.Normal)
         assert mode() == PowerMode.Normal
 
+    def test_status_without_mode(self):
+        self.device._reset_state()
+
+        # The Power Strip  2 doesn't support power modes
+        self.device.state["mode"] = None
+        assert self.state().mode is None
+
     def test_set_wifi_led(self):
         def wifi_led():
             return self.device.status().wifi_led
@@ -108,8 +115,8 @@ class TestPowerStrip(TestCase):
 
         self.device.set_power_price(0)
         assert power_price() == 0
-        self.device.set_power_price(1.5)
-        assert power_price() == 1.5
+        self.device.set_power_price(1)
+        assert power_price() == 1
         self.device.set_power_price(2)
         assert power_price() == 2
 


### PR DESCRIPTION
New properties and commands added: wifi_led, power_price.

@rytilahti Could you provide a response example for

```
mirobo raw_command get_prop "['power', 'temperature', 'current', 'mode', 'power_consume_rate', 'wifi_led', 'power_price']"
```

Thanks!