### PR TITLE
Force parameters to be an empty list if none is given

### DIFF
--- a/miio/airconditioningcompanion.py
+++ b/miio/airconditioningcompanion.py
@@ -267,7 +267,7 @@ class AirConditioningCompanion(Device):
     )
     def status(self) -> AirConditioningCompanionStatus:
         """Return device status."""
-        status = self.send("get_model_and_state", [])
+        status = self.send("get_model_and_state")
         return AirConditioningCompanionStatus(status)
 
     @command(
@@ -298,7 +298,7 @@ class AirConditioningCompanion(Device):
     )
     def learn_result(self):
         """Read the learned command."""
-        return self.send("get_ir_learn_result", [])
+        return self.send("get_ir_learn_result")
 
     @command(
         click.argument("slot", type=int),

--- a/miio/chuangmi_plug.py
+++ b/miio/chuangmi_plug.py
@@ -131,7 +131,7 @@ class ChuangmiPlug(Device):
                 properties_count, values_count)
 
         if self.model == MODEL_CHUANGMI_PLUG_V3:
-            load_power = self.send("get_power", [])  # Response: [300]
+            load_power = self.send("get_power")  # Response: [300]
             if len(load_power) == 1:
                 properties.append('load_power')
                 values.append(load_power[0] * 0.01)
@@ -145,7 +145,7 @@ class ChuangmiPlug(Device):
     def on(self):
         """Power on."""
         if self.model == MODEL_CHUANGMI_PLUG_V1:
-            return self.send("set_on", [])
+            return self.send("set_on")
 
         return self.send("set_power", ["on"])
 
@@ -155,7 +155,7 @@ class ChuangmiPlug(Device):
     def off(self):
         """Power off."""
         if self.model == MODEL_CHUANGMI_PLUG_V1:
-            return self.send("set_off", [])
+            return self.send("set_off")
 
         return self.send("set_power", ["off"])
 
@@ -164,14 +164,14 @@ class ChuangmiPlug(Device):
     )
     def usb_on(self):
         """Power on."""
-        return self.send("set_usb_on", [])
+        return self.send("set_usb_on")
 
     @command(
         default_output = format_output("Powering USB off"),
     )
     def usb_off(self):
         """Power off."""
-        return self.send("set_usb_off", [])
+        return self.send("set_usb_off")
 
     @command(
         click.argument("wifi_led", type=bool),

--- a/miio/cooker.py
+++ b/miio/cooker.py
@@ -817,7 +817,7 @@ class Cooker(Device):
         The temperature is only available while cooking.
         Approx. six data points per minute.
         """
-        data = self.send('get_temp_history', [])
+        data = self.send('get_temp_history')
 
         return TemperatureHistory(data[0])
 

--- a/miio/device.py
+++ b/miio/device.py
@@ -230,6 +230,8 @@ class Device(metaclass=DeviceGroupMeta):
 
         if parameters is not None:
             cmd["params"] = parameters
+        else:
+            cmd["params"] = []
 
         send_ts = self._device_ts + datetime.timedelta(seconds=1)
         header = {'length': 0, 'unknown': 0x00000000,

--- a/miio/device.py
+++ b/miio/device.py
@@ -316,7 +316,7 @@ class Device(metaclass=DeviceGroupMeta):
         """Get miIO protocol information from the device.
         This includes information about connected wlan network,
         and harware and software versions."""
-        return DeviceInfo(self.send("miIO.info", []))
+        return DeviceInfo(self.send("miIO.info"))
 
     def update(self, url: str, md5: str):
         """Start an OTA update."""
@@ -331,11 +331,11 @@ class Device(metaclass=DeviceGroupMeta):
 
     def update_progress(self) -> int:
         """Return current update progress [0-100]."""
-        return self.send("miIO.get_ota_progress", [])[0]
+        return self.send("miIO.get_ota_progress")[0]
 
     def update_state(self):
         """Return current update state."""
-        return UpdateState(self.send("miIO.get_ota_state", [])[0])
+        return UpdateState(self.send("miIO.get_ota_state")[0])
 
     def configure_wifi(self, ssid, password, uid=0, extra_params=None):
         """Configure the wifi settings."""

--- a/miio/wifirepeater.py
+++ b/miio/wifirepeater.py
@@ -94,7 +94,7 @@ class WifiRepeater(Device):
     )
     def status(self) -> WifiRepeaterStatus:
         """Return the associated stations."""
-        return WifiRepeaterStatus(self.send("miIO.get_repeater_sta_info", []))
+        return WifiRepeaterStatus(self.send("miIO.get_repeater_sta_info"))
 
     @command(
         default_output=format_output(
@@ -107,7 +107,7 @@ class WifiRepeater(Device):
     def configuration(self) -> WifiRepeaterConfiguration:
         """Return the configuration of the accesspoint."""
         return WifiRepeaterConfiguration(
-            self.send("miIO.get_repeater_ap_info", []))
+            self.send("miIO.get_repeater_ap_info"))
 
     @command(
         click.argument("wifi_roaming", type=bool),


### PR DESCRIPTION
This seems to work fine with yeelight and gen1 vacuum,
however, more testing is needed with other devices and/or this change
should only be done for the vacuum.

Fixes #348, #364 and #370.