### PR TITLE
Add error code 24 definition ("No-go zone or invisible wall detected")

### DIFF
--- a/miio/vacuumcontainers.py
+++ b/miio/vacuumcontainers.py
@@ -34,6 +34,7 @@ error_codes = {  # from vacuum_cleaner-EN.pdf
     21: "Laser disance sensor blocked",
     22: "Clean the dock charging contacts",
     23: "Docking station not reachable",
+    24: "No-go zone or invisible wall detected",
 }
 
 


### PR DESCRIPTION
Roborock was cleaning, got stuck, in the component got error "Definition missing for error 24", checked Mi Home for the error, and it's what I have added here.