### PR TITLE
remove pretty_cron and typing dependencies from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,8 @@
 click
 cryptography
-pretty_cron
 construct
 zeroconf
 attrs
-typing  # for py3.4 support
 pytz  # for tz offset in vacuum
 appdirs  # for user_cache_dir of vacuum_cli
 tqdm


### PR DESCRIPTION
The former is not used anymore, and the latter is irrelevant as we depend already on python 3.5+. Closes #423.