### PR TITLE
Add support for Air Quality Monitor S1 (cgllc.airmonitor.s1)

### DIFF
--- a/miio/airqualitymonitor.py
+++ b/miio/airqualitymonitor.py
@@ -105,22 +105,22 @@ class AirQualityMonitorStatus:
 
     @property
     def co2(self) -> int:
-        """Return co2 value for MODEL_AIRQUALITYMONITOR_S1."""
+        """Return co2 value (400...9999)ppm for MODEL_AIRQUALITYMONITOR_S1."""
         return self.data["co2"]
 
     @property
     def humidity(self) -> float:
-        """Return humidity value for MODEL_AIRQUALITYMONITOR_S1."""
+        """Return humidity value (0...100)% for MODEL_AIRQUALITYMONITOR_S1."""
         return self.data["humidity"]
 
     @property
     def pm25(self) -> float:
-        """Return pm2.5 value for MODEL_AIRQUALITYMONITOR_S1."""
+        """Return pm2.5 value (0...999)μg/m³ for MODEL_AIRQUALITYMONITOR_S1."""
         return self.data["pm25"]
 
     @property
     def temperature(self) -> float:
-        """Return temperature value for MODEL_AIRQUALITYMONITOR_S1."""
+        """Return temperature value (-10...50)°C for MODEL_AIRQUALITYMONITOR_S1."""
         return self.data["temperature"]
 
     @property

--- a/miio/discovery.py
+++ b/miio/discovery.py
@@ -13,7 +13,8 @@ from . import (Device, Vacuum, ChuangmiCamera, ChuangmiPlug, PowerStrip, AirPuri
                Yeelight, Fan, Cooker, AirConditioningCompanion, AirQualityMonitor, AqaraCamera)
 
 from .airconditioningcompanion import (MODEL_ACPARTNER_V1, MODEL_ACPARTNER_V2, MODEL_ACPARTNER_V3, )
-from .airqualitymonitor import (MODEL_AIRQUALITYMONITOR_V1, MODEL_AIRQUALITYMONITOR_B1, )
+from .airqualitymonitor import (MODEL_AIRQUALITYMONITOR_V1, MODEL_AIRQUALITYMONITOR_B1,
+                                MODEL_AIRQUALITYMONITOR_S1, )
 from .airhumidifier import (MODEL_HUMIDIFIER_CB1, MODEL_HUMIDIFIER_CA1, MODEL_HUMIDIFIER_V1, )
 from .chuangmi_plug import (MODEL_CHUANGMI_PLUG_V1, MODEL_CHUANGMI_PLUG_V2, MODEL_CHUANGMI_PLUG_V3,
                             MODEL_CHUANGMI_PLUG_M1, MODEL_CHUANGMI_PLUG_M3,
@@ -91,6 +92,7 @@ DEVICE_MAP = {
     "zhimi-airfresh-va2": AirFresh,
     "zhimi-airmonitor-v1": partial(AirQualityMonitor, model=MODEL_AIRQUALITYMONITOR_V1),
     "cgllc-airmonitor-b1": partial(AirQualityMonitor, model=MODEL_AIRQUALITYMONITOR_B1),
+    "cgllc-airmonitor-s1": partial(AirQualityMonitor, model=MODEL_AIRQUALITYMONITOR_S1),
     "lumi-gateway-": lambda x: other_package_info(
         x, "https://github.com/Danielhiversen/PyXiaomiGateway")
 }  # type: Dict[str, Union[Callable, Device]]


### PR DESCRIPTION
already test pass.
device details: https://www.gearbest.com/weather-station/pp_009986206287.html

```
Got new state:  <AirQualityMonitorStatus power=None, aqi=None, battery=100, usb_power=False, temperature=25.8, humidity=59, co2=540, pm25=11.8, tvoc=243, display_clock=False>
```

if merge on python_miio 0.4.6, I will update xiaomi_miio sensor on home assistant to support AirQualityMonitor:cgllc.airmonitor.s1

![image](https://user-images.githubusercontent.com/40521367/62821362-20c11200-bba6-11e9-9780-b47db6484713.png)
