### PR TITLE
Add discovery of the Xiaomi Air Quality Monitor (PM2.5) (Closes: #393)

### DIFF
--- a/miio/discovery.py
+++ b/miio/discovery.py
@@ -10,7 +10,7 @@ import zeroconf
 from . import (Device, Vacuum, ChuangmiPlug, PowerStrip, AirPurifier, AirFresh, Ceil,
                PhilipsBulb, PhilipsEyecare, PhilipsMoonlight, ChuangmiIr,
                AirHumidifier, WaterPurifier, WifiSpeaker, WifiRepeater,
-               Yeelight, Fan, Cooker, AirConditioningCompanion)
+               Yeelight, Fan, Cooker, AirConditioningCompanion, AirQualityMonitor)
 
 from .chuangmi_plug import (MODEL_CHUANGMI_PLUG_V1, MODEL_CHUANGMI_PLUG_V3,
                             MODEL_CHUANGMI_PLUG_M1, )
@@ -71,6 +71,7 @@ DEVICE_MAP = {
     "zhimi-fan-sa1": partial(Fan, model=MODEL_FAN_SA1),
     "zhimi-fan-za1": partial(Fan, model=MODEL_FAN_ZA1),
     "zhimi-airfresh-va2": AirFresh,
+    "zhimi-airmonitor-v1": AirQualityMonitor,
     "lumi-gateway-": lambda x: other_package_info(
         x, "https://github.com/Danielhiversen/PyXiaomiGateway")
 }  # type: Dict[str, Union[Callable, Device]]


### PR DESCRIPTION
The device is already supported. Just the discovery is missing.