### PR TITLE
add azure pipeline for tests, and enforce black, flake8 and isort for commits

### DIFF
--- a/.flake8.ini
+++ b/.flake8.ini
@@ -1,6 +1,0 @@
-[flake8]
-exclude = .git,.tox,__pycache__
-max-line-length = 100
-select = C,E,F,W,B,B950
-ignore = E501,W503,E203
-

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,3 +1,0 @@
-python:
-  enabled: true
-  config_file: .flake8.ini

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,19 @@ repos:
   hooks:
   - id: black
     language_version: python3
+
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.3.0
+  hooks:
+  - id: flake8
+
+- repo: https://github.com/pre-commit/mirrors-isort
+  rev: v4.3.21
+  hooks:
+  - id: isort
+
+#- repo: https://github.com/pre-commit/mirrors-mypy
+#  rev: v0.740
+#  hooks:
+#  - id: mypy
+#    args: [--no-strict-optional, --ignore-missing-imports]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include *.md
 include *.txt
-include .flake8.ini
+include *.yaml
+include *.yml
 include LICENSE
 include tox.ini
 recursive-include docs *.py

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,5 +43,5 @@ steps:
   displayName: 'Order of imports (isort)'
 
 - script: |
-    pytest --cov
+    pytest --cov miio --cov-report html
   displayName: 'Tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,8 +23,7 @@ steps:
 - script: |
     python -m pip install --upgrade pip
     pip install -r requirements.txt
-    pip install pytest pytest-azurepipelines
-    pre-commit install-hooks
+    pip install pytest pytest-azurepipelines pytest-cov
   displayName: 'Install dependencies'
 
 - script: |
@@ -44,5 +43,5 @@ steps:
   displayName: 'Order of imports (isort)'
 
 - script: |
-    pytest
+    pytest --cov
   displayName: 'Tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,9 +35,9 @@ steps:
     pre-commit run flake8 --all-files
   displayName: 'Code formating (flake8)'
 
-- script: |
-    pre-commit run mypy --all-files
-  displayName: 'Typing checks (mypy)'
+#- script: |
+#    pre-commit run mypy --all-files
+#  displayName: 'Typing checks (mypy)'
 
 - script: |
     pre-commit run isort --all-files

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,48 @@
+trigger:
+- master
+pr:
+- master
+
+pool:
+  vmImage: 'ubuntu-latest'
+strategy:
+  matrix:
+    Python36:
+      python.version: '3.6'
+    Python37:
+      python.version: '3.7'
+#    Python38:
+#      python.version: '3.8'
+
+steps:
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '$(python.version)'
+  displayName: 'Use Python $(python.version)'
+
+- script: |
+    python -m pip install --upgrade pip
+    pip install -r requirements.txt
+    pip install pytest pytest-azurepipelines
+    pre-commit install-hooks
+  displayName: 'Install dependencies'
+
+- script: |
+    pre-commit run black --all-files
+  displayName: 'Code formating (black)'
+
+- script: |
+    pre-commit run flake8 --all-files
+  displayName: 'Code formating (flake8)'
+
+- script: |
+    pre-commit run mypy --all-files
+  displayName: 'Typing checks (mypy)'
+
+- script: |
+    pre-commit run isort --all-files
+  displayName: 'Order of imports (isort)'
+
+- script: |
+    pytest
+  displayName: 'Tests'

--- a/miio/__init__.py
+++ b/miio/__init__.py
@@ -1,38 +1,39 @@
 # flake8: noqa
-from miio.airconditioningcompanion import AirConditioningCompanion
-from miio.airconditioningcompanion import AirConditioningCompanionV3
+from miio.airconditioningcompanion import (
+    AirConditioningCompanion,
+    AirConditioningCompanionV3,
+)
+from miio.airdehumidifier import AirDehumidifier
 from miio.airfresh import AirFresh
 from miio.airhumidifier import AirHumidifier
-from miio.airdehumidifier import AirDehumidifier
 from miio.airpurifier import AirPurifier
 from miio.airqualitymonitor import AirQualityMonitor
+from miio.aqaracamera import AqaraCamera
 from miio.ceil import Ceil
 from miio.chuangmi_camera import ChuangmiCamera
 from miio.chuangmi_ir import ChuangmiIr
-from miio.chuangmi_plug import Plug, PlugV1, PlugV3, ChuangmiPlug
+from miio.chuangmi_plug import ChuangmiPlug, Plug, PlugV1, PlugV3
 from miio.cooker import Cooker
