### PR TITLE
Fix miio-extract-tokens for devices without tokens

### DIFF
--- a/miio/extract_tokens.py
+++ b/miio/extract_tokens.py
@@ -72,8 +72,8 @@ class BackupDatabaseReader:
     @staticmethod
     def decrypt_ztoken(ztoken):
         """Decrypt the given ztoken, used by apple."""
-        if len(ztoken) <= 32:
-            return ztoken
+        if ztoken is None or len(ztoken) <= 32:
+            return str(ztoken)
 
         keystring = '00000000000000000000000000000000'
         key = bytes.fromhex(keystring)


### PR DESCRIPTION
The `miio.extra_tokens.BackupDatabaseReader.decrypt_ztoken` method will
raise a `TypeError` when a device in the SQLite database file has no
token defined. This occurs for local (bluetooth) devices, such as the
Mi Action Cam.

This change will fix the `miio-extra-tokens` utility, so that it will
work again, even if there are devices without tokens.

See also issue #467 for more informations.