### PR TITLE
Add tqdm to requirements list

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ attrs
 typing  # for py3.4 support
 pytz  # for tz offset in vacuum
 appdirs  # for user_cache_dir of vacuum_cli
+tqdm


### PR DESCRIPTION
`tqdm` was introduced as a dependency earlier and added to [`setup.py`](https://github.com/rytilahti/python-miio/blob/e8b6489bb956be465f7738f58ee1c7835d817623/setup.py#L57) accordingly. However, this new dependency was not reflected in the textual requirements list.