-from miio.device import Device, DeviceException, DeviceError
-from miio.fan import Fan, FanV2, FanSA1, FanZA1, FanZA4, FanP5
+from miio.device import Device, DeviceError, DeviceException
+from miio.discovery import Discovery
+from miio.fan import Fan, FanP5, FanSA1, FanV2, FanZA1, FanZA4
 from miio.philips_bulb import PhilipsBulb
 from miio.philips_eyecare import PhilipsEyecare
 from miio.philips_moonlight import PhilipsMoonlight
 from miio.powerstrip import PowerStrip
 from miio.protocol import Message, Utils
-from miio.toiletlid import Toiletlid
 from miio.pwzn_relay import PwznRelay
+from miio.toiletlid import Toiletlid
 from miio.vacuum import Vacuum, VacuumException
 from miio.vacuumcontainers import (
-    VacuumStatus,
-    ConsumableStatus,
-    DNDStatus,
     CleaningDetails,
     CleaningSummary,
+    ConsumableStatus,
+    DNDStatus,
     Timer,
+    VacuumStatus,
 )
 from miio.waterpurifier import WaterPurifier
 from miio.wifirepeater import WifiRepeater
 from miio.wifispeaker import WifiSpeaker
 from miio.yeelight import Yeelight
-from miio.aqaracamera import AqaraCamera
-
-from miio.discovery import Discovery

--- a/miio/__init__.py
+++ b/miio/__init__.py
@@ -15,7 +15,6 @@ from miio.chuangmi_ir import ChuangmiIr
 from miio.chuangmi_plug import ChuangmiPlug, Plug, PlugV1, PlugV3
 from miio.cooker import Cooker
 from miio.device import Device, DeviceError, DeviceException
-from miio.discovery import Discovery
 from miio.fan import Fan, FanP5, FanSA1, FanV2, FanZA1, FanZA4
 from miio.philips_bulb import PhilipsBulb
 from miio.philips_eyecare import PhilipsEyecare
@@ -37,3 +36,5 @@ from miio.waterpurifier import WaterPurifier
 from miio.wifirepeater import WifiRepeater
 from miio.wifispeaker import WifiSpeaker
 from miio.yeelight import Yeelight
+
+from miio.discovery import Discovery

--- a/miio/airconditioningcompanion.py
+++ b/miio/airconditioningcompanion.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import click
 
-from .click_common import command, format_output, EnumType
+from .click_common import EnumType, command, format_output
 from .device import Device, DeviceException
 
 _LOGGER = logging.getLogger(__name__)

--- a/miio/airdehumidifier.py
+++ b/miio/airdehumidifier.py
@@ -5,8 +5,8 @@ from typing import Any, Dict, Optional
 
 import click
 
-from .click_common import command, format_output, EnumType
-from .device import Device, DeviceInfo, DeviceError, DeviceException
+from .click_common import EnumType, command, format_output
+from .device import Device, DeviceError, DeviceException, DeviceInfo
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/miio/airfresh.py
+++ b/miio/airfresh.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional
 
 import click
 
-from .click_common import command, format_output, EnumType
+from .click_common import EnumType, command, format_output
 from .device import Device, DeviceException
 
 _LOGGER = logging.getLogger(__name__)

--- a/miio/airhumidifier.py
+++ b/miio/airhumidifier.py
@@ -5,8 +5,8 @@ from typing import Any, Dict, Optional
 
 import click
 
-from .click_common import command, format_output, EnumType
-from .device import Device, DeviceInfo, DeviceError, DeviceException
+from .click_common import EnumType, command, format_output
+from .device import Device, DeviceError, DeviceException, DeviceInfo
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/miio/airpurifier.py
+++ b/miio/airpurifier.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional
 
 import click
 
-from .click_common import command, format_output, EnumType
+from .click_common import EnumType, command, format_output
 from .device import Device, DeviceException
 
 _LOGGER = logging.getLogger(__name__)

--- a/miio/airqualitymonitor.py
+++ b/miio/airqualitymonitor.py
@@ -25,13 +25,7 @@ AVAILABLE_PROPERTIES_COMMON = [
     "sensor_state",
 ]
 
-AVAILABLE_PROPERTIES_B1 = [
-    "co2e",
-    "humidity",
-    "pm25",
-    "temperature",
-    "tvoc"
-]
+AVAILABLE_PROPERTIES_B1 = ["co2e", "humidity", "pm25", "temperature", "tvoc"]
 
 AVAILABLE_PROPERTIES_S1 = ["battery", "co2", "humidity", "pm25", "temperature", "tvoc"]
 
