### PR TITLE
Gateway get_device_prop_exp command

### DIFF
--- a/miio/gateway.py
+++ b/miio/gateway.py
@@ -122,6 +122,11 @@ class Gateway(Device):
         """Get the value of a property for given sid."""
         return self.send("get_device_prop", [sid, property])
 
+    @command(click.argument("sid"), click.argument("properties", nargs=-1))
+    def get_device_prop_exp(self, sid, properties):
+        """Get the value of a bunch of properties for given sid."""
+        return self.send("get_device_prop_exp", [[sid] + list(properties)])
+
     @command(click.argument("sid"), click.argument("property"), click.argument("value"))
     def set_device_prop(self, sid, property, value):
         """Set the device property."""


### PR DESCRIPTION
Example command (e.g. parent device is lumi.acpartner.v3, child device is lumi.relay.c2acn01): `miiocli --debug gateway --ip 192.168.xxx.xxx --token xxxx get_device_prop_exp lumi.xxxx channel_0 channel_1 load_power`