### PR TITLE
Prepare 0.4.2 - Dropping the Pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Change Log
 
+## [0.4.2](https://github.com/rytilahti/python-miio/tree/0.4.2)
+
+This release removes the version pinning for "construct" library as its API has been stabilized and we don't want to force our downstreams for our version choices.
+
+Another notable change is dropping the "mirobo" package which has been deprecated for a very long time, and everyone using it should have had converted to use "miio" already.
+
+This release also changes the behavior of vacuum's `got_error` property to signal properly if an error has occured. The previous behavior was based on checking the state instead of the error number, which changed after an error to 'idle' after a short while.
+
+[Full Changelog](https://github.com/rytilahti/python-miio/compare/0.4.1...0.4.2)
+
+**Fixed bugs:**
+
+- Zoned cleanup start and stops imediately [\#355](https://github.com/rytilahti/python-miio/issues/355)
+
+**Closed issues:**
+
+- STATE not supported: Updating, state\_code: 14 [\#381](https://github.com/rytilahti/python-miio/issues/381)
+- cant get it to work with xiaomi robot vacuum cleaner s50 [\#378](https://github.com/rytilahti/python-miio/issues/378)
+- airfresh problem [\#377](https://github.com/rytilahti/python-miio/issues/377)
+- get device token is 000000000000000000 [\#366](https://github.com/rytilahti/python-miio/issues/366)
+- Rockrobo firmware 3.3.9\_003254 [\#358](https://github.com/rytilahti/python-miio/issues/358)
+- No response from the device on Xiaomi Roborock v2 [\#349](https://github.com/rytilahti/python-miio/issues/349)
+- Information : Xiaomi Aqara Smart Camera Hack [\#347](https://github.com/rytilahti/python-miio/issues/347)
+
+**Merged pull requests:**
+
+- Expand documentation for token from Android backup [\#382](https://github.com/rytilahti/python-miio/pull/382) ([sgtio](https://github.com/sgtio))
+- vacuum's got\_error: compare against error code, not against the state [\#379](https://github.com/rytilahti/python-miio/pull/379) ([rytilahti](https://github.com/rytilahti))
+- Add tqdm to requirements list [\#369](https://github.com/rytilahti/python-miio/pull/369) ([pluehne](https://github.com/pluehne))
+- Improve repr format [\#368](https://github.com/rytilahti/python-miio/pull/368) ([syssi](https://github.com/syssi))
+
+
 ## [0.4.1](https://github.com/rytilahti/python-miio/tree/0.4.1)
 
 This release provides support for some new devices, improved support of existing devices and various fixes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## [0.4.2](https://github.com/rytilahti/python-miio/tree/0.4.2)
 
 This release removes the version pinning for "construct" library as its API has been stabilized and we don't want to force our downstreams for our version choices.
-
 Another notable change is dropping the "mirobo" package which has been deprecated for a very long time, and everyone using it should have had converted to use "miio" already.
+Furthermore the client tools work now with click's version 7+.
 
 This release also changes the behavior of vacuum's `got_error` property to signal properly if an error has occured. The previous behavior was based on checking the state instead of the error number, which changed after an error to 'idle' after a short while.
 
@@ -26,6 +26,7 @@ This release also changes the behavior of vacuum's `got_error` property to signa
 
 **Merged pull requests:**
 
+- Fix click7 compatibility [\#387](https://github.com/rytilahti/python-miio/pull/387) ([rytilahti](https://github.com/rytilahti))
 - Expand documentation for token from Android backup [\#382](https://github.com/rytilahti/python-miio/pull/382) ([sgtio](https://github.com/sgtio))
 - vacuum's got\_error: compare against error code, not against the state [\#379](https://github.com/rytilahti/python-miio/pull/379) ([rytilahti](https://github.com/rytilahti))
 - Add tqdm to requirements list [\#369](https://github.com/rytilahti/python-miio/pull/369) ([pluehne](https://github.com/pluehne))

--- a/miio/protocol.py
+++ b/miio/protocol.py
@@ -27,9 +27,6 @@ from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 _LOGGER = logging.getLogger(__name__)
 
-# needs to be maintained in sync with setup.py and requirements.txt
-assert construct.version_string == "2.9.41"
-
 
 class Utils:
     """ This class is adapted from the original xpn.py code by gst666 """

--- a/miio/version.py
+++ b/miio/version.py
@@ -1,2 +1,2 @@
 # flake8: noqa
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/mirobo/__init__.py
+++ b/mirobo/__init__.py
@@ -1,7 +1,0 @@
-# flake8: noqa
-from miio import *
-import warnings
-warnings.simplefilter('always', DeprecationWarning)
-warnings.warn("Please convert to using 'miio' package, this package will "
-              "be removed at some point in the future", DeprecationWarning,
-              stacklevel=2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 click
 cryptography
 pretty_cron
-construct==2.9.41
+construct
 zeroconf
 attrs
 typing  # for py3.4 support

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     license='GPLv3',
 
     classifiers=[
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Programming Language :: Python :: 3.5',
@@ -38,14 +38,14 @@ setup(
 
     keywords='xiaomi miio vacuum',
 
-    packages=["miio", "mirobo"],
+    packages=["miio"],
 
     include_package_data=True,
 
     python_requires='>=3.5',
 
     install_requires=[
-        'construct==2.9.41',
+        'construct',
         'click',
         'cryptography',
         'pretty_cron',


### PR DESCRIPTION
This release removes the version pinning for "construct" library as its API has been stabilized and we don't want to force our downstreams for our version choices.

Another notable change is dropping the "mirobo" package which has been deprecated for a very long time, and everyone using it should have had converted to use "miio" already.

This release also changes the behavior of vacuum's `got_error` property to signal properly if an error has occured. The previous behavior was based on checking the state instead of the error number, which changed after an error to 'idle' after a short while.

Replaces #376. Closes #374. Relates to https://github.com/home-assistant/home-assistant/pull/16562 .

edit: to add, this also changes the pypi classifier to stable, I suppose we are are stable enough for that!