@@ -204,7 +198,9 @@ class AirQualityMonitor(Device):
             self.model = model
         elif model is not None:
             self.model = MODEL_AIRQUALITYMONITOR_V1
-            _LOGGER.error("Device model %s unsupported. Falling back to %s.", model, self.model)
+            _LOGGER.error(
+                "Device model %s unsupported. Falling back to %s.", model, self.model
+            )
         else:
             """Force autodetection"""
             self.model = None
@@ -250,7 +246,10 @@ class AirQualityMonitor(Device):
                 values_count,
             )
 
-        if self.model == MODEL_AIRQUALITYMONITOR_S1 or self.model == MODEL_AIRQUALITYMONITOR_B1:
+        if (
+            self.model == MODEL_AIRQUALITYMONITOR_S1
+            or self.model == MODEL_AIRQUALITYMONITOR_B1
+        ):
             return AirQualityMonitorStatus(defaultdict(lambda: None, values))
         else:
             return AirQualityMonitorStatus(

--- a/miio/alarmclock.py
+++ b/miio/alarmclock.py
@@ -1,9 +1,10 @@
 import enum
 import time
+
 import click
 
+from .click_common import EnumType, command
 from .device import Device
-from .click_common import command, EnumType
 
 
 class HourlySystem(enum.Enum):

--- a/miio/aqaracamera.py
+++ b/miio/aqaracamera.py
@@ -7,11 +7,11 @@ TODO: add alarm/sound parts (get_music_info, {get,set}_alarming_volume,
 TODO: add sdcard status & fix all TODOS
 TODO: add tests
 """
-import attr
 import logging
-from typing import Any, Dict
 from enum import IntEnum
+from typing import Any, Dict
 
+import attr
 import click
 
 from .click_common import command, format_output

--- a/miio/chuangmi_ir.py
+++ b/miio/chuangmi_ir.py
@@ -3,19 +3,19 @@ import re
 
 import click
 from construct import (
-    Struct,
-    Const,
-    Rebuild,
-    this,
-    len_,
     Adapter,
+    Array,
+    BitsInteger,
+    BitStruct,
     Computed,
+    Const,
+    Int16ub,
     Int16ul,
     Int32ul,
-    Int16ub,
-    Array,
-    BitStruct,
-    BitsInteger,
+    Rebuild,
+    Struct,
+    len_,
+    this,
 )
 
 from .click_common import command, format_output

--- a/miio/chuangmi_plug.py
+++ b/miio/chuangmi_plug.py
@@ -1,6 +1,6 @@
 import logging
 from collections import defaultdict
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional
 
 import click
 

--- a/miio/cli.py
+++ b/miio/cli.py
@@ -4,8 +4,8 @@ import logging
 import click
 
 from miio.click_common import (
-    ExceptionHandlerGroup,
     DeviceGroupMeta,
+    ExceptionHandlerGroup,
     GlobalContextObject,
     json_output,
 )

--- a/miio/click_common.py
+++ b/miio/click_common.py
@@ -3,23 +3,25 @@
 This file contains common functions for cli tools.
 """
 import ast
+import ipaddress
+import json
+import logging
+import re
 import sys
+from functools import partial, wraps
+from typing import Union
+
+import click
+
+import miio
+
+from .exceptions import DeviceError
 
 if sys.version_info < (3, 5):
     print(
         "To use this script you need python 3.5 or newer, got %s" % (sys.version_info,)
     )
     sys.exit(1)
-import click
-import ipaddress
-import miio
-import logging
-import json
-import re
-from typing import Union
-from functools import wraps
-from functools import partial
-from .exceptions import DeviceError
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/miio/cooker.py
+++ b/miio/cooker.py
@@ -3,7 +3,7 @@ import logging
 import string
 from collections import defaultdict
 from datetime import time
-from typing import Optional, List
+from typing import List, Optional
 
 import click
 

--- a/miio/device.py
+++ b/miio/device.py
@@ -9,8 +9,8 @@ from typing import Any, List, Optional  # noqa: F401
 import click
 import construct
 
-from .click_common import DeviceGroupMeta, command, format_output, LiteralParamType
-from .exceptions import DeviceException, DeviceError, RecoverableError
+from .click_common import DeviceGroupMeta, LiteralParamType, command, format_output
+from .exceptions import DeviceError, DeviceException, RecoverableError
 from .protocol import Message
 
 _LOGGER = logging.getLogger(__name__)

--- a/miio/discovery.py
+++ b/miio/discovery.py
@@ -3,70 +3,68 @@ import inspect
 import ipaddress
 import logging
 from functools import partial
-from typing import Union, Callable, Dict, Optional  # noqa: F401
+from typing import Callable, Dict, Optional, Union  # noqa: F401
 
 import zeroconf
 
 from . import (
-    Device,
-    Vacuum,
-    ChuangmiCamera,
-    ChuangmiPlug,
-    PowerStrip,
-    AirPurifier,
+    AirConditioningCompanion,
     AirFresh,
+    AirHumidifier,
+    AirPurifier,
+    AirQualityMonitor,
+    AqaraCamera,
     Ceil,
+    ChuangmiCamera,
+    ChuangmiIr,
+    ChuangmiPlug,
+    Cooker,
+    Device,
+    Fan,
     PhilipsBulb,
     PhilipsEyecare,
     PhilipsMoonlight,
-    ChuangmiIr,
-    AirHumidifier,
-    WaterPurifier,
-    WifiSpeaker,
-    WifiRepeater,
-    Yeelight,
-    Fan,
-    Cooker,
-    AirConditioningCompanion,
-    AirQualityMonitor,
-    AqaraCamera,
+    PowerStrip,
     Toiletlid,
+    Vacuum,
+    WaterPurifier,
+    WifiRepeater,
+    WifiSpeaker,
+    Yeelight,
 )
-
 from .airconditioningcompanion import (
     MODEL_ACPARTNER_V1,
     MODEL_ACPARTNER_V2,
     MODEL_ACPARTNER_V3,
 )
+from .airhumidifier import (
+    MODEL_HUMIDIFIER_CA1,
+    MODEL_HUMIDIFIER_CB1,
+    MODEL_HUMIDIFIER_V1,
+)
 from .airqualitymonitor import (
-    MODEL_AIRQUALITYMONITOR_V1,
     MODEL_AIRQUALITYMONITOR_B1,
     MODEL_AIRQUALITYMONITOR_S1,
-)
-from .airhumidifier import (
-    MODEL_HUMIDIFIER_CB1,
-    MODEL_HUMIDIFIER_CA1,
-    MODEL_HUMIDIFIER_V1,
+    MODEL_AIRQUALITYMONITOR_V1,
 )
 from .alarmclock import AlarmClock
 from .chuangmi_plug import (
+    MODEL_CHUANGMI_PLUG_HMI205,
+    MODEL_CHUANGMI_PLUG_HMI206,
+    MODEL_CHUANGMI_PLUG_M1,
+    MODEL_CHUANGMI_PLUG_M3,
     MODEL_CHUANGMI_PLUG_V1,
     MODEL_CHUANGMI_PLUG_V2,
     MODEL_CHUANGMI_PLUG_V3,
-    MODEL_CHUANGMI_PLUG_M1,
-    MODEL_CHUANGMI_PLUG_M3,
-    MODEL_CHUANGMI_PLUG_HMI205,
-    MODEL_CHUANGMI_PLUG_HMI206,
 )
-
 from .fan import (
+    MODEL_FAN_P5,
+    MODEL_FAN_SA1,
     MODEL_FAN_V2,
     MODEL_FAN_V3,
-    MODEL_FAN_SA1,
     MODEL_FAN_ZA1,
     MODEL_FAN_ZA3,
     MODEL_FAN_ZA4,
-    MODEL_FAN_P5,
 )
 from .powerstrip import MODEL_POWER_STRIP_V1, MODEL_POWER_STRIP_V2
 from .toiletlid import MODEL_TOILETLID_V1

--- a/miio/extract_tokens.py
+++ b/miio/extract_tokens.py
@@ -1,10 +1,10 @@
+import json
 import logging
 import sqlite3
 import tempfile
-import json
+import xml.etree.ElementTree as ET
 from pprint import pformat as pf
 from typing import Iterator
-import xml.etree.ElementTree as ET
 
 import attr
 import click

--- a/miio/fan.py
+++ b/miio/fan.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional
 
 import click
 
-from .click_common import command, format_output, EnumType
+from .click_common import EnumType, command, format_output
 from .device import Device, DeviceException
 
 _LOGGER = logging.getLogger(__name__)

--- a/miio/philips_moonlight.py
+++ b/miio/philips_moonlight.py
@@ -6,7 +6,7 @@ import click
 
 from .click_common import command, format_output
 from .device import Device, DeviceException
-from .utils import int_to_rgb, rgb_to_int
+from .utils import int_to_rgb
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/miio/powerstrip.py
+++ b/miio/powerstrip.py
@@ -1,11 +1,11 @@
 import enum
 import logging
 from collections import defaultdict
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional
 
 import click
 
-from .click_common import command, format_output, EnumType
+from .click_common import EnumType, command, format_output
 from .device import Device, DeviceException
 
 _LOGGER = logging.getLogger(__name__)

--- a/miio/protocol.py
+++ b/miio/protocol.py
@@ -17,22 +17,21 @@ import json
 import logging
 from typing import Any, Dict, Tuple
 
-import construct
 from construct import (
-    Struct,
+    Adapter,
     Bytes,
+    Checksum,
     Const,
+    Default,
+    GreedyBytes,
+    Hex,
+    IfThenElse,
     Int16ub,
     Int32ub,
-    GreedyBytes,
-    Adapter,
-    Checksum,
+    Pointer,
     RawCopy,
     Rebuild,
-    IfThenElse,
-    Default,
-    Pointer,
-    Hex,
+    Struct,
 )
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import padding

--- a/miio/pwzn_relay.py
+++ b/miio/pwzn_relay.py
@@ -1,6 +1,6 @@
 import logging
 from collections import defaultdict
-from typing import Dict, Any
+from typing import Any, Dict
 
 import click
 

--- a/miio/tests/test_airconditioningcompanion.py
+++ b/miio/tests/test_airconditioningcompanion.py
@@ -1,21 +1,21 @@
-import string
 import json
 import os
+import string
 from unittest import TestCase
 
 import pytest
 
 from miio import AirConditioningCompanion, AirConditioningCompanionV3
 from miio.airconditioningcompanion import (
-    OperationMode,
+    MODEL_ACPARTNER_V3,
+    STORAGE_SLOT_ID,
+    AirConditioningCompanionException,
+    AirConditioningCompanionStatus,
     FanSpeed,
+    Led,
+    OperationMode,
     Power,
     SwingMode,
-    Led,
-    AirConditioningCompanionStatus,
-    AirConditioningCompanionException,
-    STORAGE_SLOT_ID,
-    MODEL_ACPARTNER_V3,
 )
 
 STATE_ON = ["on"]

--- a/miio/tests/test_airdehumidifier.py
+++ b/miio/tests/test_airdehumidifier.py
@@ -4,14 +4,15 @@ import pytest
 
 from miio import AirDehumidifier
 from miio.airdehumidifier import (
-    OperationMode,
-    FanSpeed,
-    AirDehumidifierStatus,
-    AirDehumidifierException,
     MODEL_DEHUMIDIFIER_V1,
+    AirDehumidifierException,
+    AirDehumidifierStatus,
+    FanSpeed,
+    OperationMode,
 )
-from .dummies import DummyDevice
 from miio.device import DeviceInfo
+
+from .dummies import DummyDevice
 
 
 class DummyAirDehumidifierV1(DummyDevice, AirDehumidifier):

--- a/miio/tests/test_airfresh.py
+++ b/miio/tests/test_airfresh.py
@@ -4,11 +4,12 @@ import pytest
 
 from miio import AirFresh
 from miio.airfresh import (
-    OperationMode,
-    LedBrightness,
-    AirFreshStatus,
     AirFreshException,
+    AirFreshStatus,
+    LedBrightness,
+    OperationMode,
 )
+
 from .dummies import DummyDevice
 
 

--- a/miio/tests/test_airhumidifier.py
+++ b/miio/tests/test_airhumidifier.py
@@ -4,16 +4,17 @@ import pytest
 
 from miio import AirHumidifier
 from miio.airhumidifier import (
-    OperationMode,
-    LedBrightness,
-    AirHumidifierStatus,
-    AirHumidifierException,
-    MODEL_HUMIDIFIER_V1,
     MODEL_HUMIDIFIER_CA1,
     MODEL_HUMIDIFIER_CB1,
+    MODEL_HUMIDIFIER_V1,
+    AirHumidifierException,
+    AirHumidifierStatus,
+    LedBrightness,
+    OperationMode,
 )
-from .dummies import DummyDevice
 from miio.device import DeviceInfo
+
+from .dummies import DummyDevice
 
 
 class DummyAirHumidifierV1(DummyDevice, AirHumidifier):

--- a/miio/tests/test_airpurifier.py
+++ b/miio/tests/test_airpurifier.py
@@ -4,13 +4,14 @@ import pytest
 
 from miio import AirPurifier
 from miio.airpurifier import (
-    OperationMode,
-    LedBrightness,
-    FilterType,
-    SleepMode,
-    AirPurifierStatus,
     AirPurifierException,
+    AirPurifierStatus,
+    FilterType,
+    LedBrightness,
+    OperationMode,
+    SleepMode,
 )
+
 from .dummies import DummyDevice
 
 

--- a/miio/tests/test_airqualitymonitor.py
+++ b/miio/tests/test_airqualitymonitor.py
@@ -4,11 +4,12 @@ import pytest
 
 from miio import AirQualityMonitor
 from miio.airqualitymonitor import (
-    AirQualityMonitorStatus,
-    MODEL_AIRQUALITYMONITOR_V1,
-    MODEL_AIRQUALITYMONITOR_S1,
     MODEL_AIRQUALITYMONITOR_B1,
+    MODEL_AIRQUALITYMONITOR_S1,
+    MODEL_AIRQUALITYMONITOR_V1,
+    AirQualityMonitorStatus,
 )
+
 from .dummies import DummyDevice
 
 
@@ -141,7 +142,8 @@ class DummyAirQualityMonitorB1(DummyDevice, AirQualityMonitor):
             "temperature": 19.799999237060547,
             "temperature_unit": "c",
             "tvoc": 1.3948699235916138,
-            "tvoc_unit": "mg_m3"}
+            "tvoc_unit": "mg_m3",
+        }
         self.return_values = {"get_air_data": self._get_state}
         super().__init__(args, kwargs)
 

