### PR TITLE
WIP: Initial support for nextgen vacuums (with prefixed methods)

### DIFF
--- a/miio/device.py
+++ b/miio/device.py
@@ -230,6 +230,8 @@ class Device(metaclass=DeviceGroupMeta):
 
         if parameters is not None:
             cmd["params"] = parameters
+        else:
+            cmd["params"] = []
 
         send_ts = self._device_ts + datetime.timedelta(seconds=1)
         header = {'length': 0, 'unknown': 0x00000000,

--- a/miio/vacuum_cli.py
+++ b/miio/vacuum_cli.py
@@ -30,9 +30,10 @@ pass_dev = click.make_pass_decorator(miio.Device, ensure=True)
 @click.option('-d', '--debug', default=False, count=True)
 @click.option('--id-file', type=click.Path(dir_okay=False, writable=True),
               default=user_cache_dir('python-miio') + '/python-mirobo.seq')
+@click.option('--nextgen', is_flag=True)
 @click.version_option()
 @click.pass_context
-def cli(ctx, ip: str, token: str, debug: int, id_file: str):
+def cli(ctx, ip: str, token: str, debug: int, id_file: str, nextgen: bool):
     """A tool to command Xiaomi Vacuum robot."""
     if debug:
         logging.basicConfig(level=logging.DEBUG)
@@ -59,7 +60,7 @@ def cli(ctx, ip: str, token: str, debug: int, id_file: str):
     except (FileNotFoundError, TypeError, ValueError):
         pass
 
-    vac = miio.Vacuum(ip, token, start_id, debug)
+    vac = miio.Vacuum(ip, token, start_id, debug, nextgen)
 
     vac.manual_seqnum = manual_seq
     _LOGGER.debug("Connecting to %s with token %s", ip, token)

--- a/miio/vacuumcontainers.py
+++ b/miio/vacuumcontainers.py
@@ -41,6 +41,17 @@ class VacuumStatus:
         #  'msg_ver': 4, 'map_present': 1, 'error_code': 0, 'in_cleaning': 0,
         #  'clean_area': 0, 'battery': 100, 'fan_power': 20, 'msg_seq': 320}],
         #  'id': 1}
+
+        # v8 new items
+        # TODO: create getters
+        # clean_mode, begin_time, clean_trigger,
+        # back_trigger, clean_strategy, and completed
+        #
+        #{"msg_ver":8,"msg_seq":60,"state":5,"battery":93,"clean_mode":0,
+        # "fan_power":50,"error_code":0,"map_present":1,"in_cleaning":1,
+        # "dnd_enabled":0,"begin_time":1534333389,"clean_time":21,
+        # "clean_area":202500,"clean_trigger":2,"back_trigger":0,
+        # "completed":0,"clean_strategy":1}
         self.data = data
 
     @property


### PR DESCRIPTION
This adds initial support for vacuums using a different call convention (prefixing some calls with `user.`). Passing `--nextgen` (name will probably change or get dropped) option sets this mode active.

This should fix #348, #364 and #370, but testing is needed.

TODO:
* Status reports (v8 compared to v4 from gen1) contain new values which are not currently exposed: clean_mode, begin_time, clean_trigger, back_trigger, clean_strategy, and completed
  * Help from someone with a device would be appreciated here.
* Find the best way to autodetect which convention to use without passing a flag.