### PR TITLE
Add control for persistent maps, no-go zones and barriers

### DIFF
--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -183,6 +183,77 @@ class Vacuum(Device):
         # returns ['retry'] without internet
         return self.send("get_map_v1")
 
+    @command(
+        click.argument("start", type=bool)
+    )
+    def edit_map(self, start):
+        """Start map editing?"""
+        if start:
+            return self.send("start_edit_map")[0] == "ok"
+        else:
+            return self.send("end_edit_map")[0] == "ok"
+
+    @command(
+        click.option("--version", default=1)
+    )
+    def fresh_map(self, version):
+        """Return fresh map?"""
+        if version == 1:
+            return self.send("get_fresh_map")
+        elif version == 2:
+            return self.send("get_fresh_map_v2")
+        else:
+            raise VacuumException("Unknown map version: %s" % version)
+
+    @command(
+        click.option("--version", default=1)
+    )
+    def persist_map(self, version):
+        """Return fresh map?"""
+        if version == 1:
+            return self.send("get_persist_map")
+        elif version == 2:
+            return self.send("get_persist_map_v2")
+        else:
+            raise VacuumException("Unknown map version: %s" % version)
+
+    @command(
+        click.argument("id", type=int),
+        click.argument("x1", type=int),
+        click.argument("y1", type=int),
+        click.argument("x2", type=int),
+        click.argument("y2", type=int),
+    )
+    def create_software_barrier(self, id, x1, y1, x2, y2):
+        """Create software barrier (gen2 only?).
+
+        Requires new fw version.
+        3.3.9_001633+?
+        """
+        return self.send("save_map", [id, x1, y1, x2, y2])[0] == "ok"
+
+    @command(
+        click.argument("id", type=int),
+        click.argument("x1")
+    )
+    def create_nogo_zone(self, id, x1, y1, x2, y2, x3, y3, x4, y4):
+        """Create a rectangular no-go zone (gen2 only?).
+
+        Requires new fw version.
+        3.3.9_001633+?
+        """
+        return self.send("save_map",
+                         [id, x1, y1, x2, y2, x3, y3, x4, y4])[0] == "ok"
+
+    @command(
+        click.argument("enable", type=bool)
+    )
+    def set_lab_mode(self, enable):
+        """Set the lab mode?
+
+        No clue what does this oo and which fw is required."""
+        return self.send("set_lab_status", int(enable))['ok']
+
     @command()
     def clean_history(self) -> CleaningSummary:
         """Return generic cleaning history."""

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -218,40 +218,55 @@ class Vacuum(Device):
             raise VacuumException("Unknown map version: %s" % version)
 
     @command(
-        click.argument("id", type=int),
         click.argument("x1", type=int),
         click.argument("y1", type=int),
         click.argument("x2", type=int),
         click.argument("y2", type=int),
     )
-    def create_software_barrier(self, id, x1, y1, x2, y2):
+    def create_software_barrier(self, x1, y1, x2, y2):
         """Create software barrier (gen2 only?).
 
+        NOTE: Multiple nogo zones and barriers could be added by passing
+        a list of them to save_map.
+
         Requires new fw version.
         3.3.9_001633+?
         """
-        return self.send("save_map", [id, x1, y1, x2, y2])[0] == "ok"
+        # First parameter indicates the type, 1 = barrier
+        payload = [1, x1, y1, x2, y2]
+        return self.send("save_map", payload)[0] == "ok"
 
     @command(
-        click.argument("id", type=int),
-        click.argument("x1")
+        click.argument("x1", type=int),
+        click.argument("y1", type=int),
+        click.argument("x2", type=int),
+        click.argument("y2", type=int),
+        click.argument("x3", type=int),
+        click.argument("y3", type=int),
+        click.argument("x4", type=int),
+        click.argument("y4", type=int),
     )
-    def create_nogo_zone(self, id, x1, y1, x2, y2, x3, y3, x4, y4):
+    def create_nogo_zone(self, x1, y1, x2, y2, x3, y3, x4, y4):
         """Create a rectangular no-go zone (gen2 only?).
+
+        NOTE: Multiple nogo zones and barriers could be added by passing
+        a list of them to save_map.
 
         Requires new fw version.
         3.3.9_001633+?
         """
-        return self.send("save_map",
-                         [id, x1, y1, x2, y2, x3, y3, x4, y4])[0] == "ok"
+        # First parameter indicates the type, 0 = zone
+        payload = [0, x1, y1, x2, y2, x3, y3, x4, y4]
+        return self.send("save_map", payload)[0] == "ok"
 
     @command(
         click.argument("enable", type=bool)
     )
-    def set_lab_mode(self, enable):
-        """Set the lab mode?
+    def enable_lab_mode(self, enable):
+        """Enable persistent maps and software barriers.
 
-        No clue what does this oo and which fw is required."""
+        This is required to use create_nogo_zone and create_software_barrier
+        commands."""
         return self.send("set_lab_status", int(enable))['ok']
 
     @command()


### PR DESCRIPTION
Completely untested for now, works only on gen2 and requires a fairly
recent firmware version supporting no-go zones and barriers.

Based on information from https://github.com/marcelrv/XiaomiRobotVacuumProtocol/issues/15