### PR TITLE
Add fan_speed_presets() for querying available fan speeds

### DIFF
--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -470,8 +470,8 @@ class Vacuum(Device):
         )
 
     @command()
-    def supported_fanspeeds(self) -> Dict[str, int]:
-        """Return dictionary containing supported fanspeeds."""
+    def fan_speed_presets(self) -> Dict[str, int]:
+        """Return dictionary containing supported fan speeds."""
         if self.model is None:
             self._autodetect_model()
 
@@ -680,10 +680,7 @@ class Vacuum(Device):
             _LOGGER.debug("Writing %s to %s", seqs, id_file)
             path_obj = pathlib.Path(id_file)
             cache_dir = path_obj.parents[0]
-            try:
-                cache_dir.mkdir(parents=True)
-            except FileExistsError:
-                pass  # after dropping py3.4 support, use exist_ok for mkdir
+            cache_dir.mkdir(parents=True, exist_ok=True)
             with open(id_file, "w") as f:
                 json.dump(seqs, f)
 

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -441,11 +441,11 @@ class Vacuum(Device):
 
         For the moment this is used only for the fanspeeds,
         but that could be extended to cover other supported features."""
-        # cloud-blocked vacuums will not return proper payloads
         try:
             info = self.info()
             self.model = info.model
         except TypeError:
+            # cloud-blocked vacuums will not return proper payloads
             self._fanspeeds = FanspeedV1
             self.model = ROCKROBO_V1
             _LOGGER.debug("Unable to query model, falling back to %s", self._fanspeeds)
@@ -454,7 +454,7 @@ class Vacuum(Device):
         _LOGGER.info("model: %s", self.model)
 
         if info.model == ROCKROBO_V1:
-            _LOGGER.info("Got robov1, checking for firmware version")
+            _LOGGER.debug("Got robov1, checking for firmware version")
             fw_version = info.firmware_version
             version, build = fw_version.split("_")
             version = tuple(map(int, version.split(".")))

--- a/miio/viomivacuum.py
+++ b/miio/viomivacuum.py
@@ -3,6 +3,7 @@ import time
 from collections import defaultdict
 from datetime import timedelta
 from enum import Enum
+from typing import Dict
 
 import click
 
@@ -338,3 +339,8 @@ class ViomiVacuum(Device):
     def carpet_mode(self, mode: ViomiCarpetTurbo):
         """Set the carpet mode."""
         return self.send("set_carpetturbo", [mode.value])
+
+    @command()
+    def supported_fanspeeds(self) -> Dict[str, int]:
+        """Return dictionary containing supported fanspeeds."""
+        return {x.name: x.value for x in list(ViomiVacuumSpeed)}

--- a/miio/viomivacuum.py
+++ b/miio/viomivacuum.py
@@ -341,6 +341,6 @@ class ViomiVacuum(Device):
         return self.send("set_carpetturbo", [mode.value])
 
     @command()
-    def supported_fanspeeds(self) -> Dict[str, int]:
+    def fan_speed_presets(self) -> Dict[str, int]:
         """Return dictionary containing supported fanspeeds."""
         return {x.name: x.value for x in list(ViomiVacuumSpeed)}


### PR DESCRIPTION
This returns a dictionary {name, value} of the available fan speeds,
the main driver being the need to simplify homeassistant integrations for different devices.

For viomi vacuums this is currently straightforward and hard-coded, but we do special handling
for rockrobo devices (based on info() responses):

* If the query succeeds, newer firmware versions (3.5.7+) of v1 are handled as a special case,
  otherwise the new-style [100-105] mapping is returned.

* If the query fails, we fall back to rockrobo v1's percentage-based mapping.
  This happens, e.g., when the vacuum has no cloud connectivity.

Related to #523

Related downstream issues
https://github.com/home-assistant/core/pull/32821
https://github.com/home-assistant/core/issues/31268
https://github.com/home-assistant/core/issues/27268