### PR TITLE
Support of the Air Purifier V3 added (Closes: #231)

### DIFF
--- a/miio/airpurifier.py
+++ b/miio/airpurifier.py
@@ -13,10 +13,16 @@ class AirPurifierException(DeviceException):
 
 
 class OperationMode(enum.Enum):
+    # Supported modes of the Air Purifier Pro, 2, V3
     Auto = 'auto'
     Silent = 'silent'
     Favorite = 'favorite'
+    # Additional supported modes of the Air Purifier 2 and V3
     Idle = 'idle'
+    # Additional supported modes of the Air Purifier V3
+    Medium = 'medium'
+    High = 'high'
+    Strong = 'strong'
 
 
 class SleepMode(enum.Enum):

--- a/miio/airpurifier.py
+++ b/miio/airpurifier.py
@@ -74,6 +74,20 @@ class AirPurifierStatus:
         'rfid_product_id': None, 'rfid_tag': None,
         'act_sleep': 'close'}
 
+        Response of a Air Purifier V3 (zhimi.airpurifier.v3)
+
+        {'power': 'off', 'aqi': 0, 'humidity': None, 'temp_dec': None,
+         'mode': 'idle', 'led': 'off', 'led_b': 10, 'buzzer': 'on',
+         'child_lock': 'off', 'bright': 43, 'favorite_level': None,
+         'filter1_life': 26, 'f1_hour_used': 2573, 'use_time': None,
+         'motor1_speed': 0}
+
+        {‘power’: 'on', ‘aqi’: 18, ‘humidity’: None, ‘temp_dec’: None,
+         ‘mode’: 'silent', ‘led’: 'off', ‘led_b’: 10, ‘buzzer’: 'on',
+         ‘child_lock’: 'off', ‘bright’: 4, ‘favorite_level’: None,
+         ‘filter1_life’: 26, ‘f1_hour_used’: 2574, ‘use_time’: None,
+         ‘motor1_speed’: 648}
+
         A request is limited to 16 properties.
         """
 
@@ -134,7 +148,10 @@ class AirPurifierStatus:
     def led_brightness(self) -> Optional[LedBrightness]:
         """Brightness of the LED."""
         if self.data["led_b"] is not None:
-            return LedBrightness(self.data["led_b"])
+            try:
+                return LedBrightness(self.data["led_b"])
+            except ValueError:
+                return None
 
         return None
 

--- a/miio/tests/test_airpurifier.py
+++ b/miio/tests/test_airpurifier.py
@@ -273,6 +273,13 @@ class TestAirPurifier(TestCase):
         self.device.state["led_b"] = None
         assert self.state().led_brightness is None
 
+    def test_status_unknown_led_brightness(self):
+        self.device._reset_state()
+
+        # The Air Purifier V3 returns a led brightness of 10 f.e.
+        self.device.state["led_b"] = 10
+        assert self.state().led_brightness is None
+
     def test_status_without_temperature(self):
         self.device._reset_state()
         self.device.state["temp_dec"] = None


### PR DESCRIPTION
The Air Purifier V3 doesn't support led brightness but provides a strange value for the property nevertheless. cp. #231