### PR TITLE
WIP: improve miotdevice API, add gosund plug support (cuco.plug.cp1)

### DIFF
--- a/miio/__init__.py
+++ b/miio/__init__.py
@@ -22,6 +22,7 @@ from miio.device import Device
 from miio.exceptions import DeviceError, DeviceException
 from miio.fan import Fan, FanP5, FanSA1, FanV2, FanZA1, FanZA4
 from miio.gateway import Gateway
+from miio.gosund_plug import GosundPlug
 from miio.heater import Heater
 from miio.philips_bulb import PhilipsBulb, PhilipsWhiteBulb
 from miio.philips_eyecare import PhilipsEyecare

--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -255,16 +255,6 @@ class AirPurifierMiotStatus:
 class AirPurifierMiot(MiotDevice):
     """Main class representing the air purifier which uses MIoT protocol."""
 
-    def __init__(
-        self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-    ) -> None:
-        super().__init__(_MAPPING, ip, token, start_id, debug, lazy_discover)
-
     @command(
         default_output=format_output(
             "",
@@ -297,7 +287,7 @@ class AirPurifierMiot(MiotDevice):
         return AirPurifierMiotStatus(
             {
                 prop["did"]: prop["value"] if prop["code"] == 0 else None
-                for prop in self.get_properties_for_mapping()
+                for prop in self.get_properties_for_mapping(_MAPPING)
             }
         )
 

--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -294,12 +294,12 @@ class AirPurifierMiot(MiotDevice):
     @command(default_output=format_output("Powering on"))
     def on(self):
         """Power on."""
-        return self.set_property(_MAPPING, "power", True)
+        return self.set_property_from_mapping(_MAPPING, "power", True)
 
     @command(default_output=format_output("Powering off"))
     def off(self):
         """Power off."""
-        return self.set_property(_MAPPING, "power", False)
+        return self.set_property_from_mapping(_MAPPING, "power", False)
 
     @command(
         click.argument("level", type=int),
@@ -309,7 +309,7 @@ class AirPurifierMiot(MiotDevice):
         """Set fan level."""
         if level < 1 or level > 3:
             raise AirPurifierMiotException("Invalid fan level: %s" % level)
-        return self.set_property(_MAPPING, "fan_level", level)
+        return self.set_property_from_mapping(_MAPPING, "fan_level", level)
 
     @command(
         click.argument("rpm", type=int),
@@ -323,7 +323,7 @@ class AirPurifierMiot(MiotDevice):
                 "Invalid favorite motor speed: %s. Must be between 300 and 2300 and divisible by 10"
                 % rpm
             )
-        return self.set_property(_MAPPING, "favorite_rpm", rpm)
+        return self.set_property_from_mapping(_MAPPING, "favorite_rpm", rpm)
 
     @command(
         click.argument("volume", type=int),
@@ -335,7 +335,7 @@ class AirPurifierMiot(MiotDevice):
             raise AirPurifierMiotException(
                 "Invalid volume: %s. Must be between 0 and 100" % volume
             )
-        return self.set_property(_MAPPING, "buzzer_volume", volume)
+        return self.set_property_from_mapping(_MAPPING, "buzzer_volume", volume)
 
     @command(
         click.argument("mode", type=EnumType(OperationMode, False)),
@@ -343,7 +343,7 @@ class AirPurifierMiot(MiotDevice):
     )
     def set_mode(self, mode: OperationMode):
         """Set mode."""
-        return self.set_property(_MAPPING, "mode", mode.value)
+        return self.set_property_from_mapping(_MAPPING, "mode", mode.value)
 
     @command(
         click.argument("level", type=int),
@@ -356,7 +356,7 @@ class AirPurifierMiot(MiotDevice):
         if level < 0 or level > 14:
             raise AirPurifierMiotException("Invalid favorite level: %s" % level)
 
-        return self.set_property(_MAPPING, "favorite_level", level)
+        return self.set_property_from_mapping(_MAPPING, "favorite_level", level)
 
     @command(
         click.argument("brightness", type=EnumType(LedBrightness, False)),
@@ -364,7 +364,9 @@ class AirPurifierMiot(MiotDevice):
     )
     def set_led_brightness(self, brightness: LedBrightness):
         """Set led brightness."""
-        return self.set_property(_MAPPING, "led_brightness", brightness.value)
+        return self.set_property_from_mapping(
+            _MAPPING, "led_brightness", brightness.value
+        )
 
     @command(
         click.argument("led", type=bool),
@@ -374,7 +376,7 @@ class AirPurifierMiot(MiotDevice):
     )
     def set_led(self, led: bool):
         """Turn led on/off."""
-        return self.set_property(_MAPPING, "led", led)
+        return self.set_property_from_mapping(_MAPPING, "led", led)
 
     @command(
         click.argument("buzzer", type=bool),
@@ -384,7 +386,7 @@ class AirPurifierMiot(MiotDevice):
     )
     def set_buzzer(self, buzzer: bool):
         """Set buzzer on/off."""
-        return self.set_property(_MAPPING, "buzzer", buzzer)
+        return self.set_property_from_mapping(_MAPPING, "buzzer", buzzer)
 
     @command(
         click.argument("lock", type=bool),
@@ -394,4 +396,4 @@ class AirPurifierMiot(MiotDevice):
     )
     def set_child_lock(self, lock: bool):
         """Set child lock on/off."""
-        return self.set_property(_MAPPING, "child_lock", lock)
+        return self.set_property_from_mapping(_MAPPING, "child_lock", lock)

--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -294,12 +294,12 @@ class AirPurifierMiot(MiotDevice):
     @command(default_output=format_output("Powering on"))
     def on(self):
         """Power on."""
-        return self.set_property("power", True)
+        return self.set_property(_MAPPING, "power", True)
 
     @command(default_output=format_output("Powering off"))
     def off(self):
         """Power off."""
-        return self.set_property("power", False)
+        return self.set_property(_MAPPING, "power", False)
 
     @command(
         click.argument("level", type=int),
@@ -309,7 +309,7 @@ class AirPurifierMiot(MiotDevice):
         """Set fan level."""
         if level < 1 or level > 3:
             raise AirPurifierMiotException("Invalid fan level: %s" % level)
-        return self.set_property("fan_level", level)
+        return self.set_property(_MAPPING, "fan_level", level)
 
     @command(
         click.argument("rpm", type=int),
@@ -323,7 +323,7 @@ class AirPurifierMiot(MiotDevice):
                 "Invalid favorite motor speed: %s. Must be between 300 and 2300 and divisible by 10"
                 % rpm
             )
-        return self.set_property("favorite_rpm", rpm)
+        return self.set_property(_MAPPING, "favorite_rpm", rpm)
 
     @command(
         click.argument("volume", type=int),
@@ -335,7 +335,7 @@ class AirPurifierMiot(MiotDevice):
             raise AirPurifierMiotException(
                 "Invalid volume: %s. Must be between 0 and 100" % volume
             )
-        return self.set_property("buzzer_volume", volume)
+        return self.set_property(_MAPPING, "buzzer_volume", volume)
 
     @command(
         click.argument("mode", type=EnumType(OperationMode, False)),
@@ -343,7 +343,7 @@ class AirPurifierMiot(MiotDevice):
     )
     def set_mode(self, mode: OperationMode):
         """Set mode."""
-        return self.set_property("mode", mode.value)
+        return self.set_property(_MAPPING, "mode", mode.value)
 
     @command(
         click.argument("level", type=int),
@@ -356,7 +356,7 @@ class AirPurifierMiot(MiotDevice):
         if level < 0 or level > 14:
             raise AirPurifierMiotException("Invalid favorite level: %s" % level)
 
-        return self.set_property("favorite_level", level)
+        return self.set_property(_MAPPING, "favorite_level", level)
 
     @command(
         click.argument("brightness", type=EnumType(LedBrightness, False)),
@@ -364,7 +364,7 @@ class AirPurifierMiot(MiotDevice):
     )
     def set_led_brightness(self, brightness: LedBrightness):
         """Set led brightness."""
-        return self.set_property("led_brightness", brightness.value)
+        return self.set_property(_MAPPING, "led_brightness", brightness.value)
 
     @command(
         click.argument("led", type=bool),
@@ -374,7 +374,7 @@ class AirPurifierMiot(MiotDevice):
     )
     def set_led(self, led: bool):
         """Turn led on/off."""
-        return self.set_property("led", led)
+        return self.set_property(_MAPPING, "led", led)
 
     @command(
         click.argument("buzzer", type=bool),
@@ -384,7 +384,7 @@ class AirPurifierMiot(MiotDevice):
     )
     def set_buzzer(self, buzzer: bool):
         """Set buzzer on/off."""
-        return self.set_property("buzzer", buzzer)
+        return self.set_property(_MAPPING, "buzzer", buzzer)
 
     @command(
         click.argument("lock", type=bool),
@@ -394,4 +394,4 @@ class AirPurifierMiot(MiotDevice):
     )
     def set_child_lock(self, lock: bool):
         """Set child lock on/off."""
-        return self.set_property("child_lock", lock)
+        return self.set_property(_MAPPING, "child_lock", lock)

--- a/miio/gosund_plug.py
+++ b/miio/gosund_plug.py
@@ -1,0 +1,35 @@
+import logging
+from dataclasses import dataclass, field
+
+from .click_common import command, format_output
+from .miot_device import MiotDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class GosundPlugStatus:
+    _max_properties = 1
+    state: bool = field(metadata={"siid": 2, "piid": 1})
+
+
+class GosundPlug(MiotDevice):
+    """Support for gosund miot plug (cuco.plug.cp1)."""
+
+    _MAPPING = GosundPlugStatus
+
+    @command()
+    def status(self) -> GosundPlugStatus:
+        """Return current state of the plug."""
+
+        return self.get_properties_for_dataclass(GosundPlugStatus)
+
+    @command(default_output=format_output("Powering on"))
+    def on(self):
+        """Power on."""
+        return self.set_property(state=True)
+
+    @command(default_output=format_output("Powering off"))
+    def off(self):
+        """Power off."""
+        return self.set_property(state=False)

--- a/miio/miot_device.py
+++ b/miio/miot_device.py
@@ -1,8 +1,23 @@
 import logging
+from dataclasses import dataclass, field
 
+from .click_common import command
 from .device import Device
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class MiotInfo:
+    """Container for common MiotInfo service."""
+
+    _siid = 1
+    _max_properties = 1
+
+    manufacturer: str = field(metadata={"piid": 1})
+    model: str = field(metadata={"piid": 2})
+    serial_number: str = field(metadata={"piid": 3})
+    firmware_version: str = field(metadata={"piid": 4})
 
 
 class MiotDevice(Device):
@@ -10,23 +25,48 @@ class MiotDevice(Device):
 
     def __init__(
         self,
-        mapping: dict,
         ip: str = None,
         token: str = None,
         start_id: int = 0,
         debug: int = 0,
         lazy_discover: bool = True,
     ) -> None:
-        self.mapping = mapping
         super().__init__(ip, token, start_id, debug, lazy_discover)
 
-    def get_properties_for_mapping(self) -> list:
+    @command()
+    def miot_info(self) -> MiotInfo:
+        """Return common miot information."""
+        return self.get_properties_for_dataclass(MiotInfo)
+
+    def get_properties_for_dataclass(self, cls):
+        """Run a query to fill property container."""
+        fields = cls.__dataclass_fields__
+        property_mapping = {}
+
+        for field_name in fields:
+            field_meta = fields[field_name].metadata
+            siid = field_meta.get("siid", cls._siid)
+            piid = field_meta["piid"]
+            property_mapping[field_name] = {"siid": siid, "piid": piid}
+
+        response = {
+            prop["did"]: prop["value"] if prop["code"] == 0 else None
+            for prop in self.get_properties_for_mapping(
+                property_mapping, max_properties=cls._max_properties
+            )
+        }
+
+        return cls(**response)
+
+    def get_properties_for_mapping(
+        self, property_mapping, *, max_properties=15
+    ) -> list:
         """Retrieve raw properties based on mapping."""
 
         # We send property key in "did" because it's sent back via response and we can identify the property.
-        properties = [{"did": k, **v} for k, v in self.mapping.items()]
+        properties = [{"did": k, **v} for k, v in property_mapping.items()]
 
-        return self.get_properties(properties, max_properties=15)
+        return self.get_properties(properties, max_properties=max_properties)
 
     def set_property(self, property_key: str, value):
         """Sets property value."""

--- a/miio/miot_device.py
+++ b/miio/miot_device.py
@@ -78,10 +78,10 @@ class MiotDevice(Device):
 
         return self.get_properties(properties, max_properties=max_properties)
 
-    def set_property(self, property_key: str, value):
+    def set_property(self, property_mapping, property_key: str, value):
         """Sets property value."""
 
         return self.send(
             "set_properties",
-            [{"did": property_key, **self.mapping[property_key], "value": value}],
+            [{"did": property_key, **property_mapping[property_key], "value": value}],
         )

--- a/miio/tests/dummies.py
+++ b/miio/tests/dummies.py
@@ -63,7 +63,7 @@ class DummyMiotDevice(DummyDevice):
         self.state = [{"did": k, "value": v, "code": 0} for k, v in self.state.items()]
         super().__init__(*args, **kwargs)
 
-    def get_properties_for_mapping(self):
+    def get_properties_for_mapping(self, mapping=None):
         return self.state
 
     def set_property(self, property_key: str, value):


### PR DESCRIPTION
This PR aims to add better support for miot devices, and build a common API to simplify contributions for new devices.

* add miot_info() to get the common information from the device
  * this includes manufacturer, model, firmeware version and serial number

* add get_properties_for_dataclass(cls) which allows easy implementation for get_properties mappings
  * each field() can define metadata containing siid and piid, these are mapped automatically to the response container
  * _siid can be used to define common siid, _max_properties can be used to set number of maximum properties per request

* "old" get_properties_for_mapping() requires explicit passing of the mapping, no more passing over `__init__`

* rename old set_property to set_property_from_mapping
    * add set_properties_from_dataclass (allows passing a mapping object with all wanted values at once)
    
    ```
    device.set_properties_from_dataclass(GosundPlugStatus(state=True, some_other_property=123)
    ```
    
    * new set_property helper which takes kwargs that are used automatically with the help of the class-given _MAPPING:
    
    ```
    device.set_property(state=True)
    ```

* Add support for gosund miot plug (cuco.plug.cp1) to show how the API could work.

## TODO
* Naming of helper methods, `_MAPPING`
* Unit tests for all MiotDevice interfaces
* Split set property requests based on `_max_properties`.
* python 3.6 compatibility (dataclasses are available only python 3.7+)
* helper to create fields with wanted metadata, maybe `add_property(piid, siid)`?
* document the API, figure out the best way to do conversions, if needed.
* handling read-only/write-only properties
* common API for actions