### PR TITLE
fix last_clean_details to return the latest, not the oldest

### DIFF
--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -191,7 +191,7 @@ class Vacuum(Device):
     @command()
     def last_clean_details(self) -> CleaningDetails:
         """Return details from the last cleaning."""
-        last_clean_id = self.clean_history().ids.pop()
+        last_clean_id = self.clean_history().ids.pop(0)
         return self.clean_details(last_clean_id, return_list=False)
 
     @command(


### PR DESCRIPTION
Add a mistakenly forgotten parameter for pop, w/o a parameter pop returns the last element in the list (that is, the oldest recorded cleaning).