--- a/miio/tests/test_ceil.py
+++ b/miio/tests/test_ceil.py
@@ -3,7 +3,8 @@ from unittest import TestCase
 import pytest
 
 from miio import Ceil
-from miio.ceil import CeilStatus, CeilException
+from miio.ceil import CeilException, CeilStatus
+
 from .dummies import DummyDevice
 
 

--- a/miio/tests/test_chuangmi_ir.py
+++ b/miio/tests/test_chuangmi_ir.py
@@ -7,6 +7,7 @@ import pytest
 
 from miio import ChuangmiIr
 from miio.chuangmi_ir import ChuangmiIrException
+
 from .dummies import DummyDevice
 
 with open(os.path.join(os.path.dirname(__file__), "test_chuangmi_ir.json")) as inp:

--- a/miio/tests/test_chuangmi_plug.py
+++ b/miio/tests/test_chuangmi_plug.py
@@ -4,11 +4,12 @@ import pytest
 
 from miio import ChuangmiPlug
 from miio.chuangmi_plug import (
-    ChuangmiPlugStatus,
+    MODEL_CHUANGMI_PLUG_M1,
     MODEL_CHUANGMI_PLUG_V1,
     MODEL_CHUANGMI_PLUG_V3,
-    MODEL_CHUANGMI_PLUG_M1,
+    ChuangmiPlugStatus,
 )
