### PR TITLE
Add support v7 version for Xiaomi AirPurifier PRO

### DIFF
--- a/miio/discovery.py
+++ b/miio/discovery.py
@@ -44,7 +44,7 @@ DEVICE_MAP = {
     "zhimi-airpurifier-v3": AirPurifier,   # v3
     "zhimi-airpurifier-v5": AirPurifier,   # v5
     "zhimi-airpurifier-v6": AirPurifier,   # v6
-    "zhimi-airpurifier-v7": AirPurifier,   # v6
+    "zhimi-airpurifier-v7": AirPurifier,   # v7
     "zhimi-airpurifier-mc1": AirPurifier,  # mc1
     "chuangmi-ir-v2": ChuangmiIr,
     "zhimi-humidifier-v1": partial(AirHumidifier, model=MODEL_HUMIDIFIER_V1),

--- a/miio/discovery.py
+++ b/miio/discovery.py
@@ -44,6 +44,7 @@ DEVICE_MAP = {
     "zhimi-airpurifier-v3": AirPurifier,   # v3
     "zhimi-airpurifier-v5": AirPurifier,   # v5
     "zhimi-airpurifier-v6": AirPurifier,   # v6
+    "zhimi-airpurifier-v7": AirPurifier,   # v6
     "zhimi-airpurifier-mc1": AirPurifier,  # mc1
     "chuangmi-ir-v2": ChuangmiIr,
     "zhimi-humidifier-v1": partial(AirHumidifier, model=MODEL_HUMIDIFIER_V1),


### PR DESCRIPTION
Add support for new `V7` version of Xiaomi AirPurifier PRO with hardware version `MW300`

```
> miiocli airpurifier --ip XXX --token XXX info

Model: zhimi.airpurifier.v7
Hardware version: MW300
Firmware version: 1.2.9_19024
Network: {'localIp': '192.168.0.XX', 'mask': '255.255.255.0', 'gw': '192.168.0.XX'}
AP: {'rssi': -63, 'ssid': 'nomnom', 'bssid': 'XXX'}
```

```
> miiocli airpurifier --ip XXX --token XXX status

Power: on
AQI: 4 μg/m³
Average AQI: 5 μg/m³
Temperature: 19.8 °C
Humidity: 56 %
Mode: favorite
LED: True
LED brightness: None
Illuminance: 18 lx
Buzzer: None
Child lock: False
Favorite level: 8
Filter life remaining: 95 %
Filter hours used: 156
Use time: None s
Purify volume: None m³
Motor speed: 328 rpm
Motor 2 speed: 1401 rpm
Sound volume: 9 %
Filter RFID product id: 0:0:30:32
Filter RFID tag: 87:5c:ac:82:b:ga:4
Filter type: FilterType.Regular
Learn mode: False
Sleep mode: None
Sleep time: None
Sleep mode learn count: None
AQI sensor enabled on power off: None
```