### PR TITLE
Vacuum: add resume_zoned_clean() and resume_or_start() helper

### DIFF
--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -72,6 +72,15 @@ class Vacuum(Device):
         return self.send("app_pause")
 
     @command()
+    def resume_or_start(self):
+        """A shortcut for resuming or starting cleaning."""
+        status = self.status()
+        if status.in_zone_cleaning and status.is_paused:
+            return self.resume_zoned_clean()
+
+        return self.start()
+
+    @command()
     def home(self):
         """Stop cleaning and return home."""
         self.send("app_pause")
@@ -94,6 +103,11 @@ class Vacuum(Device):
         """Clean zones.
         :param List zones: List of zones to clean: [[x1,y1,x2,y2, iterations],[x1,y1,x2,y2, iterations]]"""
         return self.send("app_zoned_clean", zones)
+
+    @command()
+    def resume_zoned_clean(self):
+        """Resume zone cleaning after being paused."""
+        return self.send("resume_zoned_clean")
 
     @command()
     def manual_start(self):

--- a/miio/vacuumcontainers.py
+++ b/miio/vacuumcontainers.py
@@ -139,6 +139,16 @@ class VacuumStatus:
         # return bool(self.data["in_cleaning"])
 
     @property
+    def in_zone_cleaning(self) -> bool:
+        """Return True if the vacuum is in zone cleaning mode."""
+        return self.data["in_cleaning"] == 2
+
+    @property
+    def is_paused(self) -> bool:
+        """Return True if vacuum is paused."""
+        return self.state_code == 10
+
+    @property
     def is_on(self) -> bool:
         """True if device is currently cleaning (either automatic, manual,
          spot, or zone)."""


### PR DESCRIPTION
First take on fixing #471. resume_or_start() can be used to either unpause
or start a new cleanup depending on the state of the vacuum.