+
 from .dummies import DummyDevice
 
 

--- a/miio/tests/test_click_common.py
+++ b/miio/tests/test_click_common.py
@@ -1,4 +1,4 @@
-from miio.click_common import validate_token, validate_ip
+from miio.click_common import validate_ip, validate_token
 
 
 def test_validate_token_empty():

--- a/miio/tests/test_fan.py
+++ b/miio/tests/test_fan.py
@@ -4,17 +4,18 @@ import pytest
 
 from miio import Fan, FanP5
 from miio.fan import (
-    MoveDirection,
-    LedBrightness,
-    OperationMode,
-    FanStatus,
-    FanStatusP5,
-    FanException,
+    MODEL_FAN_P5,
+    MODEL_FAN_SA1,
     MODEL_FAN_V2,
     MODEL_FAN_V3,
-    MODEL_FAN_SA1,
-    MODEL_FAN_P5,
+    FanException,
+    FanStatus,
+    FanStatusP5,
+    LedBrightness,
+    MoveDirection,
+    OperationMode,
 )
+
 from .dummies import DummyDevice
 
 

--- a/miio/tests/test_philips_bulb.py
+++ b/miio/tests/test_philips_bulb.py
@@ -3,7 +3,8 @@ from unittest import TestCase
 import pytest
 
 from miio import PhilipsBulb
