### PR TITLE
Add support for vacuum's carpet mode, which requires a recent firmware version

### DIFF
--- a/docs/vacuum.rst
+++ b/docs/vacuum.rst
@@ -204,7 +204,33 @@ To enable (dnd 22:00-0600):
 
     mirobo dnd on 22 0 6 0
 
-It is also possible to run raw commands for testing:
+Carpet mode
+~~~~~~~~~~~
+
+Carpet mode increases the suction when encountering a carpet.
+The optional parameters (when using miiocli) are unknown and set as
+they were in the original firmware.
+
+To enable:
+
+::
+
+    mirobo carpet_mode 1 (or any other true-value, such as 'true')
+
+
+To disable:
+
+::
+
+    mirobo carpet_mode 0
+
+
+Raw commands
+~~~~~~~~~~~~
+
+It is also possible to run raw commands, which can be useful
+ for testing new unknown commands or if you want to have full access
+ to what is being sent to the device:
 
 ::
 
@@ -216,8 +242,13 @@ or with parameters (same as above dnd on):
 
     mirobo raw_command set_dnd_timer '[22,0,6,0]'
 
-If you find a new command please let us know by creating a pull request
-or an issue, if you do not want to implement it on your own!
+The input is passed as it is to the device as the `params` value,
+so it is also possible to pass dicts.
+
+.. NOTE::
+
+    If you find a new command please let us know by creating a pull request
+    or an issue, if you do not want to implement it on your own!
 
 .. _HelpOutput:
 

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -18,7 +18,7 @@ from .click_common import (
 from .device import Device, DeviceException
 from .vacuumcontainers import (VacuumStatus, ConsumableStatus, DNDStatus,
                                CleaningSummary, CleaningDetails, Timer,
-                               SoundStatus, SoundInstallStatus, )
+                               SoundStatus, SoundInstallStatus, CarpetModeStatus)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -341,6 +341,31 @@ class Vacuum(Device):
             extra_params["gmt_offset"] = offset_as_float
 
         return super().configure_wifi(ssid, password, uid, extra_params)
+
+    @command()
+    def carpet_mode(self):
+        """Get carpet mode settings"""
+        return CarpetModeStatus(self.send("get_carpet_mode")[0])
+
+    @command(
+        click.argument("enabled", required=True, type=bool),
+        click.argument("stall_time", required=False, default=10, type=int),
+        click.argument("low", required=False, default=400, type=int),
+        click.argument("high", required=False, default=500, type=int),
+        click.argument("integral", required=False, default=450, type=int)
+    )
+    def set_carpet_mode(self, enabled: bool, stall_time: int = 10,
+                        low: int = 400, high: int = 500, integral: int = 450):
+        """Set the carpet mode."""
+        click.echo("Setting carpet mode: %s" % enabled)
+        data = {
+            'enable': int(enabled),
+            'stall_time': stall_time,
+            'current_low': low,
+            'current_high': high,
+            'current_integral': integral,
+        }
+        return self.send("set_carpet_mode", [data])[0] == 'ok'
 
     @classmethod
     def get_device_group(cls):

--- a/miio/vacuum_cli.py
+++ b/miio/vacuum_cli.py
@@ -502,6 +502,16 @@ def timezone(vac: miio.Vacuum, tz=None):
 
 
 @cli.command()
+@click.argument('enabled', required=False, type=bool)
+@pass_dev
+def carpet_mode(vac: miio.Vacuum, enabled=None):
+    """Query or set the carpet mode."""
+    if enabled is None:
+        click.echo(vac.carpet_mode())
+    else:
+        click.echo(vac.set_carpet_mode(enabled))
+
+@cli.command()
 @click.argument('ssid', required=True)
 @click.argument('password', required=True)
 @click.argument('uid', type=int, required=False)

--- a/miio/vacuumcontainers.py
+++ b/miio/vacuumcontainers.py
@@ -475,3 +475,44 @@ class SoundInstallStatus:
 
     def __json__(self):
         return self.data
+
+
+class CarpetModeStatus:
+    """Container for carpet mode status."""
+    def __init__(self, data):
+        # {'current_high': 500, 'enable': 1, 'current_integral': 450,
+        #  'current_low': 400, 'stall_time': 10}
+        self.data = data
+
+    @property
+    def enabled(self) -> bool:
+        """True if carpet mode is enabled."""
+        return self.data['enable'] == 1
+
+    @property
+    def stall_time(self) -> int:
+        return self.data['stall_time']
+
+    @property
+    def current_low(self) -> int:
+        return self.data['current_low']
+
+    @property
+    def current_high(self) -> int:
+        return self.data['current_high']
+
+    @property
+    def current_integral(self) -> int:
+        return self.data['current_integral']
+
+    def __repr__(self):
+        return "<CarpetModeStatus enabled=%s, " \
+               "stall_time: %s, " \
+               "current (low, high, integral): (%s, %s, %s)>" % (self.enabled,
+                                                                 self.stall_time,
+                                                                 self.current_low,
+                                                                 self.current_high,
+                                                                 self.current_integral)
+
+    def __json__(self):
+        return self.data


### PR DESCRIPTION
I'm not very comfortable in the current generalized cli (as it requires so much typing currently, maybe I need to update the env vars for it to work properly), so I added a simplified interface for `mirobo`also.

Another thing that is not completely to my liking is that it's not anymore possible to use the same command for querying & setting (so just adding parameters), but maybe that can be changed, too.