### PR TITLE
Fix click7 compatibility

### DIFF
--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -419,7 +419,7 @@ class Vacuum(Device):
 
         @dg.resultcallback()
         @dg.device_pass
-        def cleanup(vac: Vacuum, **kwargs):
+        def cleanup(vac: Vacuum, *args, **kwargs):
             if vac.ip is None:  # dummy Device for discovery, skip teardown
                 return
             id_file = kwargs['id_file']

--- a/miio/vacuum_cli.py
+++ b/miio/vacuum_cli.py
@@ -73,7 +73,7 @@ def cli(ctx, ip: str, token: str, debug: int, id_file: str):
 
 @cli.resultcallback()
 @pass_dev
-def cleanup(vac: miio.Vacuum, **kwargs):
+def cleanup(vac: miio.Vacuum, *args, **kwargs):
     if vac.ip is None:  # dummy Device for discovery, skip teardown
         return
     id_file = kwargs['id_file']


### PR DESCRIPTION
click7 changed the passed parameters for a resultcallback,
this commit simply adds unused *args to the method signature to make
it work on both click6.7 and click7.

Fixes #386