### PR TITLE
Add Device.get_properties(), cleanup devices using get_prop

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ steps:
 - script: |
     python -m pip install --upgrade pip
     pip install -r requirements.txt
-    pip install pytest pytest-azurepipelines pytest-cov
+    pip install pytest pytest-azurepipelines pytest-cov pytest-mock
   displayName: 'Install dependencies'
 
 - script: |

--- a/miio/airdehumidifier.py
+++ b/miio/airdehumidifier.py
@@ -236,21 +236,7 @@ class AirDehumidifier(Device):
 
         properties = AVAILABLE_PROPERTIES[self.model]
 
-        _props = properties.copy()
-        values = []
-        while _props:
-            values.extend(self.send("get_prop", _props[:1]))
-            _props[:] = _props[1:]
-
-        properties_count = len(properties)
-        values_count = len(values)
-        if properties_count != values_count:
-            _LOGGER.error(
-                "Count (%s) of requested properties does not match the "
-                "count (%s) of received values.",
-                properties_count,
-                values_count,
-            )
+        values = self.get_properties(properties, max_properties=1)
 
         return AirDehumidifierStatus(
             defaultdict(lambda: None, zip(properties, values)), self.device_info

--- a/miio/airfresh.py
+++ b/miio/airfresh.py
@@ -228,23 +228,7 @@ class AirFresh(Device):
             "led",
         ]
 
-        # A single request is limited to 16 properties. Therefore the
-        # properties are divided into multiple requests
-        _props = properties.copy()
-        values = []
-        while _props:
-            values.extend(self.send("get_prop", _props[:15]))
-            _props[:] = _props[15:]
-
-        properties_count = len(properties)
-        values_count = len(values)
-        if properties_count != values_count:
-            _LOGGER.debug(
-                "Count (%s) of requested properties does not match the "
-                "count (%s) of received values.",
-                properties_count,
-                values_count,
-            )
+        values = self.get_properties(properties, max_properties=15)
 
         return AirFreshStatus(defaultdict(lambda: None, zip(properties, values)))
 

--- a/miio/airfresh_t2017.py
+++ b/miio/airfresh_t2017.py
@@ -280,24 +280,7 @@ class AirFreshT2017(Device):
         """Retrieve properties."""
 
         properties = AVAILABLE_PROPERTIES[self.model]
-
-        # A single request is limited to 16 properties. Therefore the
-        # properties are divided into multiple requests
-        _props = properties.copy()
-        values = []
-        while _props:
-            values.extend(self.send("get_prop", _props[:15]))
-            _props[:] = _props[15:]
-
-        properties_count = len(properties)
-        values_count = len(values)
-        if properties_count != values_count:
-            _LOGGER.debug(
-                "Count (%s) of requested properties does not match the "
-                "count (%s) of received values.",
-                properties_count,
-                values_count,
-            )
+        values = self.get_properties(properties, max_properties=15)
 
         return AirFreshStatus(defaultdict(lambda: None, zip(properties, values)))
 

--- a/miio/airhumidifier.py
+++ b/miio/airhumidifier.py
@@ -309,21 +309,7 @@ class AirHumidifier(Device):
         if self.model in [MODEL_HUMIDIFIER_CA1, MODEL_HUMIDIFIER_CB1]:
             _props_per_request = 1
 
-        _props = properties.copy()
-        values = []
-        while _props:
-            values.extend(self.send("get_prop", _props[:_props_per_request]))
-            _props[:] = _props[_props_per_request:]
-
-        properties_count = len(properties)
-        values_count = len(values)
-        if properties_count != values_count:
-            _LOGGER.error(
-                "Count (%s) of requested properties does not match the "
-                "count (%s) of received values.",
-                properties_count,
-                values_count,
-            )
+        values = self.get_properties(properties, max_properties=_props_per_request)
 
         return AirHumidifierStatus(
             defaultdict(lambda: None, zip(properties, values)), self.device_info

--- a/miio/airhumidifier_mjjsq.py
+++ b/miio/airhumidifier_mjjsq.py
@@ -167,21 +167,7 @@ class AirHumidifierMjjsq(Device):
         """Retrieve properties."""
 
         properties = AVAILABLE_PROPERTIES[self.model]
-        _props = properties.copy()
-        values = []
-        while _props:
-            values.extend(self.send("get_prop", _props[:1]))
-            _props[:] = _props[1:]
-
-        properties_count = len(properties)
-        values_count = len(values)
-        if properties_count != values_count:
-            _LOGGER.error(
-                "Count (%s) of requested properties does not match the "
-                "count (%s) of received values.",
-                properties_count,
-                values_count,
-            )
+        values = self.get_properties(properties, max_properties=1)
 
         return AirHumidifierStatus(defaultdict(lambda: None, zip(properties, values)))
 

--- a/miio/airpurifier.py
+++ b/miio/airpurifier.py
@@ -409,23 +409,7 @@ class AirPurifier(Device):
             "button_pressed",
         ]
 
