### PR TITLE
Revise device (broadcast-using) discovery process

### DIFF
--- a/miio/ceil_cli.py
+++ b/miio/ceil_cli.py
@@ -67,7 +67,7 @@ def cli(ctx, ip: str, token: str, debug: int):
 @cli.command()
 def discover():
     """Search for plugs in the network."""
-    miio.Ceil.discover()
+    miio.Ceil.send_handshake()
 
 
 @cli.command()

--- a/miio/philips_eyecare_cli.py
+++ b/miio/philips_eyecare_cli.py
@@ -67,7 +67,7 @@ def cli(ctx, ip: str, token: str, debug: int):
 @cli.command()
 def discover():
     """Search for plugs in the network."""
-    miio.PhilipsEyecare.discover()
+    miio.PhilipsEyecare.send_handshake()
 
 
 @cli.command()

--- a/miio/plug_cli.py
+++ b/miio/plug_cli.py
@@ -47,7 +47,7 @@ def cli(ctx, ip: str, token: str, debug: int):
 @cli.command()
 def discover():
     """Search for plugs in the network."""
-    miio.ChuangmiPlug.discover()
+    miio.ChuangmiPlug.send_handshake()
 
 
 @cli.command()


### PR DESCRIPTION
This is the initial commit to rework the handshake/discovery process,
separating them to separate entities.

The discovery part from Device class is moved into MiIODiscovery class usable for broadcast discovery of available devices.
Also, instead of printing out the details from discovered devices, a list of Devices is being returned.
The discover() method of the class is extended to allow discovery on all network interfaces (instead of using 255.255.255.255),
making it easier to perform the initial configuration of non-provisioned devices and/or work with devices in other subnets.

Although the change cause some duplicate code (mainly the handshake payload),
this will make the responsibilities of corresponding classes clearer and code more usable for 3rd party developers.

There will be cleanups and (likely also) renamings of some of the parts, but I wanted to make
this available for others to comment.

TODO:
* Upcasting the Device to a corresponding implementation class (miIO.info model information could be useful, too..)
* Decide how to handle the returning of discovered devices. Use a separate DiscoveredDevice class which can be used
  to initialize the real device, or use the existing Device and do the casting trick?

Related to #152 (and maybe #422).