-from miio.philips_bulb import PhilipsBulbStatus, PhilipsBulbException
+from miio.philips_bulb import PhilipsBulbException, PhilipsBulbStatus
+
 from .dummies import DummyDevice
 
 

--- a/miio/tests/test_philips_eyecare.py
+++ b/miio/tests/test_philips_eyecare.py
@@ -3,7 +3,8 @@ from unittest import TestCase
 import pytest
 
 from miio import PhilipsEyecare
-from miio.philips_eyecare import PhilipsEyecareStatus, PhilipsEyecareException
+from miio.philips_eyecare import PhilipsEyecareException, PhilipsEyecareStatus
+
 from .dummies import DummyDevice
 
 

--- a/miio/tests/test_philips_moonlight.py
+++ b/miio/tests/test_philips_moonlight.py
@@ -3,8 +3,9 @@ from unittest import TestCase
 import pytest
 
 from miio import PhilipsMoonlight
-from miio.philips_moonlight import PhilipsMoonlightStatus, PhilipsMoonlightException
+from miio.philips_moonlight import PhilipsMoonlightException, PhilipsMoonlightStatus
 from miio.utils import int_to_rgb, rgb_to_int
+
 from .dummies import DummyDevice
 
 

--- a/miio/tests/test_powerstrip.py
+++ b/miio/tests/test_powerstrip.py
@@ -4,12 +4,13 @@ import pytest
 
 from miio import PowerStrip
 from miio.powerstrip import (
-    PowerMode,
-    PowerStripStatus,
-    PowerStripException,
     MODEL_POWER_STRIP_V1,
     MODEL_POWER_STRIP_V2,
+    PowerMode,
+    PowerStripException,
+    PowerStripStatus,
 )