-        # A single request is limited to 16 properties. Therefore the
-        # properties are divided into multiple requests
-        _props = properties.copy()
-        values = []
-        while _props:
-            values.extend(self.send("get_prop", _props[:15]))
-            _props[:] = _props[15:]
-
-        properties_count = len(properties)
-        values_count = len(values)
-        if properties_count != values_count:
-            _LOGGER.debug(
-                "Count (%s) of requested properties does not match the "
-                "count (%s) of received values.",
-                properties_count,
-                values_count,
-            )
+        values = self.get_properties(properties, max_properties=15)
 
         return AirPurifierStatus(defaultdict(lambda: None, zip(properties, values)))
 

--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -297,7 +297,7 @@ class AirPurifierMiot(MiotDevice):
         return AirPurifierMiotStatus(
             {
                 prop["did"]: prop["value"] if prop["code"] == 0 else None
-                for prop in self.get_properties()
+                for prop in self.get_properties_for_mapping()
             }
         )
 

--- a/miio/ceil.py
+++ b/miio/ceil.py
@@ -112,17 +112,7 @@ class Ceil(Device):
     def status(self) -> CeilStatus:
         """Retrieve properties."""
         properties = ["power", "bright", "cct", "snm", "dv", "bl", "ac"]
-        values = self.send("get_prop", properties)
-
-        properties_count = len(properties)
-        values_count = len(values)
-        if properties_count != values_count:
-            _LOGGER.debug(
-                "Count (%s) of requested properties does not match the "
-                "count (%s) of received values.",
-                properties_count,
-                values_count,
-            )
+        values = self.get_properties(properties)
 
         return CeilStatus(defaultdict(lambda: None, zip(properties, values)))
 

--- a/miio/chuangmi_camera.py
+++ b/miio/chuangmi_camera.py
@@ -166,7 +166,7 @@ class ChuangmiCamera(Device):
             "mini_level",
         ]
 
-        values = self.send("get_prop", properties)
+        values = self.get_properties(properties)
 
         return CameraStatus(dict(zip(properties, values)))
 

--- a/miio/chuangmi_plug.py
+++ b/miio/chuangmi_plug.py
@@ -134,17 +134,7 @@ class ChuangmiPlug(Device):
     def status(self) -> ChuangmiPlugStatus:
         """Retrieve properties."""
         properties = AVAILABLE_PROPERTIES[self.model].copy()
-        values = self.send("get_prop", properties)
-
-        properties_count = len(properties)
-        values_count = len(values)
-        if properties_count != values_count:
-            _LOGGER.debug(
-                "Count (%s) of requested properties does not match the "
-                "count (%s) of received values.",
-                properties_count,
-                values_count,
-            )
+        values = self.get_properties(properties)
 
         if self.model == MODEL_CHUANGMI_PLUG_V3:
             load_power = self.send("get_power")  # Response: [300]

--- a/miio/fan.py
+++ b/miio/fan.py
@@ -418,21 +418,7 @@ class Fan(Device):
         if self.model in [MODEL_FAN_SA1, MODEL_FAN_ZA1, MODEL_FAN_ZA3, MODEL_FAN_ZA4]:
             _props_per_request = 1
 
