### PR TITLE
Fix serial number reporting for some devices, add locale command

### DIFF
--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -360,7 +360,15 @@ class Vacuum(Device):
     @command()
     def serial_number(self):
         """Get serial number."""
-        return self.send("get_serial_number")[0]["serial_number"]
+        serial = self.send("get_serial_number")
+        if isinstance(serial, list):
+            return serial[0]["serial_number"]
+        return serial
+
+    @command()
+    def locale(self):
+        """Return locale information."""
+        return self.send("app_get_locale")
 
     @command()
     def timezone(self):


### PR DESCRIPTION
Fix incorrect serial number handling for some devices as reported in #408:
```
  File "c:\program files\python\python37\lib\site-packages\python_miio-0.4.10-py3.7.egg\miio\vacuum.py", line 363, in serial_number
    return self.send("get_serial_number")[0]["serial_number"]
TypeError: string indices must be integers
```

Also adds `locale` command from #372.