### PR TITLE
s6: two new commands for map handling

### DIFF
--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -546,11 +546,10 @@ class Vacuum(Device):
         return self.send("get_recover_maps")
 
     @command(
-        click.argument("id"),
-        click.argument("map"),
+        click.argument("id"), click.argument("map"),
     )
-    def recover_map(self, id: int, map: int):
-        """Set recover maps."""
+    def use_recover_map(self, id: int, map: int):
+        """Set recover map."""
         payload = [int(id), int(map)]
         click.echo("Setting the map %s as active" % payload)
         return self.send("recover_map", payload)[0]

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -541,18 +541,15 @@ class Vacuum(Device):
         return self.send("get_room_mapping")
 
     @command()
-    def get_recover_maps(self):
-        """Get recover maps."""
+    def get_backup_maps(self):
+        """Get backup maps."""
         return self.send("get_recover_maps")
 
-    @command(
-        click.argument("id"), click.argument("map"),
-    )
-    def use_recover_map(self, id: int, map: int):
-        """Set recover map."""
-        payload = [int(id), int(map)]
-        click.echo("Setting the map %s as active" % payload)
-        return self.send("recover_map", payload)[0]
+    @command(click.argument("id", type=int))
+    def use_backup_map(self, id: int):
+        """Set backup map."""
+        click.echo("Setting the map %s as active" % id)
+        return self.send("recover_map", [id])
 
     @command()
     def get_segment_status(self):

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -541,6 +541,21 @@ class Vacuum(Device):
         return self.send("get_room_mapping")
 
     @command()
+    def get_recover_maps(self):
+        """Get recover maps."""
+        return self.send("get_recover_maps")
+
+    @command(
+        click.argument("id"),
+        click.argument("map"),
+    )
+    def recover_map(self, id: int, map: int):
+        """Set recover maps."""
+        payload = [int(id), int(map)]
+        click.echo("Setting the map %s as active" % payload)
+        return self.send("recover_map", payload)[0]
+
+    @command()
     def get_segment_status(self):
         """Get the status of a segment."""
         return self.send("get_segment_status")


### PR DESCRIPTION
This two commands are working fine with my Roborock s6

Roborock s6 has three saved maps. Command `get_recover_maps` shows you the map id's.
With the command `recover_map` you can set one of the tree maps as active.

Use case:
You manage one map with some no-go-zones and another map without no-go-zones.
Depending on whether the apartment is prepared (chars are on the table, carpets are removed) or not, use one or the other map.

Closes #607 