-        _props = properties.copy()
-        values = []
-        while _props:
-            values.extend(self.send("get_prop", _props[:_props_per_request]))
-            _props[:] = _props[_props_per_request:]
-
-        properties_count = len(properties)
-        values_count = len(values)
-        if properties_count != values_count:
-            _LOGGER.error(
-                "Count (%s) of requested properties does not match the "
-                "count (%s) of received values.",
-                properties_count,
-                values_count,
-            )
+        values = self.get_properties(properties, max_properties=_props_per_request)
 
         return FanStatus(dict(zip(properties, values)))
 
@@ -662,25 +648,7 @@ class FanP5(Device):
     def status(self) -> FanStatusP5:
         """Retrieve properties."""
         properties = AVAILABLE_PROPERTIES[self.model]
-
-        # A single request is limited to 16 properties. Therefore the
-        # properties are divided into multiple requests
-        _props_per_request = 15
-        _props = properties.copy()
-        values = []
-        while _props:
-            values.extend(self.send("get_prop", _props[:_props_per_request]))
-            _props[:] = _props[_props_per_request:]
-
-        properties_count = len(properties)
-        values_count = len(values)
-        if properties_count != values_count:
-            _LOGGER.error(
-                "Count (%s) of requested properties does not match the "
-                "count (%s) of received values.",
-                properties_count,
-                values_count,
-            )
+        values = self.get_properties(properties, max_properties=15)
 
         return FanStatusP5(dict(zip(properties, values)))
 

--- a/miio/heater.py
+++ b/miio/heater.py
@@ -196,21 +196,7 @@ class Heater(Device):
         if self.model in [MODEL_HEATER_MA1, MODEL_HEATER_ZA1]:
             _props_per_request = 1
 
-        _props = properties.copy()
-        values = []
-        while _props:
-            values.extend(self.send("get_prop", _props[:_props_per_request]))
-            _props[:] = _props[_props_per_request:]
-
-        properties_count = len(properties)
-        values_count = len(values)
-        if properties_count != values_count:
-            _LOGGER.error(
-                "Count (%s) of requested properties does not match the "
-                "count (%s) of received values.",
-                properties_count,
-                values_count,
-            )
+        values = self.get_properties(properties, max_properties=_props_per_request)
 
         return HeaterStatus(dict(zip(properties, values)))
 

--- a/miio/miot_device.py
+++ b/miio/miot_device.py
@@ -20,31 +20,13 @@ class MiotDevice(Device):
         self.mapping = mapping
         super().__init__(ip, token, start_id, debug, lazy_discover)
 
-    def get_properties(self) -> list:
+    def get_properties_for_mapping(self) -> list:
         """Retrieve raw properties based on mapping."""
 
         # We send property key in "did" because it's sent back via response and we can identify the property.
         properties = [{"did": k, **v} for k, v in self.mapping.items()]
 
-        # A single request is limited to 16 properties. Therefore the
-        # properties are divided into multiple requests
-        _props = properties.copy()
-        values = []
-        while _props:
-            values.extend(self.send("get_properties", _props[:15]))
-            _props[:] = _props[15:]
-
-        properties_count = len(properties)
-        values_count = len(values)
-        if properties_count != values_count:
-            _LOGGER.debug(
-                "Count (%s) of requested properties does not match the "
-                "count (%s) of received values.",
-                properties_count,
-                values_count,
-            )
-
-        return values
+        return self.get_properties(properties, max_properties=15)
 
     def set_property(self, property_key: str, value):
         """Sets property value."""

--- a/miio/philips_bulb.py
+++ b/miio/philips_bulb.py
@@ -13,10 +13,7 @@ _LOGGER = logging.getLogger(__name__)
 MODEL_PHILIPS_LIGHT_BULB = "philips.light.bulb"
 MODEL_PHILIPS_LIGHT_HBULB = "philips.light.hbulb"
 
