### PR TITLE
Add extra_parameters to send()

### DIFF
--- a/miio/device.py
+++ b/miio/device.py
@@ -120,10 +120,34 @@ class Device(metaclass=DeviceGroupMeta):
         self.token = token
         self._protocol = MiIOProtocol(ip, token, start_id, debug, lazy_discover)
 
-    def send(self, command: str, parameters: Any = None, retry_count=3) -> Any:
-        return self._protocol.send(command, parameters, retry_count)
+    def send(
+        self,
+        command: str,
+        parameters: Any = None,
+        retry_count=3,
+        *,
+        extra_parameters=None
+    ) -> Any:
+        """Send a command to the device.
+
+        Basic format of the request:
+        {"id": 1234, "method": command, "parameters": parameters}
+
+        `extra_parameters` allows passing elements to the top-level of the request.
+        This is necessary for some devices, such as gateway devices, which expect
+        the sub-device identifier to be on the top-level.
+
+        :param str command: Command to send
+        :param dict parameters: Parameters to send
+        :param int retry_count: How many times to retry on error
+        :param dict extra_parameters: Extra top-level parameters
+        """
+        return self._protocol.send(
+            command, parameters, retry_count, extra_parameters=extra_parameters
+        )
 
     def send_handshake(self):
+        """Send initial handshake to the device."""
         return self._protocol.send_handshake()
 
     @command(

--- a/miio/exceptions.py
+++ b/miio/exceptions.py
@@ -1,8 +1,6 @@
 class DeviceException(Exception):
     """Exception wrapping any communication errors with the device."""
 
-    pass
-
 
 class DeviceError(DeviceException):
     """Exception communicating an error delivered by the target device."""
@@ -14,5 +12,3 @@ class DeviceError(DeviceException):
 
 class RecoverableError(DeviceError):
     """Exception communicating an recoverable error delivered by the target device."""
-
-    pass

--- a/miio/miioprotocol.py
+++ b/miio/miioprotocol.py
@@ -8,7 +8,7 @@ import codecs
 import datetime
 import logging
 import socket
-from typing import Any, List
+from typing import Any, Dict, List
 
 import construct
 
@@ -126,25 +126,28 @@ class MiIOProtocol:
                 _LOGGER.warning("error while reading discover results: %s", ex)
                 break
 
-    def send(self, command: str, parameters: Any = None, retry_count=3) -> Any:
+    def send(
+        self,
+        command: str,
+        parameters: Any = None,
+        retry_count: int = 3,
+        *,
+        extra_parameters: Dict = None
+    ) -> Any:
         """Build and send the given command.
         Note that this will implicitly call :func:`send_handshake` to do a handshake,
         and will re-try in case of errors while incrementing the `_id` by 100.
 
         :param str command: Command to send
-        :param dict parameters: Parameters to send, or an empty list FIXME
+        :param dict parameters: Parameters to send, or an empty list
         :param retry_count: How many times to retry in case of failure
+        :param dict extra_parameters: Extra top-level parameters
         :raises DeviceException: if an error has occurred during communication."""
 
         if not self.lazy_discover or not self._discovered:
             self.send_handshake()
 
-        cmd = {"id": self._id, "method": command}
-
-        if parameters is not None:
-            cmd["params"] = parameters
-        else:
-            cmd["params"] = []
+        request = self._create_request(command, parameters, extra_parameters)
 
         send_ts = self._device_ts + datetime.timedelta(seconds=1)
         header = {
@@ -154,9 +157,9 @@ class MiIOProtocol:
             "ts": send_ts,
         }
 
-        msg = {"data": {"value": cmd}, "header": {"value": header}, "checksum": 0}
+        msg = {"data": {"value": request}, "header": {"value": header}, "checksum": 0}
         m = Message.build(msg, token=self.token)
-        _LOGGER.debug("%s:%s >>: %s", self.ip, self.port, cmd)
+        _LOGGER.debug("%s:%s >>: %s", self.ip, self.port, request)
         if self.debug > 1:
             _LOGGER.debug(
                 "send (timeout %s): %s",
@@ -180,25 +183,23 @@ class MiIOProtocol:
             if self.debug > 1:
                 _LOGGER.debug("recv from %s: %s", addr[0], m)
 
-            self.__id = m.data.value["id"]
+            payload = m.data.value
+            self.__id = payload["id"]
             _LOGGER.debug(
                 "%s:%s (ts: %s, id: %s) << %s",
                 self.ip,
                 self.port,
-                m.header.value.ts,
-                m.data.value["id"],
-                m.data.value,
+                payload.ts,
+                payload["id"],
+                payload,
             )
-            if "error" in m.data.value:
-                error = m.data.value["error"]
-                if "code" in error and error["code"] == -30001:
-                    raise RecoverableError(error)
-                raise DeviceError(error)
+            if "error" in payload:
+                self._handle_error(payload["error"])
 
             try:
-                return m.data.value["result"]
+                return payload["result"]
             except KeyError:
-                return m.data.value
+                return payload
         except construct.core.ChecksumError as ex:
             raise DeviceException(
                 "Got checksum error which indicates use "
@@ -212,7 +213,12 @@ class MiIOProtocol:
                 )
                 self.__id += 100
                 self._discovered = False
-                return self.send(command, parameters, retry_count - 1)
+                return self.send(
+                    command,
+                    parameters,
+                    retry_count - 1,
+                    extra_parameters=extra_parameters,
+                )
 
             _LOGGER.error("Got error when receiving: %s", ex)
             raise DeviceException("No response from the device") from ex
@@ -222,7 +228,12 @@ class MiIOProtocol:
                 _LOGGER.debug(
                     "Retrying to send failed command, retries left: %s", retry_count
                 )
-                return self.send(command, parameters, retry_count - 1)
+                return self.send(
+                    command,
+                    parameters,
+                    retry_count - 1,
+                    extra_parameters=extra_parameters,
+                )
 
             _LOGGER.error("Got error when receiving: %s", ex)
             raise DeviceException("Unable to recover failed command") from ex
@@ -238,3 +249,25 @@ class MiIOProtocol:
     @property
     def raw_id(self):
         return self.__id
+
+    def _handle_error(self, error):
+        """Raise exception based on the given error code."""
+        if "code" in error and error["code"] == -30001:
+            raise RecoverableError(error)
+        raise DeviceError(error)
+
+    def _create_request(
+        self, command: str, parameters: Any, extra_parameters: Dict = None
+    ):
+        """Create request payload."""
+        request = {"id": self._id, "method": command}
+
+        if parameters is not None:
+            request["params"] = parameters
+        else:
+            request["params"] = []
+
+        if extra_parameters is not None:
+            request = {**request, **extra_parameters}
+
+        return request

--- a/miio/miioprotocol.py
+++ b/miio/miioprotocol.py
@@ -59,9 +59,10 @@ class MiIOProtocol:
 
         :raises DeviceException: if the device could not be discovered."""
         m = MiIOProtocol.discover(self.ip)
+        header = m.header.value
         if m is not None:
-            self._device_id = m.header.value.device_id
-            self._device_ts = m.header.value.ts
+            self._device_id = header.device_id
+            self._device_ts = header.ts
             self._discovered = True
             if self.debug > 1:
                 _LOGGER.debug(m)
@@ -179,17 +180,21 @@ class MiIOProtocol:
         try:
             data, addr = s.recvfrom(1024)
             m = Message.parse(data, token=self.token)
-            self._device_ts = m.header.value.ts
+
+            header = m.header.value
+            payload = m.data.value
+
+            self.__id = payload["id"]
+            self._device_ts = header.ts
+
             if self.debug > 1:
                 _LOGGER.debug("recv from %s: %s", addr[0], m)
 
-            payload = m.data.value
-            self.__id = payload["id"]
             _LOGGER.debug(
                 "%s:%s (ts: %s, id: %s) << %s",
                 self.ip,
                 self.port,
-                payload.ts,
+                header.ts,
                 payload["id"],
                 payload,
             )

--- a/miio/tests/dummies.py
+++ b/miio/tests/dummies.py
@@ -8,7 +8,7 @@ class DummyMiIOProtocol:
         #       return_values) is a temporary workaround to minimize diff size.
         self.dummy_device = dummy_device
 
-    def send(self, command: str, parameters=None, retry_count=3):
+    def send(self, command: str, parameters=None, retry_count=3, extra_parameters=None):
         """Overridden send() to return values from `self.return_values`."""
         return self.dummy_device.return_values[command](parameters)
 

--- a/miio/tests/test_protocol.py
+++ b/miio/tests/test_protocol.py
@@ -1,81 +1,140 @@
 import binascii
-from unittest import TestCase
+
+import pytest
+
+from miio.exceptions import DeviceError, RecoverableError
 
 from .. import Utils
+from ..miioprotocol import MiIOProtocol
 from ..protocol import Message
 
+METHOD = "method"
+PARAMS = "params"
 
-class TestProtocol(TestCase):
-    def test_non_bytes_payload(self):
-        payload = "hello world"
-        valid_token = 32 * b"0"
-        with self.assertRaises(TypeError):
-            Utils.encrypt(payload, valid_token)
-        with self.assertRaises(TypeError):
-            Utils.decrypt(payload, valid_token)
 
-    def test_encrypt(self):
-        payload = b"hello world"
-        token = bytes.fromhex(32 * "0")
+@pytest.fixture
+def proto() -> MiIOProtocol:
+    return MiIOProtocol()
 
-        encrypted = Utils.encrypt(payload, token)
-        decrypted = Utils.decrypt(encrypted, token)
-        assert payload == decrypted
 
-    def test_invalid_token(self):
-        payload = b"hello world"
-        wrong_type = 1234
-        wrong_length = bytes.fromhex(16 * "0")
-        with self.assertRaises(TypeError):
-            Utils.encrypt(payload, wrong_type)
-        with self.assertRaises(TypeError):
-            Utils.decrypt(payload, wrong_type)
+def test_incrementing_id(proto):
+    old_id = proto.raw_id
+    proto._create_request("dummycmd", "dummy")
+    assert proto.raw_id > old_id
 
-        with self.assertRaises(ValueError):
-            Utils.encrypt(payload, wrong_length)
-        with self.assertRaises(ValueError):
-            Utils.decrypt(payload, wrong_length)
 
-    def test_decode_json_payload(self):
-        token = bytes.fromhex(32 * "0")
-        ctx = {"token": token}
+def test_id_loop(proto):
+    proto.__id = 9999
+    proto._create_request("dummycmd", "dummy")
+    assert proto.raw_id == 1
 
-        def build_msg(data):
-            encrypted_data = Utils.encrypt(data, token)
 
-            # header
-            magic = binascii.unhexlify(b"2131")
-            length = (32 + len(encrypted_data)).to_bytes(2, byteorder="big")
-            unknown = binascii.unhexlify(b"00000000")
-            did = binascii.unhexlify(b"01234567")
-            epoch = binascii.unhexlify(b"00000000")
+def test_request_with_none_param(proto):
+    req = proto._create_request("dummy", None)
+    assert isinstance(req["params"], list)
+    assert len(req["params"]) == 0
 
-            checksum = Utils.md5(
-                magic + length + unknown + did + epoch + token + encrypted_data
-            )
 
-            return magic + length + unknown + did + epoch + checksum + encrypted_data
+def test_request_with_string_param(proto):
+    req = proto._create_request("command", "single")
+    assert req[METHOD] == "command"
+    assert req[PARAMS] == "single"
 
-        # can parse message with valid json
-        serialized_msg = build_msg(b'{"id": 123456}')
-        parsed_msg = Message.parse(serialized_msg, **ctx)
-        assert parsed_msg.data.value
-        assert isinstance(parsed_msg.data.value, dict)
-        assert parsed_msg.data.value["id"] == 123456
 
-        # can parse message with invalid json for edge case powerstrip
-        # when not connected to cloud
-        serialized_msg = build_msg(b'{"id": 123456,,"otu_stat":0}')
-        parsed_msg = Message.parse(serialized_msg, **ctx)
-        assert parsed_msg.data.value
-        assert isinstance(parsed_msg.data.value, dict)
-        assert parsed_msg.data.value["id"] == 123456
-        assert parsed_msg.data.value["otu_stat"] == 0
+def test_request_with_list_param(proto):
+    req = proto._create_request("command", ["item"])
+    assert req[METHOD] == "command"
+    assert req[PARAMS] == ["item"]
 
-        # can parse message with invalid json for edge case xiaomi cloud
-        # reply to _sync.batch_gen_room_up_url
-        serialized_msg = build_msg(b'{"id": 123456}\x00k')
-        parsed_msg = Message.parse(serialized_msg, **ctx)
-        assert parsed_msg.data.value
-        assert isinstance(parsed_msg.data.value, dict)
-        assert parsed_msg.data.value["id"] == 123456
+
+def test_request_extra_params(proto):
+    req = proto._create_request("command", ["item"], extra_parameters={"sid": 1234})
+    assert "sid" in req
+    assert req["sid"] == 1234
+
+
+def test_device_error_handling(proto: MiIOProtocol):
+    retry_error = -30001
+    with pytest.raises(RecoverableError):
+        proto._handle_error({"code": retry_error})
+
+    with pytest.raises(DeviceError):
+        proto._handle_error({"code": 1234})
+
+
+def test_non_bytes_payload():
+    payload = "hello world"
+    valid_token = 32 * b"0"
+    with pytest.raises(TypeError):
+        Utils.encrypt(payload, valid_token)
+    with pytest.raises(TypeError):
+        Utils.decrypt(payload, valid_token)
+
+
+def test_encrypt():
+    payload = b"hello world"
+    token = bytes.fromhex(32 * "0")
+
+    encrypted = Utils.encrypt(payload, token)
+    decrypted = Utils.decrypt(encrypted, token)
+    assert payload == decrypted
+
+
+def test_invalid_token():
+    payload = b"hello world"
+    wrong_type = 1234
+    wrong_length = bytes.fromhex(16 * "0")
+    with pytest.raises(TypeError):
+        Utils.encrypt(payload, wrong_type)
+    with pytest.raises(TypeError):
+        Utils.decrypt(payload, wrong_type)
+
+    with pytest.raises(ValueError):
+        Utils.encrypt(payload, wrong_length)
+    with pytest.raises(ValueError):
+        Utils.decrypt(payload, wrong_length)
+
+
+def test_decode_json_payload():
+    token = bytes.fromhex(32 * "0")
+    ctx = {"token": token}
+
+    def build_msg(data):
+        encrypted_data = Utils.encrypt(data, token)
+
+        # header
+        magic = binascii.unhexlify(b"2131")
+        length = (32 + len(encrypted_data)).to_bytes(2, byteorder="big")
+        unknown = binascii.unhexlify(b"00000000")
+        did = binascii.unhexlify(b"01234567")
+        epoch = binascii.unhexlify(b"00000000")
+
+        checksum = Utils.md5(
+            magic + length + unknown + did + epoch + token + encrypted_data
+        )
+
+        return magic + length + unknown + did + epoch + checksum + encrypted_data
+
+    # can parse message with valid json
+    serialized_msg = build_msg(b'{"id": 123456}')
+    parsed_msg = Message.parse(serialized_msg, **ctx)
+    assert parsed_msg.data.value
+    assert isinstance(parsed_msg.data.value, dict)
+    assert parsed_msg.data.value["id"] == 123456
+
+    # can parse message with invalid json for edge case powerstrip
+    # when not connected to cloud
+    serialized_msg = build_msg(b'{"id": 123456,,"otu_stat":0}')
+    parsed_msg = Message.parse(serialized_msg, **ctx)
+    assert parsed_msg.data.value
+    assert isinstance(parsed_msg.data.value, dict)
+    assert parsed_msg.data.value["id"] == 123456
+    assert parsed_msg.data.value["otu_stat"] == 0
+
+    # can parse message with invalid json for edge case xiaomi cloud
+    # reply to _sync.batch_gen_room_up_url
+    serialized_msg = build_msg(b'{"id": 123456}\x00k')
+    parsed_msg = Message.parse(serialized_msg, **ctx)
+    assert parsed_msg.data.value
+    assert isinstance(parsed_msg.data.value, dict)
+    assert parsed_msg.data.value["id"] == 123456


### PR DESCRIPTION
This allows passing extra items to the main payload body,
necessary for adding support for subdevices.

This also includes some slight cleanups and better tests for the protocol handling code.

Related to #651