### PR TITLE
Add support for Xiaomi Aqara Gateway Alarm

### DIFF
--- a/miio/gateway_alarm.py
+++ b/miio/gateway_alarm.py
@@ -17,6 +17,7 @@ class XiaomiGatewayAlarm(Device):
         """Fetch alarm status from the device."""
         # Response: ['on'], ['off'], ['oning']
         alarm_status = self._device.send("get_arming")
+        alarm_status = alarm_status.pop()
 
         return alarm_status
 

--- a/miio/gateway_alarm.py
+++ b/miio/gateway_alarm.py
@@ -5,18 +5,18 @@ from .device import Device
 
 _LOGGER = logging.getLogger(__name__)
 
+
 class XiaomiGatewayAlarm(Device):
     """Main class representing the Xiaomi Gateway Alarm."""
 
     def __init__(self, Device) -> None:
         self._device = Device
 
-    @command(
-        default_output=format_output("[alarm_status]"))
+    @command(default_output=format_output("[alarm_status]"))
     def status(self):
         """Fetch alarm status from the device."""
         # Response: ['on'], ['off'], ['oning']
-        alarm_status = self._device.send("get_arming") 
+        alarm_status = self._device.send("get_arming")
 
         return alarm_status
 

--- a/miio/gateway_alarm.py
+++ b/miio/gateway_alarm.py
@@ -1,0 +1,31 @@
+import logging
+
+from .click_common import command, format_output
+from .device import Device
+
+_LOGGER = logging.getLogger(__name__)
+
+class XiaomiGatewayAlarm(Device):
+    """Main class representing the Xiaomi Gateway Alarm."""
+
+    def __init__(self, Device) -> None:
+        self._device = Device
+
+    @command(
+        default_output=format_output("[alarm_status]"))
+    def status(self):
+        """Fetch alarm status from the device."""
+        # Response: ['on'], ['off'], ['oning']
+        alarm_status = self._device.send("get_arming") 
+
+        return alarm_status
+
+    @command(default_output=format_output("Turning alarm on"))
+    def alarm_on(self):
+        """Turning alarm on."""
+        return self._device.send("set_arming", ["on"])
+
+    @command(default_output=format_output("Turning alarm off"))
+    def alarm_off(self):
+        """Turning alarm off."""
+        return self._device.send("set_arming", ["off"])


### PR DESCRIPTION
I am working on integrating the Xiaomi Aqara Gateway Alarm into HomeAssistant as an official component.
Since the "Xiaomi Aqara API (LAN protocol)" does not support the Alarm of the Gateway I use the "Xiaomi's miIO protocol" as implemented in your awesom library.

I know that HomeAssistant requires commans such as included in this PR to be in the upstream library instead of directly in the HomeAssistant code. That is why I want this merged in python-miio.

@rytilahti Could you please merge this PR and push to a new version of python-miio such that I can then create the PR in HomeAssistant to add official support of the Xiaomi Gateway Alarm?

Thank you in advance for your time and effort!