### PR TITLE
My shot at 'Vacuum: Provide human readable fan speeds (rytilahti#468)'

### DIFF
--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -27,8 +27,7 @@ MODELS_VACUUM_V1 = ['rockrobo.vacuum.v1']
 MODELS_VACUUM_V2 = ['roborock.vacuum.s5']
 
 
-FanSpeed = enum.Enum('FanSpeed',
-    [
+FanSpeed = enum.Enum('FanSpeed', [
         ('Quiet', 'quiet'),
         ('Balanced', 'balanced'),
         ('Turbo', 'turbo'),
@@ -56,6 +55,7 @@ class _FanSpeedV1(enum.Enum):
     Turbo = 77
     Max = 90
 
+
 @enum.unique
 class _FanSpeedV2(enum.Enum):
     Quiet = 101     # -> 38
@@ -63,6 +63,7 @@ class _FanSpeedV2(enum.Enum):
     Turbo = 103     # -> 75
     Max = 104       # -> 100
     Mop = 105
+
 
 class Consumable(enum.Enum):
     MainBrush = "main_brush_work_time"
@@ -472,7 +473,7 @@ class Vacuum(Device):
     @command(
         click.argument("speed", type=str),
     )
-    def set_fan_speed(self, speed: [int,FanSpeed]):
+    def set_fan_speed(self, speed: [int, FanSpeed]):
         """Set fan speed.
 
         :param int speed: Fan speed to set"""

--- a/miio/vacuum_cli.py
+++ b/miio/vacuum_cli.py
@@ -330,6 +330,7 @@ def fanspeed(vac: miio.Vacuum, speed):
     else:
         click.echo("Current fan speed: %s" % vac.fan_speed())
 
+
 @cli.command()
 @pass_dev
 def fanspeed_list(vac: miio.Vacuum):

--- a/miio/vacuum_cli.py
+++ b/miio/vacuum_cli.py
@@ -314,15 +314,28 @@ def dnd(vac: miio.Vacuum, cmd: str,
 
 
 @cli.command()
-@click.argument('speed', type=int, required=False)
+@click.argument('speed', type=str, required=False)
 @pass_dev
 def fanspeed(vac: miio.Vacuum, speed):
     """Query and adjust the fan speed."""
+    from miio.vacuum import FanSpeed
     if speed:
         click.echo("Setting fan speed to %s" % speed)
+        try:
+            speed = int(speed)
+        except ValueError:
+            speed = FanSpeed(speed.lower())
+
         vac.set_fan_speed(speed)
     else:
         click.echo("Current fan speed: %s" % vac.fan_speed())
+
+@cli.command()
+@pass_dev
+def fanspeed_list(vac: miio.Vacuum):
+    """Query the list of available fan speed steps of the vacuum cleaner."""
+
+    click.echo("%s" % [e.value for e in vac.fan_speed_list()])
 
 
 @cli.group(invoke_without_command=True)


### PR DESCRIPTION
Since rytilahti#468 seems to be stalled for some time I took the freedom to give it a try.

It supports both enums and integer levels. 
The issue with V2 levels is that those 100 > levels < 105 get converted to percentage level **on device** so when queried later they return a different value.

```
# mirobo fanspeed
Current fan speed: FanSpeed.Max

# mirobo fanspeed 10
Setting fan speed to 10

# mirobo fanspeed
Current fan speed: FanSpeed.Level_10

# mirobo fanspeed 60
Setting fan speed to 60

# mirobo fanspeed
Current fan speed: FanSpeed.Balanced

# mirobo fanspeed mop
Setting fan speed to mop

# mirobo fanspeed
Current fan speed: FanSpeed.Mop

# mirobo fanspeed 105
Setting fan speed to 105

# mirobo fanspeed
Current fan speed: FanSpeed.Mop
```