### PR TITLE
bump required python version to 3.6+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: python
 python:
-  - "3.5"
   - "3.6"
 install: pip install tox-travis coveralls
 script: tox

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3 :: Only",
@@ -34,7 +33,7 @@ setup(
     keywords="xiaomi miio vacuum",
     packages=["miio"],
     include_package_data=True,
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     install_requires=[
         "construct",
         "click>=7",


### PR DESCRIPTION
homeassistant requires now 3.6.1 or newer, so we can bump our requirement.
this will allow us to convert the code-base to use f-strings.

Closes #494