+
 from .dummies import DummyDevice
 
 

--- a/miio/tests/test_toiletlid.py
+++ b/miio/tests/test_toiletlid.py
@@ -3,12 +3,14 @@ from unittest import TestCase
 import pytest
 
 from miio.toiletlid import (
+    MODEL_TOILETLID_V1,
+    AmbientLightColor,
     Toiletlid,
     ToiletlidStatus,
-    AmbientLightColor,
-    MODEL_TOILETLID_V1,
 )
+
 from .dummies import DummyDevice
+
 
 """
 Response instance

--- a/miio/tests/test_vacuum.py
+++ b/miio/tests/test_vacuum.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 import pytest
 
 from miio import Vacuum, VacuumStatus
+
 from .dummies import DummyDevice
 
 

--- a/miio/tests/test_waterpurifier.py
+++ b/miio/tests/test_waterpurifier.py
@@ -4,6 +4,7 @@ import pytest
 
 from miio import WaterPurifier
 from miio.waterpurifier import WaterPurifierStatus
+
 from .dummies import DummyDevice
 
 

--- a/miio/tests/test_yeelight.py
+++ b/miio/tests/test_yeelight.py
@@ -3,7 +3,8 @@ from unittest import TestCase
 import pytest
 
 from miio import Yeelight
-from miio.yeelight import YeelightMode, YeelightStatus, YeelightException
+from miio.yeelight import YeelightException, YeelightMode, YeelightStatus
+
 from .dummies import DummyDevice
 
 

--- a/miio/toiletlid.py
+++ b/miio/toiletlid.py
@@ -4,7 +4,7 @@ from typing import Any, Dict
 
 import click
 
-from .click_common import command, format_output, EnumType
+from .click_common import EnumType, command, format_output
 from .device import Device
 
 _LOGGER = logging.getLogger(__name__)

--- a/miio/updater.py
+++ b/miio/updater.py
@@ -1,8 +1,9 @@
 import hashlib
 import logging
-import netifaces
-from http.server import HTTPServer, BaseHTTPRequestHandler
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from os.path import basename
+
+import netifaces
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/miio/utils.py
+++ b/miio/utils.py
@@ -1,7 +1,7 @@
 import functools
 import inspect
 import warnings
-from datetime import timedelta, datetime
+from datetime import datetime, timedelta
 from typing import Tuple
 
 

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -12,18 +12,18 @@ import click
 import pytz
 from appdirs import user_cache_dir
 
-from .click_common import DeviceGroup, command, GlobalContextObject, LiteralParamType
+from .click_common import DeviceGroup, GlobalContextObject, LiteralParamType, command
 from .device import Device, DeviceException
 from .vacuumcontainers import (
-    VacuumStatus,
+    CarpetModeStatus,
+    CleaningDetails,
+    CleaningSummary,
     ConsumableStatus,
     DNDStatus,
-    CleaningSummary,
-    CleaningDetails,
-    Timer,
-    SoundStatus,
     SoundInstallStatus,
-    CarpetModeStatus,
+    SoundStatus,
+    Timer,
+    VacuumStatus,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/miio/vacuum_cli.py
+++ b/miio/vacuum_cli.py
@@ -16,10 +16,11 @@ from tqdm import tqdm
 import miio  # noqa: E402
 from miio.click_common import (
     ExceptionHandlerGroup,
+    LiteralParamType,
     validate_ip,
     validate_token,
-    LiteralParamType,
 )
+
 from .device import UpdateState
 from .updater import OneShotServer
 
@@ -618,7 +619,7 @@ def update_firmware(vac: miio.Vacuum, url: str, md5: str, ip: str):
             try:
                 state = vac.update_state()
                 progress = vac.update_progress()
-            except:  # we may not get our messages through during upload
+            except:  # we may not get our messages through during upload # noqa
                 continue
 
             if state == UpdateState.Installing:

--- a/miio/vacuumcontainers.py
+++ b/miio/vacuumcontainers.py
@@ -1,9 +1,9 @@
 # -*- coding: UTF-8 -*#
-from datetime import datetime, timedelta, time
+from datetime import datetime, time, timedelta
 from enum import IntEnum
 from typing import Any, Dict, List
 
-from .utils import deprecated, pretty_time, pretty_seconds
+from .utils import deprecated, pretty_seconds, pretty_time
 
 
 def pretty_area(x: float) -> float:

--- a/miio/waterpurifier.py
+++ b/miio/waterpurifier.py
@@ -1,5 +1,4 @@
 import logging
-from collections import defaultdict
 from typing import Any, Dict
 
 from .click_common import command, format_output

--- a/miio/yeelight.py
+++ b/miio/yeelight.py
@@ -1,7 +1,8 @@
 import warnings
-import click
 from enum import IntEnum
-from typing import Tuple, Optional
+from typing import Optional, Tuple
+
+import click
 
 from .click_common import command, format_output
 from .device import Device, DeviceException

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import re
+
 from setuptools import setup
 
 with open("miio/version.py") as f:
@@ -15,7 +16,7 @@ def readme():
 
 setup(
     name="python-miio",
-    version=__version__,
+    version=__version__,  # type: ignore # noqa: F821
     description="Python library for interfacing with Xiaomi smart appliances",
     long_description=readme(),
     url="https://github.com/rytilahti/python-miio",

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
-line_length=88
+line_length=100
 known_first_party=miio
 known_third_party=
   appdirs

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands=flake8 miio
 
 [flake8]
 exclude = .git,.tox,__pycache__
-max-line-length = 100
+max-line-length = 88
 select = C,E,F,W,B,B950
 ignore = E501,W503,E203
 
@@ -48,7 +48,7 @@ multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
-line_length=100
+line_length=88
 known_first_party=miio
 known_third_party=
   appdirs
@@ -71,7 +71,7 @@ omit =
   miio/extract_tokens.py
   miio/tests/*
   miio/version.py
+
 [coverage:report]
 exclude_lines =
   def __repr__
-

--- a/tox.ini
+++ b/tox.ini
@@ -36,10 +36,32 @@ commands=flake8 miio
 [flake8]
 exclude = .git,.tox,__pycache__
 max-line-length = 100
+select = C,E,F,W,B,B950
+ignore = E501,W503,E203
 
 [testenv:typing]
 deps=mypy
 commands=mypy --ignore-missing-imports miio
+
+[isort]
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=88
+known_first_party=miio
+known_third_party=
+  appdirs
+  attr
+  click
+  construct
+  cryptography
+  netifaces
+  pytest
+  pytz
+  setuptools
+  tqdm
+  zeroconf
 
 [coverage:run]
 source = miio

--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,7 @@ force_grid_wrap=0
 use_parentheses=True
 line_length=88
 known_first_party=miio
+forced_separate=miio.discover
 known_third_party=
   appdirs
   attr


### PR DESCRIPTION
Up for discussion :-) Having all formating enforced by the pre-commit makes it easy to contribute without having to worry about that. Travis, Hound, and Coveralls could be disabled in the future.

I'd prefer adding mypy checks also, but that will require a bit more work to make it happen.

* Add pre-commit hooks for flake8, isort.
* Use azure dev for running precommit checks and tests.
* Use black's default line length (88) instead of (100). This seems to work fine.