-AVAILABLE_PROPERTIES_COMMON = [
-    "power",
-    "dv",
-]
+AVAILABLE_PROPERTIES_COMMON = ["power", "dv"]
 
 AVAILABLE_PROPERTIES = {
     MODEL_PHILIPS_LIGHT_HBULB: AVAILABLE_PROPERTIES_COMMON + ["bri"],
@@ -121,17 +118,7 @@ class PhilipsWhiteBulb(Device):
         """Retrieve properties."""
 
         properties = AVAILABLE_PROPERTIES[self.model]
-        values = self.send("get_prop", properties)
-
-        properties_count = len(properties)
-        values_count = len(values)
-        if properties_count != values_count:
-            _LOGGER.debug(
-                "Count (%s) of requested properties does not match the "
-                "count (%s) of received values.",
-                properties_count,
-                values_count,
-            )
+        values = self.get_properties(properties)
 
         return PhilipsBulbStatus(defaultdict(lambda: None, zip(properties, values)))
 

--- a/miio/philips_eyecare.py
+++ b/miio/philips_eyecare.py
@@ -133,16 +133,7 @@ class PhilipsEyecare(Device):
             "bls",
             "dvalue",
         ]
-        values = self.send("get_prop", properties)
-        properties_count = len(properties)
-        values_count = len(values)
-        if properties_count != values_count:
-            _LOGGER.debug(
-                "Count (%s) of requested properties does not match the "
-                "count (%s) of received values.",
-                properties_count,
-                values_count,
-            )
+        values = self.get_properties(properties)
 
         return PhilipsEyecareStatus(defaultdict(lambda: None, zip(properties, values)))
 

--- a/miio/philips_moonlight.py
+++ b/miio/philips_moonlight.py
@@ -164,17 +164,7 @@ class PhilipsMoonlight(Device):
             "mb",
             "wkp",
         ]
-        values = self.send("get_prop", properties)
-
-        properties_count = len(properties)
-        values_count = len(values)
-        if properties_count != values_count:
-            _LOGGER.debug(
-                "Count (%s) of requested properties does not match the "
-                "count (%s) of received values.",
-                properties_count,
-                values_count,
-            )
+        values = self.get_properties(properties)
 
         return PhilipsMoonlightStatus(
             defaultdict(lambda: None, zip(properties, values))

--- a/miio/philips_rwread.py
+++ b/miio/philips_rwread.py
@@ -14,7 +14,7 @@ _LOGGER = logging.getLogger(__name__)
 MODEL_PHILIPS_LIGHT_RWREAD = "philips.light.rwread"
 
 AVAILABLE_PROPERTIES = {
-    MODEL_PHILIPS_LIGHT_RWREAD: ["power", "bright", "dv", "snm", "flm", "chl", "flmv"],
+    MODEL_PHILIPS_LIGHT_RWREAD: ["power", "bright", "dv", "snm", "flm", "chl", "flmv"]
 }
 
 
@@ -139,16 +139,7 @@ class PhilipsRwread(Device):
     def status(self) -> PhilipsRwreadStatus:
         """Retrieve properties."""
         properties = AVAILABLE_PROPERTIES[self.model]
-        values = self.send("get_prop", properties)
-        properties_count = len(properties)
-        values_count = len(values)
-        if properties_count != values_count:
-            _LOGGER.debug(
-                "Count (%s) of requested properties does not match the "
-                "count (%s) of received values.",
-                properties_count,
-                values_count,
-            )
+        values = self.get_properties(properties)
 
         return PhilipsRwreadStatus(defaultdict(lambda: None, zip(properties, values)))
 

--- a/miio/powerstrip.py
+++ b/miio/powerstrip.py
@@ -198,17 +198,7 @@ class PowerStrip(Device):
     def status(self) -> PowerStripStatus:
         """Retrieve properties."""
         properties = AVAILABLE_PROPERTIES[self.model]
-        values = self.send("get_prop", properties)
-
-        properties_count = len(properties)
-        values_count = len(values)
-        if properties_count != values_count:
-            _LOGGER.debug(
-                "Count (%s) of requested properties does not match the "
-                "count (%s) of received values.",
-                properties_count,
-                values_count,
-            )
+        values = self.get_properties(properties)
 
         return PowerStripStatus(defaultdict(lambda: None, zip(properties, values)))
 

--- a/miio/pwzn_relay.py
+++ b/miio/pwzn_relay.py
@@ -130,18 +130,7 @@ class PwznRelay(Device):
         """Retrieve properties."""
 
         properties = AVAILABLE_PROPERTIES[self.model].copy()
-
-        values = self.send("get_prop", properties)
-
-        properties_count = len(properties)
-        values_count = len(values)
-        if properties_count != values_count:
-            _LOGGER.debug(
-                "Count (%s) of requested properties does not match the "
-                "count (%s) of received values.",
-                properties_count,
-                values_count,
-            )
+        values = self.get_properties(properties)
 
         return PwznRelayStatus(defaultdict(lambda: None, zip(properties, values)))
 

--- a/miio/tests/dummies.py
+++ b/miio/tests/dummies.py
@@ -63,7 +63,7 @@ class DummyMiotDevice(DummyDevice):
         self.state = [{"did": k, "value": v, "code": 0} for k, v in self.state.items()]
         super().__init__(*args, **kwargs)
 
-    def get_properties(self):
+    def get_properties_for_mapping(self):
         return self.state
 
     def set_property(self, property_key: str, value):

--- a/miio/tests/test_device.py
+++ b/miio/tests/test_device.py
@@ -1,0 +1,18 @@
+import math
+
+import pytest
+
+from miio import Device
+
+
+@pytest.mark.parametrize("max_properties", [None, 1, 15])
+def test_get_properties_splitting(mocker, max_properties):
+    properties = [i for i in range(20)]
+
+    send = mocker.patch("miio.Device.send")
+    d = Device("127.0.0.1", "68ffffffffffffffffffffffffffffff")
+    d.get_properties(properties, max_properties=max_properties)
+
+    if max_properties is None:
+        max_properties = len(properties)
+    assert send.call_count == math.ceil(len(properties) / max_properties)

--- a/miio/toiletlid.py
+++ b/miio/toiletlid.py
@@ -119,16 +119,8 @@ class Toiletlid(Device):
     def status(self) -> ToiletlidStatus:
         """Retrieve properties."""
         properties = AVAILABLE_PROPERTIES[self.model]
-        values = self.send("get_prop", properties)
-        properties_count = len(properties)
-        values_count = len(values)
-        if properties_count != values_count:
-            _LOGGER.error(
-                "Count (%s) of requested properties does not match the "
-                "count (%s) of received values.",
-                properties_count,
-                values_count,
-            )
+        values = self.get_properties(properties)
+
         color = self.get_ambient_light()
         return ToiletlidStatus(dict(zip(properties, values), ambient_light=color))
 

--- a/miio/viomivacuum.py
+++ b/miio/viomivacuum.py
@@ -233,7 +233,7 @@ class ViomiVacuum(Device):
             "has_newmap",
         ]
 
