### PR TITLE
Require click version >=7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
 
     install_requires=[
         'construct',
-        'click',
+        'click>=7',
         'cryptography',
         'zeroconf',
         'attrs',


### PR DESCRIPTION
The command line interface is different for versions <7 (underscores instead of dash, see https://github.com/pallets/click/issues/1123). The documentation only documents the commands with dash. So click>=7 is required.