### PR TITLE
add firmware property + convert device list to dict

### DIFF
--- a/miio/gateway.py
+++ b/miio/gateway.py
@@ -640,6 +640,11 @@ class SubDevice:
         return self.type.name
 
     @property
+    def firmware_version(self):
+        """Return the firmware version."""
+        return self._fw_ver
+
+    @property
     def battery(self):
         """Return the battery level."""
         return self._battery

--- a/miio/gateway.py
+++ b/miio/gateway.py
@@ -126,7 +126,7 @@ class Gateway(Device):
         self._radio = GatewayRadio(parent=self)
         self._zigbee = GatewayZigbee(parent=self)
         self._light = GatewayLight(parent=self)
-        self._devices = []
+        self._devices = {}
 
     @property
     def alarm(self) -> "GatewayAlarm":
@@ -151,7 +151,7 @@ class Gateway(Device):
 
     @property
     def devices(self):
-        """Return a list of the already discovered devices."""
+        """Return a dict of the already discovered devices."""
         return self._devices
 
     @command()
@@ -172,7 +172,7 @@ class Gateway(Device):
             DeviceType.AqaraWallOutlet: AqaraWallOutlet,
         }
         devices_raw = self.get_prop("device_list")
-        self._devices = []
+        self._devices = {}
 
         for x in range(0, len(devices_raw), 5):
             # Extract discovered information
@@ -203,7 +203,7 @@ class Gateway(Device):
 
             # Initialize and save the subdevice, ignoring the gateway itself
             if device_type != DeviceType.Gateway:
-                self._devices.append(subdevice_cls(self, dev_info))
+                self._devices[dev_info.sid] = subdevice_cls(self, dev_info)
 
         return self._devices
 


### PR DESCRIPTION
This adds a firmware_version property to the subdevice class since HomeAssistant needs to acces the firmware_version property for the device registry.
If directly accesed like `subdevice._fw_ver` it results in a pylint error: `W0212: Access to a protected member _fw_ver of a client class (protected-access)`

I made a base implementation for subdevices in HomeAssistant that also registers all subdevices in the device registry, the PR is here: https://github.com/home-assistant/core/pull/36539/files

It also converts the self._devices from a list to a dict with as key the sid of the subdevice.
This is done because this will probably be needed once a callback meganism is implemented, the server will then need an easy way to get the correct subdevice when it knows the sid, instead of having to loop over the whole list and check the sid in this way direct key acces can be used.
This is related to https://github.com/rytilahti/python-miio/pull/709
