### PR TITLE
Check for empty clean_history instead of crashing on it

### DIFF
--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -189,9 +189,15 @@ class Vacuum(Device):
         return CleaningSummary(self.send("get_clean_summary"))
 
     @command()
-    def last_clean_details(self) -> CleaningDetails:
-        """Return details from the last cleaning."""
-        last_clean_id = self.clean_history().ids.pop(0)
+    def last_clean_details(self) -> Optional[CleaningDetails]:
+        """Return details from the last cleaning.
+
+        Returns None if there has been no cleanups."""
+        history = self.clean_history()
+        if not history.ids:
+            return None
+
+        last_clean_id = history.ids.pop(0)
         return self.clean_details(last_clean_id, return_list=False)
 
     @command(


### PR DESCRIPTION
Fixes https://github.com/rytilahti/python-miio/issues/457, related to https://github.com/home-assistant/home-assistant/pull/20620