### PR TITLE
Support of multiple zones for app_zoned_cleaning

### DIFF
--- a/miio/tests/test_vacuum.py
+++ b/miio/tests/test_vacuum.py
@@ -145,7 +145,7 @@ class TestVacuum(TestCase):
     def test_zoned_clean(self):
         self.device.start()
         assert self.status().is_on is True
-        self.device.zoned_clean(25000, 25000, 25500, 25500, 3)
+        self.device.zoned_clean([25000, 25000, 25500, 25500, 3],[23000, 23000, 22500, 22500, 1])
         assert self.status().state_code == self.device.STATE_ZONED_CLEAN
 
     @pytest.mark.xfail

--- a/miio/tests/test_vacuum.py
+++ b/miio/tests/test_vacuum.py
@@ -31,9 +31,6 @@ class DummyVacuum(DummyDevice, Vacuum):
             'battery': 100,
             'fan_power': 20,
             'msg_seq': 320,
-            'goto_target': {'x_coord': 24000, 'y_coord': 24500},
-            'zoned_area': {'x1_coord': 24000, 'y1_coord': 24500,
-                           'x2_coord': 28000, 'y2_coord': 29500, 'iterations': 3}
         }
 
         self.return_values = {
@@ -149,6 +146,7 @@ class TestVacuum(TestCase):
         self.device.start()
         assert self.status().is_on is True
         self.device.zoned_clean(25000, 25000, 25500, 25500, 3)
+        self.device.zoned_clean(25000,25000,25500,25500,3)
         assert self.status().state_code == self.device.STATE_ZONED_CLEAN
 
     @pytest.mark.xfail

--- a/miio/tests/test_vacuum.py
+++ b/miio/tests/test_vacuum.py
@@ -145,7 +145,7 @@ class TestVacuum(TestCase):
     def test_zoned_clean(self):
         self.device.start()
         assert self.status().is_on is True
-        self.device.zoned_clean([25000, 25000, 25500, 25500, 3],[23000, 23000, 22500, 22500, 1])
+        self.device.zoned_clean([[25000, 25000, 25500, 25500, 3], [23000, 23000, 22500, 22500, 1]])
         assert self.status().state_code == self.device.STATE_ZONED_CLEAN
 
     @pytest.mark.xfail

--- a/miio/tests/test_vacuum.py
+++ b/miio/tests/test_vacuum.py
@@ -146,7 +146,6 @@ class TestVacuum(TestCase):
         self.device.start()
         assert self.status().is_on is True
         self.device.zoned_clean(25000, 25000, 25500, 25500, 3)
-        self.device.zoned_clean(25000,25000,25500,25500,3)
         assert self.status().state_code == self.device.STATE_ZONED_CLEAN
 
     @pytest.mark.xfail

--- a/miio/tests/test_vacuum.py
+++ b/miio/tests/test_vacuum.py
@@ -31,6 +31,9 @@ class DummyVacuum(DummyDevice, Vacuum):
             'battery': 100,
             'fan_power': 20,
             'msg_seq': 320,
+            'goto_target': {'x_coord': 24000, 'y_coord': 24500},
+            'zoned_area': {'x1_coord': 24000, 'y1_coord': 24500,
+                           'x2_coord': 28000, 'y2_coord': 29500, 'iterations': 3}
         }
 
         self.return_values = {

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -76,15 +76,29 @@ class Vacuum(Device):
     @command(
         click.argument("x_coord", type=int),
         click.argument("y_coord", type=int),
-
     )
     def goto(self, x_coord: int, y_coord: int):
         """Go to specific target.
-
         :param int x_coord: x coordinate
         :param int y_coord: y coordinate"""
         return self.send("app_goto_target",
                          [x_coord, y_coord])
+    @command(
+        click.argument("x_coord", type=int),
+        click.argument("y_coord", type=int),
+        click.argument("x2_coord", type=int),
+        click.argument("y2_coord", type=int),
+        click.argument("iterations", type=int),
+    )
+    def zoned_clean(self, x_coord: int, y_coord: int, x2_coord: int, y2_coord: int, iterations: int):
+        """Clean a zoned area.
+        :param int x_coord: x coordinate bottom left corner
+        :param int y_coord: y coordinate bottom left corner
+        :param int x2_coord: x2 coordinate top right corner
+        :param int y2_coord: y2 coordinate top right corner
+        :param int iterations: How many times the zone should be cleaned"""
+        return self.send("app_zoned_clean",
+                         [x_coord, y_coord, x2_coord, y2_coord, iterations])
 
     @command(
         click.argument("x_coord", type=int),

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -81,8 +81,7 @@ class Vacuum(Device):
         """Go to specific target.
         :param int x_coord: x coordinate
         :param int y_coord: y coordinate"""
-        return self.send("app_goto_target",
-                         [x_coord, y_coord])
+        return self.send("app_goto_target", [x_coord, y_coord])
 
     @command(
         click.argument("x1_coord", type=int),
@@ -116,15 +115,15 @@ class Vacuum(Device):
     @command(
         click.argument("zones"),
     )
-    def zoned_clean(self, *zones):
+    def zoned_clean(self, zones: List):
         """Cleans zoned areas.
-        :enter one or multiple zones: [x1,y1,x2,y2, iterations],[x1,y1,x2,y2, iterations]: 
+        :Enter a list of zones to clean: [[x1,y1,x2,y2, iterations],[x1,y1,x2,y2, iterations]]
         :param int x1: x1 coordinate bottom left corner
         :param int y1: y1 coordinate bottom left corner
         :param int x2: x2 coordinate top right corner
         :param int y2: y2 coordinate top right corner
         :param int iterations: How many times the zone should be cleaned"""
-        return self.send("app_zoned_clean", [zones])
+        return self.send("app_zoned_clean", zones)
 
     @command()
     def manual_start(self):

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -114,22 +114,17 @@ class Vacuum(Device):
                          [x_coord, y_coord])
 
     @command(
-        click.argument("x1_coord", type=int),
-        click.argument("y1_coord", type=int),
-        click.argument("x2_coord", type=int),
-        click.argument("y2_coord", type=int),
-        click.argument("iterations", type=int),
+        click.argument("zones"),
     )
-    def zoned_clean(self, x1_coord: int, y1_coord: int,
-                    x2_coord: int, y2_coord: int, iterations: int):
-        """Clean a zoned area.
-        :param int x1_coord: x1 coordinate bottom left corner
-        :param int y1_coord: y1 coordinate bottom left corner
-        :param int x2_coord: x2 coordinate top right corner
-        :param int y2_coord: y2 coordinate top right corner
+    def zoned_clean(self, zones):
+        """Cleans zoned areas.
+        :enter a list of zones: [[x1,y1,x2,y2, iterations],[x1,y1,x2,y2, iterations]]: 
+        :param int x1 coordinate bottom left corner
+        :param int y1: y1 coordinate bottom left corner
+        :param int x2: x2 coordinate top right corner
+        :param int y2: y2 coordinate top right corner
         :param int iterations: How many times the zone should be cleaned"""
-        return self.send("app_zoned_clean",
-                         [x1_coord, y1_coord, x2_coord, y2_coord, iterations])
+        return self.send("app_zoned_clean",zones)
 
     @command()
     def manual_start(self):

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -91,16 +91,16 @@ class Vacuum(Device):
         click.argument("y2_coord", type=int),
         click.argument("iterations", type=int),
     )
-    def zoned_clean(self, x_coord: int, y_coord: int,
+    def zoned_clean(self, x1_coord: int, y1_coord: int,
                     x2_coord: int, y2_coord: int, iterations: int):
         """Clean a zoned area.
-        :param int x_coord: x coordinate bottom left corner
-        :param int y_coord: y coordinate bottom left corner
+        :param int x1_coord: x1 coordinate bottom left corner
+        :param int y1_coord: y1 coordinate bottom left corner
         :param int x2_coord: x2 coordinate top right corner
         :param int y2_coord: y2 coordinate top right corner
         :param int iterations: How many times the zone should be cleaned"""
         return self.send("app_zoned_clean",
-                         [x_coord, y_coord, x2_coord, y2_coord, iterations])
+                         [x1_coord, y1_coord, x2_coord, y2_coord, iterations])
 
     @command(
         click.argument("x_coord", type=int),

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -72,6 +72,19 @@ class Vacuum(Device):
         """Stop cleaning and return home."""
         self.send("app_stop")
         return self.send("app_charge")
+    
+    @command(
+        click.argument("x_coord", type=int),
+        click.argument("y_coord", type=int),
+
+    )
+    def goto(self, x_coord: int, y_coord: int):
+        """Go to specific target.
+
+        :param int x_coord: x coordinate
+        :param int y_coord: y coordinate"""
+        return self.send("app_goto_target",
+                         [x_coord, y_coord])
 
     @command(
         click.argument("x_coord", type=int),

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -15,7 +15,7 @@ from appdirs import user_cache_dir
 from .click_common import (
     DeviceGroup, command, GlobalContextObject,
 )
-from .device import Device, DeviceException
+from .device import Device, DeviceException, LiteralParamType
 from .vacuumcontainers import (VacuumStatus, ConsumableStatus, DNDStatus,
                                CleaningSummary, CleaningDetails, Timer,
                                SoundStatus, SoundInstallStatus, CarpetModeStatus)
@@ -84,45 +84,11 @@ class Vacuum(Device):
         return self.send("app_goto_target", [x_coord, y_coord])
 
     @command(
-        click.argument("x1_coord", type=int),
-        click.argument("y1_coord", type=int),
-        click.argument("x2_coord", type=int),
-        click.argument("y2_coord", type=int),
-        click.argument("iterations", type=int),
-    )
-    def zoned_clean(self, x1_coord: int, y1_coord: int,
-                    x2_coord: int, y2_coord: int, iterations: int):
-        """Clean a zoned area.
-        :param int x1_coord: x1 coordinate bottom left corner
-        :param int y1_coord: y1 coordinate bottom left corner
-        :param int x2_coord: x2 coordinate top right corner
-        :param int y2_coord: y2 coordinate top right corner
-        :param int iterations: How many times the zone should be cleaned"""
-        return self.send("app_zoned_clean",
-                         [x1_coord, y1_coord, x2_coord, y2_coord, iterations])
-
-    @command(
-        click.argument("x_coord", type=int),
-        click.argument("y_coord", type=int),
-    )
-    def goto(self, x_coord: int, y_coord: int):
-        """Go to specific target.
-        :param int x_coord: x coordinate
-        :param int y_coord: y coordinate"""
-        return self.send("app_goto_target",
-                         [x_coord, y_coord])
-
-    @command(
-        click.argument("zones"),
+        click.argument("zones", type=LiteralParamType(), required=True),
     )
     def zoned_clean(self, zones: List):
         """Cleans zoned areas.
-        :Enter a list of zones to clean: [[x1,y1,x2,y2, iterations],[x1,y1,x2,y2, iterations]]
-        :param int x1: x1 coordinate bottom left corner
-        :param int y1: y1 coordinate bottom left corner
-        :param int x2: x2 coordinate top right corner
-        :param int y2: y2 coordinate top right corner
-        :param int iterations: How many times the zone should be cleaned"""
+        :param List zones: List of zones to clean: [[x1,y1,x2,y2, iterations],[x1,y1,x2,y2, iterations]]"""
         return self.send("app_zoned_clean", zones)
 
     @command()

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -119,7 +119,7 @@ class Vacuum(Device):
     def zoned_clean(self, *zones):
         """Cleans zoned areas.
         :enter one or multiple zones: [x1,y1,x2,y2, iterations],[x1,y1,x2,y2, iterations]: 
-        :param int x1 coordinate bottom left corner
+        :param int x1: x1 coordinate bottom left corner
         :param int y1: y1 coordinate bottom left corner
         :param int x2: x2 coordinate top right corner
         :param int y2: y2 coordinate top right corner

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -83,7 +83,7 @@ class Vacuum(Device):
         :param int y_coord: y coordinate"""
         return self.send("app_goto_target",
                          [x_coord, y_coord])
-    
+
     @command(
         click.argument("x_coord", type=int),
         click.argument("y_coord", type=int),
@@ -91,7 +91,7 @@ class Vacuum(Device):
         click.argument("y2_coord", type=int),
         click.argument("iterations", type=int),
     )
-    def zoned_clean(self, x_coord: int, y_coord: int, 
+    def zoned_clean(self, x_coord: int, y_coord: int,
                     x2_coord: int, y2_coord: int, iterations: int):
         """Clean a zoned area.
         :param int x_coord: x coordinate bottom left corner

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -13,9 +13,9 @@ import pytz
 from appdirs import user_cache_dir
 
 from .click_common import (
-    DeviceGroup, command, GlobalContextObject,
+    DeviceGroup, command, GlobalContextObject, LiteralParamType
 )
-from .device import Device, DeviceException, LiteralParamType
+from .device import Device, DeviceException
 from .vacuumcontainers import (VacuumStatus, ConsumableStatus, DNDStatus,
                                CleaningSummary, CleaningDetails, Timer,
                                SoundStatus, SoundInstallStatus, CarpetModeStatus)
@@ -87,7 +87,7 @@ class Vacuum(Device):
         click.argument("zones", type=LiteralParamType(), required=True),
     )
     def zoned_clean(self, zones: List):
-        """Cleans zoned areas.
+        """Clean zones.
         :param List zones: List of zones to clean: [[x1,y1,x2,y2, iterations],[x1,y1,x2,y2, iterations]]"""
         return self.send("app_zoned_clean", zones)
 

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -72,7 +72,7 @@ class Vacuum(Device):
         """Stop cleaning and return home."""
         self.send("app_stop")
         return self.send("app_charge")
-    
+
     @command(
         click.argument("x_coord", type=int),
         click.argument("y_coord", type=int),
@@ -83,6 +83,7 @@ class Vacuum(Device):
         :param int y_coord: y coordinate"""
         return self.send("app_goto_target",
                          [x_coord, y_coord])
+    
     @command(
         click.argument("x_coord", type=int),
         click.argument("y_coord", type=int),
@@ -90,7 +91,8 @@ class Vacuum(Device):
         click.argument("y2_coord", type=int),
         click.argument("iterations", type=int),
     )
-    def zoned_clean(self, x_coord: int, y_coord: int, x2_coord: int, y2_coord: int, iterations: int):
+    def zoned_clean(self, x_coord: int, y_coord: int, 
+                    x2_coord: int, y2_coord: int, iterations: int):
         """Clean a zoned area.
         :param int x_coord: x coordinate bottom left corner
         :param int y_coord: y coordinate bottom left corner

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -116,15 +116,15 @@ class Vacuum(Device):
     @command(
         click.argument("zones"),
     )
-    def zoned_clean(self, zones):
+    def zoned_clean(self, *zones):
         """Cleans zoned areas.
-        :enter a list of zones: [[x1,y1,x2,y2, iterations],[x1,y1,x2,y2, iterations]]: 
+        :enter a list of zones: [x1,y1,x2,y2, iterations],[x1,y1,x2,y2, iterations]: 
         :param int x1 coordinate bottom left corner
         :param int y1: y1 coordinate bottom left corner
         :param int x2: x2 coordinate top right corner
         :param int y2: y2 coordinate top right corner
         :param int iterations: How many times the zone should be cleaned"""
-        return self.send("app_zoned_clean",zones)
+        return self.send("app_zoned_clean", [zones])
 
     @command()
     def manual_start(self):

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -85,8 +85,8 @@ class Vacuum(Device):
                          [x_coord, y_coord])
 
     @command(
-        click.argument("x_coord", type=int),
-        click.argument("y_coord", type=int),
+        click.argument("x1_coord", type=int),
+        click.argument("y1_coord", type=int),
         click.argument("x2_coord", type=int),
         click.argument("y2_coord", type=int),
         click.argument("iterations", type=int),

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -118,7 +118,7 @@ class Vacuum(Device):
     )
     def zoned_clean(self, *zones):
         """Cleans zoned areas.
-        :enter a list of zones: [x1,y1,x2,y2, iterations],[x1,y1,x2,y2, iterations]: 
+        :enter one or multiple zones: [x1,y1,x2,y2, iterations],[x1,y1,x2,y2, iterations]: 
         :param int x1 coordinate bottom left corner
         :param int y1: y1 coordinate bottom left corner
         :param int x2: x2 coordinate top right corner

--- a/miio/vacuum_cli.py
+++ b/miio/vacuum_cli.py
@@ -7,7 +7,7 @@ import sys
 import threading
 import time
 from pprint import pformat as pf
-from typing import Any  # noqa: F401
+from typing import Any, List  # noqa: F401
 
 import click
 import pretty_cron
@@ -16,7 +16,7 @@ from tqdm import tqdm
 
 import miio  # noqa: E402
 from miio.click_common import (ExceptionHandlerGroup, validate_ip,
-                               validate_token, )
+                               validate_token, LiteralParamType)
 from .device import UpdateState
 from .updater import OneShotServer
 
@@ -199,16 +199,19 @@ def home(vac: miio.Vacuum):
 
 @cli.command()
 @pass_dev
-def goto(vac: miio.Vacuum):
-    """Going to target."""
-    click.echo("Going to target : %s" % vac.goto())
+@click.argument('x_coord', type=int)
+@click.argument('y_coord', type=int)
+def goto(vac: miio.Vacuum, x_coord: int, y_coord: int):
+    """Go to specific target."""
+    click.echo("Going to target : %s" % vac.goto(x_coord, y_coord))
 
 
 @cli.command()
 @pass_dev
-def zoned_clean(vac: miio.Vacuum):
-    """Cleaning zone(s)."""
-    click.echo("Cleaning zone(s) : %s" % vac.zoned_clean())
+@click.argument("zones", type=LiteralParamType(), required=True)
+def zoned_clean(vac: miio.Vacuum, zones: List):
+    """Clean zone."""
+    click.echo("Cleaning zone(s) : %s" % vac.zoned_clean(zones))
 
 @cli.group()
 @pass_dev

--- a/miio/vacuum_cli.py
+++ b/miio/vacuum_cli.py
@@ -196,11 +196,13 @@ def home(vac: miio.Vacuum):
     """Return home."""
     click.echo("Requesting return to home: %s" % vac.home())
 
+
 @cli.command()
 @pass_dev
 def goto(vac: miio.Vacuum):
     """Going to target."""
     click.echo("Going to target : %s" % vac.goto())
+
 
 @cli.command()
 @pass_dev

--- a/miio/vacuum_cli.py
+++ b/miio/vacuum_cli.py
@@ -196,6 +196,17 @@ def home(vac: miio.Vacuum):
     """Return home."""
     click.echo("Requesting return to home: %s" % vac.home())
 
+@cli.command()
+@pass_dev
+def goto(vac: miio.Vacuum):
+    """Going to target."""
+    click.echo("Going to target : %s" % vac.goto())
+
+@cli.command()
+@pass_dev
+def zoned_clean(vac: miio.Vacuum):
+    """Cleaning zone(s)."""
+    click.echo("Cleaning zone(s) : %s" % vac.zoned_clean())
 
 @cli.group()
 @pass_dev


### PR DESCRIPTION
The vacuum only accepts zones within a list, so even a single list has to be passed like this:

[[x1,y1,x2,y2, iterations]]

The current code only sends "[x1,y1,x2,y2, iterations]" to the vacuum, so it does not work. I tried to change the code so that it accepts multiple zones, but I am not sure if it works like this. In addition, I have no no idea how to define the click.argument for a list. So I definitely going to need help on this one.