### PR TITLE
Added support of Aqara Wireless Relay 2ch (LLKZMK11LM)

### DIFF
--- a/devtools/containers.py
+++ b/devtools/containers.py
@@ -163,12 +163,12 @@ class Service(DataClassJsonMixin):
     def as_code(self):
         s = ""
         s += f"class {pretty_name(self.description)}(MiOTService):\n"
-        s += f'    """\n'
+        s += '    """\n'
         s += f"    {self.description} ({self.type}) (siid: {self.iid})\n"
         s += f"    Events: {len(self.events)}\n"
         s += f"    Properties: {len(self.properties)}\n"
         s += f"    Actions: {len(self.actions)}\n"
-        s += f'    """\n\n'
+        s += '    """\n\n'
         s += "#### PROPERTIES ####\n"
         for property in self.properties:
             s += indent(property.as_code(self.iid))
@@ -188,10 +188,10 @@ class Device(DataClassJsonMixin):
 
     def as_code(self):
         s = ""
-        s += f'"""'
+        s += '"""'
         s += f"Support template for {self.description} ({self.type})\n\n"
         s += f"Contains {len(self.services)} services\n"
-        s += f'"""\n\n'
+        s += '"""\n\n'
 
         for serv in self.services:
             s += serv.as_code()

--- a/miio/gateway.py
+++ b/miio/gateway.py
@@ -42,7 +42,7 @@ class DeviceType(IntEnum):
     AqaraMotion = 52
     AqaraMagnet = 53
     AqaraRelayTwoChannels = 54
-    AqaraSqaureButton = 62
+    AqaraSquareButton = 62
 
 
 class AqaraRelayToggleValue(Enum):

--- a/miio/gateway.py
+++ b/miio/gateway.py
@@ -1,11 +1,11 @@
 import logging
 from datetime import datetime
-from enum import IntEnum
+from enum import IntEnum, Enum
 from typing import Optional
 
 import click
 
-from .click_common import command, format_output
+from .click_common import EnumType, command, format_output
 from .device import Device
 from .utils import brightness_and_color_to_int, int_to_brightness, int_to_rgb
 
@@ -34,12 +34,26 @@ class DeviceType(IntEnum):
     SwitchOneChannel = 9
     SensorHT = 10
     Plug = 11
+    SensorSmoke = 15
     AqaraHT = 19
     SwitchLiveOneChannel = 20
     SwitchLiveTwoChannels = 21
     AqaraSwitch = 51
     AqaraMotion = 52
     AqaraMagnet = 53
+    AqaraRelayTwoChannels = 54
+    AqaraSqaureButton = 62
+
+
+class AqaraRelayToggleValue(Enum):
+    toggle = "toggle"
+    on = "on"
+    off = "off"
+
+
+class AqaraRelayChannel(Enum):
+    first = "channel_0"
+    second = "channel_1"
 
 
 class Gateway(Device):
@@ -138,6 +152,28 @@ class Gateway(Device):
     def set_device_prop(self, sid, property, value):
         """Set the device property."""
         return self.send("set_device_prop", {"sid": sid, property: value})
+
+    @command(
+        click.argument("sid"),
+        click.argument("channel", type=EnumType(AqaraRelayChannel)),
+        click.argument("value", type=EnumType(AqaraRelayToggleValue))
+    )
+    def relay_toggle(self, sid, channel, value):
+        """Toggle Aqara Wireless Relay 2ch"""
+        return self.send('toggle_ctrl_neutral', [channel.value, value.value], extra_parameters={'sid': sid})[0]
+
+    @command(
+        click.argument("sid"),
+        click.argument("channel", type=EnumType(AqaraRelayChannel)),
+    )
+    def relay_get_state(self, sid, channel):
+        """Get the state of Aqara Wireless Relay 2ch for given sid"""
+        return self.send('get_device_prop_exp', [[sid, channel.value]])[0][0]
+
+    @command(click.argument("sid"))
+    def relay_get_load_power(self, sid):
+        """Get the the load power of Aqara Wireless Relay 2ch for given sid"""
+        return self.send('get_device_prop_exp', [[sid, 'load_power']])[0][0]
 
     @command()
     def clock(self):

--- a/miio/gateway.py
+++ b/miio/gateway.py
@@ -156,11 +156,15 @@ class Gateway(Device):
     @command(
         click.argument("sid"),
         click.argument("channel", type=EnumType(AqaraRelayChannel)),
-        click.argument("value", type=EnumType(AqaraRelayToggleValue))
+        click.argument("value", type=EnumType(AqaraRelayToggleValue)),
     )
     def relay_toggle(self, sid, channel, value):
         """Toggle Aqara Wireless Relay 2ch"""
-        return self.send('toggle_ctrl_neutral', [channel.value, value.value], extra_parameters={'sid': sid})[0]
+        return self.send(
+            "toggle_ctrl_neutral",
+            [channel.value, value.value],
+            extra_parameters={"sid": sid},
+        )[0]
 
     @command(
         click.argument("sid"),
@@ -168,12 +172,12 @@ class Gateway(Device):
     )
     def relay_get_state(self, sid, channel):
         """Get the state of Aqara Wireless Relay 2ch for given sid"""
-        return self.send('get_device_prop_exp', [[sid, channel.value]])[0][0]
+        return self.send("get_device_prop_exp", [[sid, channel.value]])[0][0]
 
     @command(click.argument("sid"))
     def relay_get_load_power(self, sid):
         """Get the the load power of Aqara Wireless Relay 2ch for given sid"""
-        return self.send('get_device_prop_exp', [[sid, 'load_power']])[0][0]
+        return self.send("get_device_prop_exp", [[sid, "load_power"]])[0][0]
 
     @command()
     def clock(self):

--- a/miio/gateway.py
+++ b/miio/gateway.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime
-from enum import IntEnum, Enum
+from enum import Enum, IntEnum
 from typing import Optional
 
 import click


### PR DESCRIPTION
Found commands here => https://github.com/igzero/xiaomigateway

Works as follows:

> $ miiocli gateway --ip 192.168.2.109 --token XXXX devices
> Running command devices
> [<Subdevice DeviceType.Cube: lumi.158d000103ec74 fw: 3 bat: 60>, <Subdevice DeviceType.SensorHT: lumi.158d00040e2330 fw: 2 bat: 60>, <Subdevice DeviceType.Cube: lumi.158d00010202de fw: 3 bat: 60>, <Subdevice DeviceType.Unknown62: lumi.158d000429d96f fw: 5 bat: 60>, <Subdevice DeviceType.AqaraHT: lumi.158d000465ade7 fw: 3 bat: 60>, <Subdevice DeviceType.Unknown15: lumi.158d0003f0d874 fw: 1 bat: 60>, <Subdevice DeviceType.Unknown54: lumi.158d0004454133 fw: 36 bat: 60>]
> $ miiocli gateway --ip 192.168.2.109 --token XXXX relay_get_state lumi.158d0004454133 first
> Running command relay_get_state
> on
> $ miiocli gateway --ip 192.168.2.109 --token XXXX relay_toggle lumi.158d0004454133 first toggle
> Running command relay_toggle
> ok
> $ miiocli gateway --ip 192.168.2.109 --token XXXX relay_toggle lumi.158d0004454133 second on
> Running command relay_toggle
> ok
> $ miiocli gateway --ip 192.168.2.109 --token XXXX relay_get_load_power lumi.158d0004454133
> Running command relay_get_load_power
> 0.06