### PR TITLE
miiocli: Fix raw_command parameters (Closes: #335)

### DIFF
--- a/miio/click_common.py
+++ b/miio/click_common.py
@@ -2,6 +2,7 @@
 
 This file contains common functions for cli tools.
 """
+import ast
 import sys
 if sys.version_info < (3, 5):
     print("To use this script you need python 3.5 or newer, got %s" %
@@ -91,6 +92,16 @@ class EnumType(click.Choice):
             word.pop()
 
         return ("_".join(word)).upper()
+
+
+class LiteralParamType(click.ParamType):
+    name = 'literal'
+
+    def convert(self, value, param, ctx):
+        try:
+            return ast.literal_eval(value)
+        except ValueError:
+            self.fail('%s is not a valid literal' % value, param, ctx)
 
 
 class GlobalContextObject:

--- a/miio/device.py
+++ b/miio/device.py
@@ -10,7 +10,7 @@ import click
 import construct
 
 from .click_common import (
-    DeviceGroupMeta, command, format_output,
+    DeviceGroupMeta, command, format_output, LiteralParamType
 )
 from .exceptions import DeviceException, DeviceError
 from .protocol import Message
@@ -289,17 +289,17 @@ class Device(metaclass=DeviceGroupMeta):
             raise DeviceException("No response from the device") from ex
 
     @command(
-        click.argument('cmd', required=True),
-        click.argument('parameters', required=False),
+        click.argument('command', type=str, required=True),
+        click.argument('parameters', type=LiteralParamType(), required=False),
     )
-    def raw_command(self, cmd, params):
+    def raw_command(self, command, parameters):
         """Send a raw command to the device.
         This is mostly useful when trying out commands which are not
         implemented by a given device instance.
 
-        :param str cmd: Command to send
-        :param dict params: Parameters to send"""
-        return self.send(cmd, params)
+        :param str command: Command to send
+        :param dict parameters: Parameters to send"""
+        return self.send(command, parameters)
 
     @command(
         default_output=format_output(


### PR DESCRIPTION
```
miiocli -d device --ip 192.168.132.37 --token 9f2ec23a56cc86fee0c01ff1e34c7b25 raw_command get_prop "['power','snm']"
```
works fine now.