### PR TITLE
Provide the mac address as property of the device info

### DIFF
--- a/miio/device.py
+++ b/miio/device.py
@@ -95,6 +95,12 @@ class DeviceInfo:
             return self.data["hw_ver"]
         return None
 
+    def mac_address(self) -> Optional[str]:
+        """MAC address if available."""
+        if self.data["mac"] is not None:
+            return self.data["mac"]
+        return None
+
     @property
     def raw(self):
         """Raw data as returned by the device."""


### PR DESCRIPTION
I want to use the mac address as `unique_id` at home assistant.