-        values = self.send("get_prop", properties)
+        values = self.get_properties(properties)
 
         return ViomiVacuumStatus(defaultdict(lambda: None, zip(properties, values)))
 

--- a/miio/waterpurifier.py
+++ b/miio/waterpurifier.py
@@ -183,21 +183,7 @@ class WaterPurifier(Device):
         ]
 
         _props_per_request = 1
-        _props = properties.copy()
-        values = []
-        while _props:
-            values.extend(self.send("get_prop", _props[:_props_per_request]))
-            _props[:] = _props[_props_per_request:]
-
-        properties_count = len(properties)
-        values_count = len(values)
-        if properties_count != values_count:
-            _LOGGER.error(
-                "Count (%s) of requested properties does not match the "
-                "count (%s) of received values.",
-                properties_count,
-                values_count,
-            )
+        values = self.get_properties(properties, max_properties=_props_per_request)
 
         return WaterPurifierStatus(dict(zip(properties, values)))
 

--- a/miio/yeelight.py
+++ b/miio/yeelight.py
@@ -145,7 +145,7 @@ class Yeelight(Device):
             "save_state",
         ]
 
-        values = self.send("get_prop", properties)
+        values = self.get_properties(properties)
 
         return YeelightStatus(dict(zip(properties, values)))
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps=
   pytest
   pytest-cov
+  pytest-mock
   voluptuous
 commands=
     py.test --cov --cov-config=tox.ini miio


### PR DESCRIPTION
This will move common handling for property request splitting,
and verifying the results, into the Device class.

Also, add tests for this functionality.