### PR TITLE
Add new device type mappings, add note about 'used_for_public'

### DIFF
--- a/miio/gateway.py
+++ b/miio/gateway.py
@@ -84,7 +84,7 @@ class Gateway(Device):
     * toggle_plug
     * remove_all_bind
     * list_bind [0]
- 
+
     * self.get_prop("used_for_public") # Return the 'used_for_public' status, probably this has to do with developer mode.
     * self.set_prop("used_for_public", state) # Set the 'used_for_public' state, probably this has to do with developer mode.
 

--- a/miio/gateway.py
+++ b/miio/gateway.py
@@ -37,28 +37,30 @@ class DeviceType(IntEnum):
     """DeviceType matching using the values provided by Xiaomi."""
 
     Unknown = -1
-    Gateway = 0
+    Gateway = 0 # lumi.0
     Switch = 1
     Motion = 2
     Magnet = 3
     SwitchTwoChannels = 7
-    Cube = 8
+    Cube = 8                    # lumi.sensor_cube.v1
     SwitchOneChannel = 9
     SensorHT = 10
     Plug = 11
+    RemoteSwitchSingleV1 = 14   # lumi.sensor_86sw1.v1
     SensorSmoke = 15
-    AqaraHT = 19
+    AqaraHT = 19                # lumi.weather.v1
     SwitchLiveOneChannel = 20
     SwitchLiveTwoChannels = 21
     AqaraSwitch = 51
     AqaraMotion = 52
-    AqaraMagnet = 53
+    AqaraMagnet = 53            # lumi.sensor_magnet.aq2
     AqaraRelayTwoChannels = 54
-    AqaraSquareButton = 62
+    AqaraSquareButton = 62      # lumi.sensor_switch.aq3
     AqaraSwitchOneChannel = 63
     AqaraSwitchTwoChannels = 64
-    RemoteSwitchSingle = 134
-    RemoteSwitchDouble = 135
+    AqaraWallOutlet = 65        # lumi.ctrl_86plug.aq1
+    RemoteSwitchSingle = 134    # lumi.remote.b186acn01
+    RemoteSwitchDouble = 135    # lumi.remote.b286acn01
 
 
 @attr.s(auto_attribs=True)

--- a/miio/gateway.py
+++ b/miio/gateway.py
@@ -37,7 +37,7 @@ class DeviceType(IntEnum):
     """DeviceType matching using the values provided by Xiaomi."""
 
     Unknown = -1
-    Gateway = 0 # lumi.0
+    Gateway = 0                 # lumi.0
     Switch = 1
     Motion = 2
     Magnet = 3
@@ -87,8 +87,8 @@ class Gateway(Device):
     * remove_all_bind
     * list_bind [0]
 
-    * self.get_prop("used_for_public") # Return the 'used_for_public' status, probably this has to do with developer mode.
-    * self.set_prop("used_for_public", state) # Set the 'used_for_public' state, probably this has to do with developer mode.
+    * self.get_prop("used_for_public") # Return the 'used_for_public' status, return value: [0] or [1], probably this has to do with developer mode.
+    * self.set_prop("used_for_public", state) # Set the 'used_for_public' state, value: 0 or 1, probably this has to do with developer mode.
 
     * welcome
     * set_curtain_level

--- a/miio/gateway.py
+++ b/miio/gateway.py
@@ -43,7 +43,7 @@ class DeviceType(IntEnum):
     Magnet = 3
     SwitchTwoChannels = 7
     Cube = 8                    # lumi.sensor_cube.v1
-    SwitchOneChannel = 9
+    SwitchOneChannel = 9        # lumi.ctrl_neutral1.v1
     SensorHT = 10
     Plug = 11
     RemoteSwitchSingleV1 = 14   # lumi.sensor_86sw1.v1

--- a/miio/gateway.py
+++ b/miio/gateway.py
@@ -84,6 +84,9 @@ class Gateway(Device):
     * toggle_plug
     * remove_all_bind
     * list_bind [0]
