### PR TITLE
vacuum's got_error: compare against error code, not against the state

### DIFF
--- a/miio/vacuumcontainers.py
+++ b/miio/vacuumcontainers.py
@@ -139,7 +139,7 @@ class VacuumStatus:
     @property
     def got_error(self) -> bool:
         """True if an error has occured."""
-        return self.state_code == 12
+        return self.error_code != 0
 
     def __repr__(self) -> str:
         s = "<VacuumStatus state=%s, error=%s " % (self.state, self.error)


### PR DESCRIPTION
The vacuum changes the state to error state only for a short period of time before returning to a "Disconnected" state if nothing else happens.

This will change the behaviour of `got_error` to check the error code against 0.