### PR TITLE
Add PayloadDecodeException and DeviceInfoUnavailableException

### DIFF
--- a/miio/device.py
+++ b/miio/device.py
@@ -5,6 +5,7 @@ from typing import Any, Optional  # noqa: F401
 import click
 
 from .click_common import DeviceGroupMeta, LiteralParamType, command, format_output
+from .exceptions import DeviceInfoUnavailableException, PayloadDecodeException
 from .miioprotocol import MiIOProtocol
 
 _LOGGER = logging.getLogger(__name__)
@@ -177,7 +178,12 @@ class Device(metaclass=DeviceGroupMeta):
         """Get miIO protocol information from the device.
         This includes information about connected wlan network,
         and hardware and software versions."""
-        return DeviceInfo(self._protocol.send("miIO.info"))
+        try:
+            return DeviceInfo(self._protocol.send("miIO.info"))
+        except PayloadDecodeException as ex:
+            raise DeviceInfoUnavailableException(
+                "Unable to request miIO.info from the device"
+            ) from ex
 
     def update(self, url: str, md5: str):
         """Start an OTA update."""

--- a/miio/exceptions.py
+++ b/miio/exceptions.py
@@ -2,8 +2,28 @@ class DeviceException(Exception):
     """Exception wrapping any communication errors with the device."""
 
 
+class PayloadDecodeException(DeviceException):
+    """Exception for failures in payload decoding.
+
+    This is raised when the json payload cannot be decoded,
+    indicating invalid response from a device.
+    """
+
+
+class DeviceInfoUnavailableException(DeviceException):
+    """Exception raised when requesting miio.info fails.
+
+    This allows users to gracefully handle cases where the information unavailable.
+    This can happen, for instance, when the device has no cloud access.
+    """
+
+
 class DeviceError(DeviceException):
-    """Exception communicating an error delivered by the target device."""
+    """Exception communicating an error delivered by the target device.
+
+    The device given error code and message can be accessed with
+     `code` and `message` variables.
+     """
 
     def __init__(self, error):
         self.code = error.get("code")

--- a/miio/protocol.py
+++ b/miio/protocol.py
@@ -38,6 +38,8 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import padding
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
+from miio.exceptions import PayloadDecodeException
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -193,7 +195,10 @@ class EncryptionAdapter(Adapter):
                 # log the error when decrypted bytes couldn't be loaded
                 # after trying all quirk adaptions
                 if i == len(decrypted_quirks) - 1:
-                    _LOGGER.error("unable to parse json '%s': %s", decoded, ex)
+                    _LOGGER.debug("Unable to parse json '%s': %s", decoded, ex)
+                    raise PayloadDecodeException(
+                        "Unable to parse message payload"
+                    ) from ex
 
         return None
 


### PR DESCRIPTION
Enables better control of error cases for downstream users:

* PayloadDecodeException gets raised if the payload cannot be decoded even after all quirks are tried
* DeviceInfoUnavailable gets raised by Device.info() if decoding the miIO.info payload fails

Related: https://github.com/home-assistant/core/pull/34225