+ 
+    * self.get_prop("used_for_public") # Return the 'used_for_public' status, probably this has to do with developer mode.
+    * self.set_prop("used_for_public", state) # Set the 'used_for_public' state, probably this has to do with developer mode.
 
     * welcome
     * set_curtain_level
@@ -236,16 +239,6 @@ class Gateway(Device):
             click.echo("Key must be of length 16, was %s" % len(key))
 
         return self.send("set_lumi_dpf_aes_key", [key])
-
-    @command()
-    def get_used_for_public(self):
-        """Return the 'used_for_public' status, probably this has to do with developer mode."""
-        return self.get_prop("used_for_public")
-
-    @command(click.argument("state"))
-    def set_used_for_public(self, state):
-        """Set the 'used_for_public' state, probably this has to do with developer mode."""
-        return self.set_prop("used_for_public", state)
 
     @command()
     def timezone(self):

--- a/miio/gateway.py
+++ b/miio/gateway.py
@@ -37,30 +37,30 @@ class DeviceType(IntEnum):
     """DeviceType matching using the values provided by Xiaomi."""
 
     Unknown = -1
-    Gateway = 0                 # lumi.0
+    Gateway = 0  # lumi.0
     Switch = 1
     Motion = 2
     Magnet = 3
     SwitchTwoChannels = 7
-    Cube = 8                    # lumi.sensor_cube.v1
-    SwitchOneChannel = 9        # lumi.ctrl_neutral1.v1
+    Cube = 8  # lumi.sensor_cube.v1
+    SwitchOneChannel = 9  # lumi.ctrl_neutral1.v1
     SensorHT = 10
     Plug = 11
-    RemoteSwitchSingleV1 = 14   # lumi.sensor_86sw1.v1
+    RemoteSwitchSingleV1 = 14  # lumi.sensor_86sw1.v1
     SensorSmoke = 15
-    AqaraHT = 19                # lumi.weather.v1
+    AqaraHT = 19  # lumi.weather.v1
     SwitchLiveOneChannel = 20
     SwitchLiveTwoChannels = 21
     AqaraSwitch = 51
     AqaraMotion = 52
-    AqaraMagnet = 53            # lumi.sensor_magnet.aq2
+    AqaraMagnet = 53  # lumi.sensor_magnet.aq2
     AqaraRelayTwoChannels = 54
-    AqaraSquareButton = 62      # lumi.sensor_switch.aq3
+    AqaraSquareButton = 62  # lumi.sensor_switch.aq3
     AqaraSwitchOneChannel = 63
     AqaraSwitchTwoChannels = 64
-    AqaraWallOutlet = 65        # lumi.ctrl_86plug.aq1
-    RemoteSwitchSingle = 134    # lumi.remote.b186acn01
-    RemoteSwitchDouble = 135    # lumi.remote.b286acn01
+    AqaraWallOutlet = 65  # lumi.ctrl_86plug.aq1
+    RemoteSwitchSingle = 134  # lumi.remote.b186acn01
+    RemoteSwitchDouble = 135  # lumi.remote.b286acn01
 
 
 @attr.s(auto_attribs=True)

--- a/miio/gateway.py
+++ b/miio/gateway.py
@@ -238,6 +238,16 @@ class Gateway(Device):
         return self.send("set_lumi_dpf_aes_key", [key])
 
     @command()
+    def get_used_for_public(self):
+        """Return the 'used_for_public' status, probably this has to do with developer mode."""
+        return self.get_prop("used_for_public")
+
+    @command(click.argument("state"))
+    def set_used_for_public(self, state):
+        """Set the 'used_for_public' state, probably this has to do with developer mode."""
+        return self.set_prop("used_for_public", state)
+
+    @command()
     def timezone(self):
         """Get current timezone."""
         return self.get_prop("tzone_sec")


### PR DESCRIPTION
Not entirely sure what this command does, but I think it has to do with enabeling/disabeling developer mode.
In any case, I came accross this command while sniffing gateway trafic