### PR TITLE
Drop python 3.4 support, which paves a way for nicer API for asyncio among other things

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: python
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
 install: pip install tox-travis coveralls

--- a/miio/click_common.py
+++ b/miio/click_common.py
@@ -3,8 +3,8 @@
 This file contains common functions for cli tools.
 """
 import sys
-if sys.version_info < (3, 4):
-    print("To use this script you need python 3.4 or newer, got %s" %
+if sys.version_info < (3, 5):
+    print("To use this script you need python 3.5 or newer, got %s" %
           sys.version_info)
     sys.exit(1)
 import click

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
@@ -41,14 +40,13 @@ setup(
 
     packages=["miio", "mirobo"],
 
-    python_requires='>=3.4',
+    python_requires='>=3.5',
 
     install_requires=[
         'construct==2.9.31',
         'click',
         'cryptography',
         'pretty_cron',
-        'typing; python_version < "3.5"',
         'zeroconf',
         'attrs',
         'android_backup',

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
-envlist=py34,py35,py36,py37,flake8,typing
+envlist=py35,py36,py37,flake8,typing
 
 [tox:travis]
-3.4 = py34
 3.5 = py35
 3.6 = py36
 3.7 = py37


### PR DESCRIPTION
Now that homeassistant depends on python 3.5 (which has been already available in debian stretch for a while), I think we can consider dropping py3.4 support.

Related to #91.