### PR TITLE
Gateway: add name + model property to subdevice & add loads of subdevices

### DIFF
--- a/miio/gateway.py
+++ b/miio/gateway.py
@@ -46,19 +46,21 @@ class DeviceType(IntEnum):
     SwitchOneChannel = 9  # lumi.ctrl_neutral1.v1
     SensorHT = 10  # lumi.sensor_ht
     Plug = 11  # lumi.plug
-    RemoteSwitchDoubleV1 = 12  # lumi.sensor_86sw2
+    RemoteSwitchDoubleV1 = 12  # lumi.sensor_86sw2.v1
+    Curtain = 13  # lumi.curtain
     RemoteSwitchSingleV1 = 14  # lumi.sensor_86sw1.v1
     SensorSmoke = 15  # lumi.sensor_smoke
-    AqaraHT = 19  # lumi.weather.v1
     AqaraWallOutletV1 = 17  # lumi.ctrl_86plug.v1
+    SensorNatgas = 18  # lumi.sensor_natgas
+    AqaraHT = 19  # lumi.weather.v1
     SwitchLiveOneChannel = 20  # lumi.ctrl_ln1
     SwitchLiveTwoChannels = 21  # lumi.ctrl_ln2
     AqaraSwitch = 51  # lumi.sensor_switch.aq2
     AqaraMotion = 52  # lumi.sensor_motion.aq2
     AqaraMagnet = 53  # lumi.sensor_magnet.aq2
+    AqaraRelayTwoChannels = 54  # lumi.relay.c2acn01
     AqaraWaterLeak = 55  # lumi.sensor_wleak.aq1
     AqaraVibration = 56  # lumi.vibration.aq1
-    AqaraRelayTwoChannels = 54  # lumi.relay.c2acn01
     AqaraSquareButtonV3 = 62  # lumi.sensor_switch.aq3
     AqaraSwitchOneChannel = 63  # lumi.ctrl_ln1.aq1
     AqaraSwitchTwoChannels = 64  # lumi.ctrl_ln2.aq1
@@ -68,8 +70,6 @@ class DeviceType(IntEnum):
     RemoteSwitchDouble = 135  # lumi.remote.b286acn01
 
 
-# 13 - lumi.curtain
-# 18 - lumi.sensor_natgas
 # 59 - lumi.lock.aq1
 # 66 - lumi.light.aqcn02
 # 68 - lumi.sensor_cube.aqgl01
@@ -210,18 +210,20 @@ class Gateway(Device):
             DeviceType.SensorHT: SensorHT,
             DeviceType.Plug: Plug,
             DeviceType.RemoteSwitchDoubleV1: RemoteSwitchDoubleV1,
+            DeviceType.Curtain: Curtain,
             DeviceType.RemoteSwitchSingleV1: RemoteSwitchSingleV1,
             DeviceType.SensorSmoke: SensorSmoke,
-            DeviceType.AqaraHT: AqaraHT,
             DeviceType.AqaraWallOutletV1: AqaraWallOutletV1,
+            DeviceType.SensorNatgas: SensorNatgas,
+            DeviceType.AqaraHT: AqaraHT,
             DeviceType.SwitchLiveOneChannel: SwitchLiveOneChannel,
             DeviceType.SwitchLiveTwoChannels: SwitchLiveTwoChannels,
             DeviceType.AqaraSwitch: AqaraSwitch,
             DeviceType.AqaraMotion: AqaraMotion,
             DeviceType.AqaraMagnet: AqaraMagnet,
+            DeviceType.AqaraRelayTwoChannels: AqaraRelayTwoChannels,
             DeviceType.AqaraWaterLeak: AqaraWaterLeak,
             DeviceType.AqaraVibration: AqaraVibration,
-            DeviceType.AqaraRelayTwoChannels: AqaraRelayTwoChannels,
             DeviceType.AqaraSquareButtonV3: AqaraSquareButtonV3,
             DeviceType.AqaraSwitchOneChannel: AqaraSwitchOneChannel,
             DeviceType.AqaraSwitchTwoChannels: AqaraSwitchTwoChannels,
@@ -705,8 +707,6 @@ class SubDevice:
     @property
     def name(self):
         """Return the name of the device."""
-        if self._name == "unknown":
-            self._name = self.device_type
         return f"{self._name} ({self.sid})"
 
     @property
@@ -977,6 +977,15 @@ class RemoteSwitchDoubleV1(SubDevice):
     _name = "Remote switch double"
 
 
+class Curtain(SubDevice):
+    """Subdevice Curtain specific properties and methods"""
+
+    properties = []
+    _zigbee_model = "lumi.curtain"
+    _model = "ZNCLDJ11LM"
+    _name = "Curtain"
+
+
 class RemoteSwitchSingleV1(SubDevice):
     """Subdevice RemoteSwitchSingleV1 specific properties and methods"""
 
@@ -992,7 +1001,25 @@ class SensorSmoke(SubDevice):
     properties = []
     _zigbee_model = "lumi.sensor_smoke"
     _model = "JTYJ-GD-01LM/BW"
-    _name = "Honeywell Smoke Detector"
+    _name = "Honeywell smoke detector"
+
+
+class AqaraWallOutletV1(SubDevice):
+    """Subdevice AqaraWallOutletV1 specific properties and methods"""
+
+    properties = []
+    _zigbee_model = "lumi.ctrl_86plug.v1"
+    _model = "QBCZ11LM"
+    _name = "Wall outlet"
+
+
+class SensorNatgas(SubDevice):
+    """Subdevice SensorNatgas specific properties and methods"""
+
+    properties = []
+    _zigbee_model = "lumi.sensor_natgas"
+    _model = "JTQJ-BF-01LM/BW"
+    _name = "Honeywell natural gas detector"
 
 
 class AqaraHT(SubDevice):
@@ -1025,15 +1052,6 @@ class AqaraHT(SubDevice):
                 "One or more unexpected results while "
                 "fetching properties %s: %s" % (self.properties, values)
             ) from ex
-
-
-class AqaraWallOutletV1(SubDevice):
-    """Subdevice AqaraWallOutletV1 specific properties and methods"""
-
-    properties = []
-    _zigbee_model = "lumi.ctrl_86plug.v1"
-    _model = "QBCZ11LM"
-    _name = "Wall outlet"
 
 
 class SwitchLiveOneChannel(SubDevice):
@@ -1093,24 +1111,6 @@ class AqaraMagnet(SubDevice):
         self._props.status = values[0]
 
 
-class AqaraWaterLeak(SubDevice):
-    """Subdevice AqaraWaterLeak specific properties and methods"""
-
-    properties = []
-    _zigbee_model = "lumi.sensor_wleak.aq1"
-    _model = "SJCGQ11LM"
-    _name = "Water leak sensor"
-
-
-class AqaraVibration(SubDevice):
-    """Subdevice AqaraVibration specific properties and methods"""
-
-    properties = []
-    _zigbee_model = "lumi.vibration.aq1"
-    _model = "DJT11LM"
-    _name = "Vibration sensor"
-
-
 class AqaraRelayTwoChannels(SubDevice):
     """Subdevice AqaraRelayTwoChannels specific properties and methods"""
 
@@ -1155,6 +1155,24 @@ class AqaraRelayTwoChannels(SubDevice):
     def toggle(self, channel, value):
         """Toggle Aqara Wireless Relay 2ch"""
         return self.send_arg("toggle_ctrl_neutral", [channel.value, value.value]).pop()
+
+
+class AqaraWaterLeak(SubDevice):
+    """Subdevice AqaraWaterLeak specific properties and methods"""
+
+    properties = []
+    _zigbee_model = "lumi.sensor_wleak.aq1"
+    _model = "SJCGQ11LM"
+    _name = "Water leak sensor"
+
+
+class AqaraVibration(SubDevice):
+    """Subdevice AqaraVibration specific properties and methods"""
+
+    properties = []
+    _zigbee_model = "lumi.vibration.aq1"
+    _model = "DJT11LM"
+    _name = "Vibration sensor"
 
 
 class AqaraSquareButtonV3(SubDevice):

--- a/miio/gateway.py
+++ b/miio/gateway.py
@@ -38,29 +38,69 @@ class DeviceType(IntEnum):
 
     Unknown = -1
     Gateway = 0  # lumi.0
-    Switch = 1
-    Motion = 2
-    Magnet = 3
-    SwitchTwoChannels = 7
+    Switch = 1  # lumi.sensor_switch
+    Motion = 2  # lumi.sensor_motion
+    Magnet = 3  # lumi.sensor_magnet
+    SwitchTwoChannels = 7  # lumi.ctrl_neutral2
     Cube = 8  # lumi.sensor_cube.v1
     SwitchOneChannel = 9  # lumi.ctrl_neutral1.v1
-    SensorHT = 10
-    Plug = 11
+    SensorHT = 10  # lumi.sensor_ht
+    Plug = 11  # lumi.plug
+    RemoteSwitchDoubleV1 = 12  # lumi.sensor_86sw2
     RemoteSwitchSingleV1 = 14  # lumi.sensor_86sw1.v1
-    SensorSmoke = 15
+    SensorSmoke = 15  # lumi.sensor_smoke
     AqaraHT = 19  # lumi.weather.v1
-    SwitchLiveOneChannel = 20
-    SwitchLiveTwoChannels = 21
-    AqaraSwitch = 51
-    AqaraMotion = 52
+    AqaraWallOutletV1 = 17  # lumi.ctrl_86plug.v1
+    SwitchLiveOneChannel = 20  # lumi.ctrl_ln1
+    SwitchLiveTwoChannels = 21  # lumi.ctrl_ln2
+    AqaraSwitch = 51  # lumi.sensor_switch.aq2
+    AqaraMotion = 52  # lumi.sensor_motion.aq2
     AqaraMagnet = 53  # lumi.sensor_magnet.aq2
-    AqaraRelayTwoChannels = 54
-    AqaraSquareButton = 62  # lumi.sensor_switch.aq3
-    AqaraSwitchOneChannel = 63
-    AqaraSwitchTwoChannels = 64
+    AqaraWaterLeak = 55  # lumi.sensor_wleak.aq1
+    AqaraVibration = 56  # lumi.vibration.aq1
+    AqaraRelayTwoChannels = 54  # lumi.relay.c2acn01
+    AqaraSquareButtonV3 = 62  # lumi.sensor_switch.aq3
+    AqaraSwitchOneChannel = 63  # lumi.ctrl_ln1.aq1
+    AqaraSwitchTwoChannels = 64  # lumi.ctrl_ln2.aq1
     AqaraWallOutlet = 65  # lumi.ctrl_86plug.aq1
+    
+    AqaraSquareButton = 133  # lumi.remote.b1acn01
     RemoteSwitchSingle = 134  # lumi.remote.b186acn01
     RemoteSwitchDouble = 135  # lumi.remote.b286acn01
+
+
+# 13 - lumi.curtain
+# 18 - lumi.sensor_natgas
+# 59 - lumi.lock.aq1
+# 66 - lumi.light.aqcn02
+# 68 - lumi.sensor_cube.aqgl01
+# 70 - lumi.lock.acn02
+# 71 - lumi.curtain.aq2
+# 72 - lumi.curtain.hagl04
+# 81 - lumi.lock.v1
+# 82 - ikea.light.led1545g12
+# 83 - ikea.light.led1546g12
+# 84 - ikea.light.led1536g5
+# 85 - ikea.light.led1537r6
+# 86 - ikea.light.led1623g12
+# 87 - ikea.light.led1650r5
+# 88 - ikea.light.led1649c5
+# 163 - lumi.lock.acn03
+# 166 - lumi.lock.acn05
+# 167 - lumi.switch.b1lacn02
+# 168 - lumi.switch.b2lacn02
+# 169 - lumi.switch.b1nacn02
+# 170 - lumi.switch.b2nacn02
+# 171 - lumi.remote.b186acn02
+# 172 - lumi.remote.b286acn02
+# 176 - lumi.switch.n3acn3
+# 177 - lumi.switch.l3acn3
+# 202 - lumi.dimmer.rgbegl01
+# 203 - lumi.dimmer.c3egl01
+# 204 - lumi.dimmer.cwegl01
+# 205 - lumi.airrtc.vrfegl01
+# 206 - lumi.airrtc.tcpecn01
+# 207 - lumi.airrtc.tcpecn02
 
 
 @attr.s(auto_attribs=True)
@@ -171,7 +211,7 @@ class Gateway(Device):
             DeviceType.AqaraSwitchTwoChannels: AqaraSwitchTwoChannels,
             DeviceType.AqaraWallOutlet: AqaraWallOutlet,
             DeviceType.Cube: Cube,
-            DeviceType.AqaraSquareButton: AqaraSquareButton,
+            DeviceType.AqaraSquareButtonV3: AqaraSquareButtonV3,
             DeviceType.SwitchOneChannel: SwitchOneChannel,
             DeviceType.RemoteSwitchSingleV1: RemoteSwitchSingleV1,
             DeviceType.RemoteSwitchSingle: RemoteSwitchSingle,
@@ -812,8 +852,8 @@ class SensorHT(SubDevice):
 
     accessor = "get_prop_sensor_ht"
     properties = ["temperature", "humidity", "pressure"]
-    _zigbee_model = "unknown"
-    _model = "unknown"
+    _zigbee_model = "lumi.sensor_ht"
+    _model = "RTCGQ01LM"
     _name = "Weather sensor"
 
     @attr.s(auto_attribs=True)
@@ -865,8 +905,8 @@ class AqaraPlug(SubDevice):
 
     accessor = "get_prop_plug"
     properties = ["power", "neutral_0", "load_power"]
-    _zigbee_model = "unknown"
-    _model = "unknown"
+    _zigbee_model = "lumi.plug"
+    _model = "ZNCZ02LM"
     _name = "Plug"
 
     @attr.s(auto_attribs=True)
@@ -890,8 +930,8 @@ class AqaraRelayTwoChannels(SubDevice):
     """Subdevice AqaraRelayTwoChannels specific properties and methods"""
 
     properties = ["load_power", "channel_0", "channel_1"]
-    _zigbee_model = "unknown"
-    _model = "unknown"
+    _zigbee_model = "lumi.relay.c2acn01"
+    _model = "LLKZMK11LM"
     _name = "Relay"
 
     @attr.s(auto_attribs=True)
@@ -936,8 +976,8 @@ class AqaraSwitchOneChannel(SubDevice):
     """Subdevice AqaraSwitchOneChannel specific properties and methods"""
 
     properties = ["neutral_0", "load_power"]
-    _zigbee_model = "unknown"
-    _model = "unknown"
+    _zigbee_model = "lumi.ctrl_ln1.aq1"
+    _model = "QBKG11LM"
     _name = "Wall switch single"
 
     @attr.s(auto_attribs=True)
@@ -959,8 +999,8 @@ class AqaraSwitchTwoChannels(SubDevice):
     """Subdevice AqaraSwitchTwoChannels specific properties and methods"""
 
     properties = ["neutral_0", "neutral_1", "load_power"]
-    _zigbee_model = "unknown"
-    _model = "unknown"
+    _zigbee_model = "lumi.ctrl_ln2.aq1"
+    _model = "QBKG12LM"
     _name = "Wall switch double"
 
     @attr.s(auto_attribs=True)
@@ -1027,8 +1067,8 @@ class Cube(SubDevice):
     _name = "Cube"
 
 
-class AqaraSquareButton(SubDevice):
-    """Subdevice AqaraSquareButton specific properties and methods"""
+class AqaraSquareButtonV3(SubDevice):
+    """Subdevice AqaraSquareButtonV3 specific properties and methods"""
 
     properties = []
     _zigbee_model = "lumi.sensor_switch.aq3"

--- a/miio/gateway.py
+++ b/miio/gateway.py
@@ -286,7 +286,7 @@ class Gateway(Device):
             if device_type != DeviceType.Gateway:
                 self._devices[dev_info.sid] = subdevice_cls(self, dev_info)
                 if self._devices[dev_info.sid].status == {}:
-                    _LOGGER.warning(
+                    _LOGGER.info(
                         "Discovered subdevice type '%s', has no device specific properties defined, "
                         "this device has not been fully implemented yet (model: %s, name: %s).",
                         device_type.name,

--- a/miio/gateway.py
+++ b/miio/gateway.py
@@ -829,6 +829,7 @@ class SubDevice:
             )
         return self._fw_ver
 
+
 class Switch(SubDevice):
     """Subdevice Switch specific properties and methods"""
 

--- a/miio/gateway.py
+++ b/miio/gateway.py
@@ -47,7 +47,7 @@ class DeviceType(IntEnum):
     SensorHT = 10  # lumi.sensor_ht
     Plug = 11  # lumi.plug
     RemoteSwitchDoubleV1 = 12  # lumi.sensor_86sw2.v1
-    Curtain = 13  # lumi.curtain
+    CurtainV1 = 13  # lumi.curtain
     RemoteSwitchSingleV1 = 14  # lumi.sensor_86sw1.v1
     SensorSmoke = 15  # lumi.sensor_smoke
     AqaraWallOutletV1 = 17  # lumi.ctrl_86plug.v1
@@ -61,45 +61,45 @@ class DeviceType(IntEnum):
     AqaraRelayTwoChannels = 54  # lumi.relay.c2acn01
     AqaraWaterLeak = 55  # lumi.sensor_wleak.aq1
     AqaraVibration = 56  # lumi.vibration.aq1
+    DoorLockS1 = 59  # lumi.lock.aq1
     AqaraSquareButtonV3 = 62  # lumi.sensor_switch.aq3
     AqaraSwitchOneChannel = 63  # lumi.ctrl_ln1.aq1
     AqaraSwitchTwoChannels = 64  # lumi.ctrl_ln2.aq1
     AqaraWallOutlet = 65  # lumi.ctrl_86plug.aq1
+    AqaraSmartBulbE27 = 66  # lumi.light.aqcn02
+    CubeV2 = 68  # lumi.sensor_cube.aqgl01
+    LockS2 = 70  # lumi.lock.acn02
+    Curtain = 71  # lumi.curtain.aq2
+    CurtainB1 = 72  # lumi.curtain.hagl04
+    LockV1 = 81  # lumi.lock.v1
+    IkeaBulb82 = 82  # ikea.light.led1545g12
+    IkeaBulb83 = 83  # ikea.light.led1546g12 
+    IkeaBulb84 = 84  # ikea.light.led1536g5
+    IkeaBulb85 = 85  # ikea.light.led1537r6
+    IkeaBulb86 = 86  # ikea.light.led1623g12
+    IkeaBulb87 = 87  # ikea.light.led1650r5
+    IkeaBulb88 = 88  # ikea.light.led1649c5
     AqaraSquareButton = 133  # lumi.remote.b1acn01
     RemoteSwitchSingle = 134  # lumi.remote.b186acn01
     RemoteSwitchDouble = 135  # lumi.remote.b286acn01
+    LockS2Pro = 163  # lumi.lock.acn03
+    D1RemoteSwitchSingle = 171  # lumi.remote.b186acn02
+    D1RemoteSwitchDouble = 172  # lumi.remote.b286acn02
+    D1WallSwitchTriple = 176  # lumi.switch.n3acn3
+    D1WallSwitchTripleNN = 177  # lumi.switch.l3acn3
+    ThermostatS2 = 207  # lumi.airrtc.tcpecn02
 
 
-# 59 - lumi.lock.aq1
-# 66 - lumi.light.aqcn02
-# 68 - lumi.sensor_cube.aqgl01
-# 70 - lumi.lock.acn02
-# 71 - lumi.curtain.aq2
-# 72 - lumi.curtain.hagl04
-# 81 - lumi.lock.v1
-# 82 - ikea.light.led1545g12
-# 83 - ikea.light.led1546g12
-# 84 - ikea.light.led1536g5
-# 85 - ikea.light.led1537r6
-# 86 - ikea.light.led1623g12
-# 87 - ikea.light.led1650r5
-# 88 - ikea.light.led1649c5
-# 163 - lumi.lock.acn03
 # 166 - lumi.lock.acn05
 # 167 - lumi.switch.b1lacn02
 # 168 - lumi.switch.b2lacn02
 # 169 - lumi.switch.b1nacn02
 # 170 - lumi.switch.b2nacn02
-# 171 - lumi.remote.b186acn02
-# 172 - lumi.remote.b286acn02
-# 176 - lumi.switch.n3acn3
-# 177 - lumi.switch.l3acn3
 # 202 - lumi.dimmer.rgbegl01
 # 203 - lumi.dimmer.c3egl01
 # 204 - lumi.dimmer.cwegl01
 # 205 - lumi.airrtc.vrfegl01
 # 206 - lumi.airrtc.tcpecn01
-# 207 - lumi.airrtc.tcpecn02
 
 
 @attr.s(auto_attribs=True)
@@ -210,7 +210,7 @@ class Gateway(Device):
             DeviceType.SensorHT: SensorHT,
             DeviceType.Plug: Plug,
             DeviceType.RemoteSwitchDoubleV1: RemoteSwitchDoubleV1,
-            DeviceType.Curtain: Curtain,
+            DeviceType.CurtainV1: CurtainV1,
             DeviceType.RemoteSwitchSingleV1: RemoteSwitchSingleV1,
             DeviceType.SensorSmoke: SensorSmoke,
             DeviceType.AqaraWallOutletV1: AqaraWallOutletV1,
@@ -224,13 +224,33 @@ class Gateway(Device):
             DeviceType.AqaraRelayTwoChannels: AqaraRelayTwoChannels,
             DeviceType.AqaraWaterLeak: AqaraWaterLeak,
             DeviceType.AqaraVibration: AqaraVibration,
+            DeviceType.DoorLockS1: DoorLockS1,
             DeviceType.AqaraSquareButtonV3: AqaraSquareButtonV3,
             DeviceType.AqaraSwitchOneChannel: AqaraSwitchOneChannel,
             DeviceType.AqaraSwitchTwoChannels: AqaraSwitchTwoChannels,
             DeviceType.AqaraWallOutlet: AqaraWallOutlet,
+            DeviceType.AqaraSmartBulbE27: AqaraSmartBulbE27,
+            DeviceType.CubeV2: CubeV2,
+            DeviceType.LockS2: LockS2,
+            DeviceType.Curtain: Curtain,
+            DeviceType.CurtainB1: CurtainB1,
+            DeviceType.LockV1: LockV1,
+            DeviceType.IkeaBulb82: IkeaBulb82,
+            DeviceType.IkeaBulb83: IkeaBulb83,
+            DeviceType.IkeaBulb84: IkeaBulb84,
+            DeviceType.IkeaBulb85: IkeaBulb85,
+            DeviceType.IkeaBulb86: IkeaBulb86,
+            DeviceType.IkeaBulb87: IkeaBulb87,
+            DeviceType.IkeaBulb88: IkeaBulb88,
             DeviceType.AqaraSquareButton: AqaraSquareButton,
             DeviceType.RemoteSwitchSingle: RemoteSwitchSingle,
             DeviceType.RemoteSwitchDouble: RemoteSwitchDouble,
+            DeviceType.LockS2Pro: LockS2Pro,
+            DeviceType.D1RemoteSwitchSingle: D1RemoteSwitchSingle,
+            DeviceType.D1RemoteSwitchDouble: D1RemoteSwitchDouble,
+            DeviceType.D1WallSwitchTriple: D1WallSwitchTriple,
+            DeviceType.D1WallSwitchTripleNN: D1WallSwitchTripleNN,
+            DeviceType.ThermostatS2: ThermostatS2,
         }
         devices_raw = self.get_prop("device_list")
         self._devices = {}
@@ -978,8 +998,8 @@ class RemoteSwitchDoubleV1(SubDevice):
     _name = "Remote switch double"
 
 
-class Curtain(SubDevice):
-    """Subdevice Curtain specific properties and methods."""
+class CurtainV1(SubDevice):
+    """Subdevice CurtainV1 specific properties and methods."""
 
     properties = []
     _zigbee_model = "lumi.curtain"
@@ -1176,6 +1196,15 @@ class AqaraVibration(SubDevice):
     _name = "Vibration sensor"
 
 
+class DoorLockS1(SubDevice):
+    """Subdevice DoorLockS1 specific properties and methods."""
+
+    properties = []
+    _zigbee_model = "lumi.lock.aq1"
+    _model = "ZNMS11LM"
+    _name = "Door lock S1" 
+
+
 class AqaraSquareButtonV3(SubDevice):
     """Subdevice AqaraSquareButtonV3 specific properties and methods."""
 
@@ -1271,6 +1300,123 @@ class AqaraWallOutlet(SubDevice):
         return self.send_arg("toggle_plug", ["channel_0", "off"]).pop()
 
 
+class AqaraSmartBulbE27(SubDevice):
+    """Subdevice AqaraSmartBulbE27 specific properties and methods."""
+
+    properties = []
+    _zigbee_model = "lumi.light.aqcn02"
+    _model = "ZNLDP12LM"
+    _name = "Smart bulb E27"
+
+
+class CubeV2(SubDevice):
+    """Subdevice CubeV2 specific properties and methods."""
+
+    properties = []
+    _zigbee_model = "lumi.sensor_cube.aqgl01"
+    _model = "MFKZQ01LM"
+    _name = "Cube"
+
+
+class LockS2(SubDevice):
+    """Subdevice LockS2 specific properties and methods."""
+
+    properties = []
+    _zigbee_model = "lumi.lock.acn02"
+    _model = "ZNMS12LM"
+    _name = "Door lock S2"
+
+
+class Curtain(SubDevice):
+    """Subdevice Curtain specific properties and methods."""
+
+    properties = []
+    _zigbee_model = "lumi.curtain.aq2"
+    _model = "ZNGZDJ11LM"
+    _name = "Curtain"
+
+
+class CurtainB1(SubDevice):
+    """Subdevice CurtainB1 specific properties and methods."""
+
+    properties = []
+    _zigbee_model = "lumi.curtain.hagl04"
+    _model = "ZNCLDJ12LM"
+    _name = "Curtain B1"
+
+
+class LockV1(SubDevice):
+    """Subdevice LockV1 specific properties and methods."""
+
+    properties = []
+    _zigbee_model = "lumi.lock.v1"
+    _model = "A6121"
+    _name = "Vima cylinder lock"
+
+
+class IkeaBulb82(SubDevice):
+    """Subdevice IkeaBulb82 specific properties and methods."""
+
+    properties = []
+    _zigbee_model = "ikea.light.led1545g12"
+    _model = "LED1545G12"
+    _name = "Ikea smart bulb E27 white"
+
+
+class IkeaBulb83(SubDevice):
+    """Subdevice IkeaBulb83 specific properties and methods."""
+
+    properties = []
+    _zigbee_model = "ikea.light.led1546g12"
+    _model = "LED1546G12"
+    _name = "Ikea smart bulb E27 white"
+
+
+class IkeaBulb84(SubDevice):
+    """Subdevice IkeaBulb84 specific properties and methods."""
+
+    properties = []
+    _zigbee_model = "ikea.light.led1536g5"
+    _model = "LED1536G5"
+    _name = "Ikea smart bulb E12 white"
+
+
+class IkeaBulb85(SubDevice):
+    """Subdevice IkeaBulb85 specific properties and methods."""
+
+    properties = []
+    _zigbee_model = "ikea.light.led1537r6"
+    _model = "LED1537R6"
+    _name = "Ikea smart bulb GU10 white"
+
+
+class IkeaBulb86(SubDevice):
+    """Subdevice IkeaBulb86 specific properties and methods."""
+
+    properties = []
+    _zigbee_model = "ikea.light.led1623g12"
+    _model = "LED1623G12"
+    _name = "Ikea smart bulb E27 white"
+
+
+class IkeaBulb87(SubDevice):
+    """Subdevice IkeaBulb87 specific properties and methods."""
+
+    properties = []
+    _zigbee_model = "ikea.light.led1650r5"
+    _model = "LED1650R5"
+    _name = "Ikea smart bulb GU10 white"
+
+
+class IkeaBulb88(SubDevice):
+    """Subdevice IkeaBulb88 specific properties and methods."""
+
+    properties = []
+    _zigbee_model = "ikea.light.led1649c5"
+    _model = "LED1649C5"
+    _name = "Ikea smart bulb E12 white"
+
+
 class AqaraSquareButton(SubDevice):
     """Subdevice AqaraSquareButton specific properties and methods."""
 
@@ -1296,3 +1442,58 @@ class RemoteSwitchDouble(SubDevice):
     _zigbee_model = "lumi.remote.b286acn01"
     _model = "WXKG02LM 2018"
     _name = "Remote switch double"
+
+
+class LockS2Pro(SubDevice):
+    """Subdevice LockS2Pro specific properties and methods."""
+
+    properties = []
+    _zigbee_model = "lumi.lock.acn03"
+    _model = "ZNMS13LM"
+    _name = "Door lock S2 pro"
+
+
+class D1RemoteSwitchSingle(SubDevice):
+    """Subdevice D1RemoteSwitchSingle specific properties and methods."""
+
+    properties = []
+    _zigbee_model = "lumi.remote.b186acn02"
+    _model = "WXKG06LM"
+    _name = "D1 remote switch single"
+
+
+class D1RemoteSwitchDouble(SubDevice):
+    """Subdevice D1RemoteSwitchDouble specific properties and methods."""
+
+    properties = []
+    _zigbee_model = "lumi.remote.b286acn02"
+    _model = "WXKG07LM"
+    _name = "D1 remote switch double"
+
+
+class D1WallSwitchTriple(SubDevice):
+    """Subdevice D1WallSwitchTriple specific properties and methods."""
+
+    properties = []
+    _zigbee_model = "lumi.switch.n3acn3"
+    _model = "QBKG26LM"
+    _name = "D1 wall switch triple"
+
+
+class D1WallSwitchTripleNN(SubDevice):
+    """Subdevice D1WallSwitchTripleNN specific properties and methods."""
+
+    properties = []
+    _zigbee_model = "lumi.switch.l3acn3"
+    _model = "QBKG25LM"
+    _name = "D1 wall switch triple no neutral"
+
+
+class ThermostatS2(SubDevice):
+    """Subdevice ThermostatS2 specific properties and methods."""
+
+    properties = []
+    _zigbee_model = "lumi.airrtc.tcpecn02"
+    _model = "KTWKQ03ES"
+    _name = "Thermostat S2"
+

--- a/miio/gateway.py
+++ b/miio/gateway.py
@@ -1114,22 +1114,10 @@ class AqaraMotion(SubDevice):
 class AqaraMagnet(SubDevice):
     """Subdevice AqaraMagnet specific properties and methods."""
 
-    properties = ["unkown"]
+    properties = []
     _zigbee_model = "lumi.sensor_magnet.aq2"
     _model = "MCCGQ11LM"
     _name = "Door sensor"
-
-    @attr.s(auto_attribs=True)
-    class props:
-        """Device specific properties."""
-
-        status: str = None  # 'open' or 'closed'
-
-    @command()
-    def update(self):
-        """Update all device properties."""
-        values = self.get_property_exp(self.properties)
-        self._props.status = values[0]
 
 
 class AqaraRelayTwoChannels(SubDevice):

--- a/miio/gateway.py
+++ b/miio/gateway.py
@@ -369,18 +369,18 @@ class GatewayAlarm(GatewayDevice):
 
     @command(click.argument("seconds"))
     def set_arming_time(self, seconds):
-        """Set time the alarm stays at 'oning' before transitioning to 'on'"""
+        """Set time the alarm stays at 'oning' before transitioning to 'on'."""
         return self._gateway.send("set_arm_wait_time", [seconds])
 
     @command()
     def triggering_time(self) -> int:
-        """Return the time in seconds the alarm is going off when triggered"""
+        """Return the time in seconds the alarm is going off when triggered."""
         # Response: 30, 60, etc.
         return self._gateway.get_prop("alarm_time_len").pop()
 
     @command(click.argument("seconds"))
     def set_triggering_time(self, seconds):
-        """Set the time in seconds the alarm is going off when triggered"""
+        """Set the time in seconds the alarm is going off when triggered."""
         return self._gateway.set_prop("alarm_time_len", seconds)
 
     @command()
@@ -394,24 +394,24 @@ class GatewayAlarm(GatewayDevice):
 
     @command(click.argument("seconds"))
     def set_triggering_light(self, seconds):
-        """Set the time the gateway light blinks when the alarm is triggerd"""
+        """Set the time the gateway light blinks when the alarm is triggerd."""
         # values: 0=do not blink, 1=always blink, x>1=blink for x seconds
         return self._gateway.set_prop("en_alarm_light", seconds)
 
     @command()
     def triggering_volume(self) -> int:
-        """Return the volume level at which alarms go off [0-100]"""
+        """Return the volume level at which alarms go off [0-100]."""
         return self._gateway.send("get_alarming_volume").pop()
 
     @command(click.argument("volume"))
     def set_triggering_volume(self, volume):
-        """Set the volume level at which alarms go off [0-100]"""
+        """Set the volume level at which alarms go off [0-100]."""
         return self._gateway.send("set_alarming_volume", [volume])
 
     @command()
     def last_status_change_time(self) -> datetime:
         """
-        Return the last time the alarm changed status
+        Return the last time the alarm changed status.
         """
         return datetime.fromtimestamp(self._gateway.send("get_arming_time").pop())
 
@@ -421,7 +421,7 @@ class GatewayZigbee(GatewayDevice):
 
     @command()
     def get_zigbee_version(self):
-        """timeouts on device"""
+        """timeouts on device."""
         return self._gateway.send("get_zigbee_device_version")
 
     @command()
@@ -436,7 +436,7 @@ class GatewayZigbee(GatewayDevice):
 
     @command(click.argument("timeout", type=int))
     def zigbee_pair(self, timeout):
-        """Start pairing, use 0 to disable"""
+        """Start pairing, use 0 to disable."""
         return self._gateway.send("start_zigbee_join", [timeout])
 
     def send_to_zigbee(self):
@@ -480,7 +480,7 @@ class GatewayRadio(GatewayDevice):
 
     @command(click.argument("volume"))
     def set_radio_volume(self, volume):
-        """Set radio volume"""
+        """Set radio volume."""
         return self._gateway.send("set_fm_volume", [volume])
 
     def play_music_new(self):
@@ -527,7 +527,7 @@ class GatewayRadio(GatewayDevice):
         return self._gateway.send("remove_channels")
 
     def get_default_music(self):
-        """seems to timeout (w/o internet)"""
+        """seems to timeout (w/o internet)."""
         # params [0,1,2]
         raise NotImplementedError()
         return self._gateway.send("get_default_music")
@@ -546,12 +546,12 @@ class GatewayRadio(GatewayDevice):
         return self._gateway.send("get_mute")
 
     def download_music(self):
-        """Unknown"""
+        """Unknown."""
         raise NotImplementedError()
         return self._gateway.send("download_music")
 
     def delete_music(self):
-        """delete music"""
+        """delete music."""
         raise NotImplementedError()
         return self._gateway.send("delete_music")
 
@@ -672,7 +672,7 @@ class SubDevice:
 
     @attr.s(auto_attribs=True)
     class props:
-        """Defines properties of the specific device"""
+        """Defines properties of the specific device."""
 
     def __init__(self, gw: Gateway = None, dev_info: SubDeviceInfo = None,) -> None:
         self._gw = gw
@@ -739,7 +739,7 @@ class SubDevice:
 
     @command()
     def send(self, command):
-        """Send a command/query to the subdevice"""
+        """Send a command/query to the subdevice."""
         try:
             return self._gw.send(command, [self.sid])
         except Exception as ex:
@@ -749,7 +749,7 @@ class SubDevice:
 
     @command()
     def send_arg(self, command, arguments):
-        """Send a command/query including arguments to the subdevice"""
+        """Send a command/query including arguments to the subdevice."""
         try:
             return self._gw.send(command, arguments, extra_parameters={"sid": self.sid})
         except Exception as ex:
@@ -819,7 +819,7 @@ class SubDevice:
 
     @command()
     def get_firmware_version(self) -> Optional[int]:
-        """Returns firmware version"""
+        """Returns firmware version."""
         try:
             self._fw_ver = self.get_property("fw_ver").pop()
         except Exception as ex:
@@ -831,7 +831,7 @@ class SubDevice:
 
 
 class Switch(SubDevice):
-    """Subdevice Switch specific properties and methods"""
+    """Subdevice Switch specific properties and methods."""
 
     properties = []
     _zigbee_model = "lumi.sensor_switch"
@@ -840,7 +840,7 @@ class Switch(SubDevice):
 
 
 class Motion(SubDevice):
-    """Subdevice Motion specific properties and methods"""
+    """Subdevice Motion specific properties and methods."""
 
     properties = []
     _zigbee_model = "lumi.sensor_motion"
@@ -849,7 +849,7 @@ class Motion(SubDevice):
 
 
 class Magnet(SubDevice):
-    """Subdevice Magnet specific properties and methods"""
+    """Subdevice Magnet specific properties and methods."""
 
     properties = []
     _zigbee_model = "lumi.sensor_magnet"
@@ -858,7 +858,7 @@ class Magnet(SubDevice):
 
 
 class SwitchTwoChannels(SubDevice):
-    """Subdevice SwitchTwoChannels specific properties and methods"""
+    """Subdevice SwitchTwoChannels specific properties and methods."""
 
     properties = []
     _zigbee_model = "lumi.ctrl_neutral2"
@@ -867,7 +867,7 @@ class SwitchTwoChannels(SubDevice):
 
 
 class Cube(SubDevice):
-    """Subdevice Cube specific properties and methods"""
+    """Subdevice Cube specific properties and methods."""
 
     properties = []
     _zigbee_model = "lumi.sensor_cube.v1"
@@ -876,7 +876,7 @@ class Cube(SubDevice):
 
 
 class SwitchOneChannel(SubDevice):
-    """Subdevice SwitchOneChannel specific properties and methods"""
+    """Subdevice SwitchOneChannel specific properties and methods."""
 
     properties = ["neutral_0"]
     _zigbee_model = "lumi.ctrl_neutral1.v1"
@@ -885,34 +885,34 @@ class SwitchOneChannel(SubDevice):
 
     @attr.s(auto_attribs=True)
     class props:
-        """Device specific properties"""
+        """Device specific properties."""
 
         status: str = None  # 'on' / 'off'
 
     @command()
     def update(self):
-        """Update all device properties"""
+        """Update all device properties."""
         values = self.get_property_exp(self.properties)
         self._props.status = values[0]
 
     @command()
     def toggle(self):
-        """Toggle Switch One Channel"""
+        """Toggle Switch One Channel."""
         return self.send_arg("toggle_ctrl_neutral", ["channel_0", "toggle"]).pop()
 
     @command()
     def on(self):
-        """Turn on Switch One Channel"""
+        """Turn on Switch One Channel."""
         return self.send_arg("toggle_ctrl_neutral", ["channel_0", "on"]).pop()
 
     @command()
     def off(self):
-        """Turn off Switch One Channel"""
+        """Turn off Switch One Channel."""
         return self.send_arg("toggle_ctrl_neutral", ["channel_0", "off"]).pop()
 
 
 class SensorHT(SubDevice):
-    """Subdevice SensorHT specific properties and methods"""
+    """Subdevice SensorHT specific properties and methods."""
 
     accessor = "get_prop_sensor_ht"
     properties = ["temperature", "humidity", "pressure"]
@@ -922,7 +922,7 @@ class SensorHT(SubDevice):
 
     @attr.s(auto_attribs=True)
     class props:
-        """Device specific properties"""
+        """Device specific properties."""
 
         temperature: int = None  # in degrees celsius
         humidity: int = None  # in %
@@ -930,7 +930,7 @@ class SensorHT(SubDevice):
 
     @command()
     def update(self):
-        """Update all device properties"""
+        """Update all device properties."""
         values = self.get_property_exp(self.properties)
         try:
             self._props.temperature = values[0] / 100
@@ -944,7 +944,7 @@ class SensorHT(SubDevice):
 
 
 class Plug(SubDevice):
-    """Subdevice Plug specific properties and methods"""
+    """Subdevice Plug specific properties and methods."""
 
     accessor = "get_prop_plug"
     properties = ["power", "neutral_0", "load_power"]
@@ -954,7 +954,7 @@ class Plug(SubDevice):
 
     @attr.s(auto_attribs=True)
     class props:
-        """Device specific properties"""
+        """Device specific properties."""
 
         status: str = None  # 'on' / 'off'
         power: int = None  # diffrent power consumption?? in ?unit?
@@ -962,7 +962,7 @@ class Plug(SubDevice):
 
     @command()
     def update(self):
-        """Update all device properties"""
+        """Update all device properties."""
         values = self.get_property_exp(self.properties)
         self._props.power = values[0]
         self._props.status = values[1]
@@ -970,7 +970,7 @@ class Plug(SubDevice):
 
 
 class RemoteSwitchDoubleV1(SubDevice):
-    """Subdevice RemoteSwitchDoubleV1 specific properties and methods"""
+    """Subdevice RemoteSwitchDoubleV1 specific properties and methods."""
 
     properties = []
     _zigbee_model = "lumi.sensor_86sw2.v1"
@@ -979,7 +979,7 @@ class RemoteSwitchDoubleV1(SubDevice):
 
 
 class Curtain(SubDevice):
-    """Subdevice Curtain specific properties and methods"""
+    """Subdevice Curtain specific properties and methods."""
 
     properties = []
     _zigbee_model = "lumi.curtain"
@@ -988,7 +988,7 @@ class Curtain(SubDevice):
 
 
 class RemoteSwitchSingleV1(SubDevice):
-    """Subdevice RemoteSwitchSingleV1 specific properties and methods"""
+    """Subdevice RemoteSwitchSingleV1 specific properties and methods."""
 
     properties = []
     _zigbee_model = "lumi.sensor_86sw1.v1"
@@ -997,7 +997,7 @@ class RemoteSwitchSingleV1(SubDevice):
 
 
 class SensorSmoke(SubDevice):
-    """Subdevice SensorSmoke specific properties and methods"""
+    """Subdevice SensorSmoke specific properties and methods."""
 
     properties = []
     _zigbee_model = "lumi.sensor_smoke"
@@ -1006,7 +1006,7 @@ class SensorSmoke(SubDevice):
 
 
 class AqaraWallOutletV1(SubDevice):
-    """Subdevice AqaraWallOutletV1 specific properties and methods"""
+    """Subdevice AqaraWallOutletV1 specific properties and methods."""
 
     properties = []
     _zigbee_model = "lumi.ctrl_86plug.v1"
@@ -1015,7 +1015,7 @@ class AqaraWallOutletV1(SubDevice):
 
 
 class SensorNatgas(SubDevice):
-    """Subdevice SensorNatgas specific properties and methods"""
+    """Subdevice SensorNatgas specific properties and methods."""
 
     properties = []
     _zigbee_model = "lumi.sensor_natgas"
@@ -1024,7 +1024,7 @@ class SensorNatgas(SubDevice):
 
 
 class AqaraHT(SubDevice):
-    """Subdevice AqaraHT specific properties and methods"""
+    """Subdevice AqaraHT specific properties and methods."""
 
     accessor = "get_prop_sensor_ht"
     properties = ["temperature", "humidity", "pressure"]
@@ -1034,7 +1034,7 @@ class AqaraHT(SubDevice):
 
     @attr.s(auto_attribs=True)
     class props:
-        """Device specific properties"""
+        """Device specific properties."""
 
         temperature: int = None  # in degrees celsius
         humidity: int = None  # in %
@@ -1042,7 +1042,7 @@ class AqaraHT(SubDevice):
 
     @command()
     def update(self):
-        """Update all device properties"""
+        """Update all device properties."""
         values = self.get_property_exp(self.properties)
         try:
             self._props.temperature = values[0] / 100
@@ -1056,7 +1056,7 @@ class AqaraHT(SubDevice):
 
 
 class SwitchLiveOneChannel(SubDevice):
-    """Subdevice SwitchLiveOneChannel specific properties and methods"""
+    """Subdevice SwitchLiveOneChannel specific properties and methods."""
 
     properties = []
     _zigbee_model = "lumi.ctrl_ln1"
@@ -1065,7 +1065,7 @@ class SwitchLiveOneChannel(SubDevice):
 
 
 class SwitchLiveTwoChannels(SubDevice):
-    """Subdevice SwitchLiveTwoChannels specific properties and methods"""
+    """Subdevice SwitchLiveTwoChannels specific properties and methods."""
 
     properties = []
     _zigbee_model = "lumi.ctrl_ln2"
@@ -1074,7 +1074,7 @@ class SwitchLiveTwoChannels(SubDevice):
 
 
 class AqaraSwitch(SubDevice):
-    """Subdevice AqaraSwitch specific properties and methods"""
+    """Subdevice AqaraSwitch specific properties and methods."""
 
     properties = []
     _zigbee_model = "lumi.sensor_switch.aq2"
@@ -1083,7 +1083,7 @@ class AqaraSwitch(SubDevice):
 
 
 class AqaraMotion(SubDevice):
-    """Subdevice AqaraMotion specific properties and methods"""
+    """Subdevice AqaraMotion specific properties and methods."""
 
     properties = []
     _zigbee_model = "lumi.sensor_motion.aq2"
@@ -1092,7 +1092,7 @@ class AqaraMotion(SubDevice):
 
 
 class AqaraMagnet(SubDevice):
-    """Subdevice AqaraMagnet specific properties and methods"""
+    """Subdevice AqaraMagnet specific properties and methods."""
 
     properties = ["unkown"]
     _zigbee_model = "lumi.sensor_magnet.aq2"
@@ -1101,19 +1101,19 @@ class AqaraMagnet(SubDevice):
 
     @attr.s(auto_attribs=True)
     class props:
-        """Device specific properties"""
+        """Device specific properties."""
 
         status: str = None  # 'open' or 'closed'
 
     @command()
     def update(self):
-        """Update all device properties"""
+        """Update all device properties."""
         values = self.get_property_exp(self.properties)
         self._props.status = values[0]
 
 
 class AqaraRelayTwoChannels(SubDevice):
-    """Subdevice AqaraRelayTwoChannels specific properties and methods"""
+    """Subdevice AqaraRelayTwoChannels specific properties and methods."""
 
     properties = ["load_power", "channel_0", "channel_1"]
     _zigbee_model = "lumi.relay.c2acn01"
@@ -1122,28 +1122,28 @@ class AqaraRelayTwoChannels(SubDevice):
 
     @attr.s(auto_attribs=True)
     class props:
-        """Device specific properties"""
+        """Device specific properties."""
 
         status_ch0: str = None  # 'on' / 'off'
         status_ch1: str = None  # 'on' / 'off'
         load_power: int = None  # power consumption in ?unit?
 
     class AqaraRelayToggleValue(Enum):
-        """Options to control the relay"""
+        """Options to control the relay."""
 
         toggle = "toggle"
         on = "on"
         off = "off"
 
     class AqaraRelayChannel(Enum):
-        """Options to select wich relay to control"""
+        """Options to select wich relay to control."""
 
         first = "channel_0"
         second = "channel_1"
 
     @command()
     def update(self):
-        """Update all device properties"""
+        """Update all device properties."""
         values = self.get_property_exp(self.properties)
         self._props.load_power = values[0]
         self._props.status_ch0 = values[1]
@@ -1154,12 +1154,12 @@ class AqaraRelayTwoChannels(SubDevice):
         click.argument("value", type=EnumType(AqaraRelayToggleValue)),
     )
     def toggle(self, channel, value):
-        """Toggle Aqara Wireless Relay 2ch"""
+        """Toggle Aqara Wireless Relay 2ch."""
         return self.send_arg("toggle_ctrl_neutral", [channel.value, value.value]).pop()
 
 
 class AqaraWaterLeak(SubDevice):
-    """Subdevice AqaraWaterLeak specific properties and methods"""
+    """Subdevice AqaraWaterLeak specific properties and methods."""
 
     properties = []
     _zigbee_model = "lumi.sensor_wleak.aq1"
@@ -1168,7 +1168,7 @@ class AqaraWaterLeak(SubDevice):
 
 
 class AqaraVibration(SubDevice):
-    """Subdevice AqaraVibration specific properties and methods"""
+    """Subdevice AqaraVibration specific properties and methods."""
 
     properties = []
     _zigbee_model = "lumi.vibration.aq1"
@@ -1177,7 +1177,7 @@ class AqaraVibration(SubDevice):
 
 
 class AqaraSquareButtonV3(SubDevice):
-    """Subdevice AqaraSquareButtonV3 specific properties and methods"""
+    """Subdevice AqaraSquareButtonV3 specific properties and methods."""
 
     properties = []
     _zigbee_model = "lumi.sensor_switch.aq3"
@@ -1186,7 +1186,7 @@ class AqaraSquareButtonV3(SubDevice):
 
 
 class AqaraSwitchOneChannel(SubDevice):
-    """Subdevice AqaraSwitchOneChannel specific properties and methods"""
+    """Subdevice AqaraSwitchOneChannel specific properties and methods."""
 
     properties = ["neutral_0", "load_power"]
     _zigbee_model = "lumi.ctrl_ln1.aq1"
@@ -1195,21 +1195,21 @@ class AqaraSwitchOneChannel(SubDevice):
 
     @attr.s(auto_attribs=True)
     class props:
-        """Device specific properties"""
+        """Device specific properties."""
 
         status: str = None  # 'on' / 'off'
         load_power: int = None  # power consumption in ?unit?
 
     @command()
     def update(self):
-        """Update all device properties"""
+        """Update all device properties."""
         values = self.get_property_exp(self.properties)
         self._props.status = values[0]
         self._props.load_power = values[1]
 
 
 class AqaraSwitchTwoChannels(SubDevice):
-    """Subdevice AqaraSwitchTwoChannels specific properties and methods"""
+    """Subdevice AqaraSwitchTwoChannels specific properties and methods."""
 
     properties = ["neutral_0", "neutral_1", "load_power"]
     _zigbee_model = "lumi.ctrl_ln2.aq1"
@@ -1218,7 +1218,7 @@ class AqaraSwitchTwoChannels(SubDevice):
 
     @attr.s(auto_attribs=True)
     class props:
-        """Device specific properties"""
+        """Device specific properties."""
 
         status_ch0: str = None  # 'on' / 'off'
         status_ch1: str = None  # 'on' / 'off'
@@ -1226,7 +1226,7 @@ class AqaraSwitchTwoChannels(SubDevice):
 
     @command()
     def update(self):
-        """Update all device properties"""
+        """Update all device properties."""
         values = self.get_property_exp(self.properties)
         self._props.status_ch0 = values[0]
         self._props.status_ch1 = values[1]
@@ -1234,7 +1234,7 @@ class AqaraSwitchTwoChannels(SubDevice):
 
 
 class AqaraWallOutlet(SubDevice):
-    """Subdevice AqaraWallOutlet specific properties and methods"""
+    """Subdevice AqaraWallOutlet specific properties and methods."""
 
     properties = ["channel_0", "load_power"]
     _zigbee_model = "lumi.ctrl_86plug.aq1"
@@ -1243,36 +1243,36 @@ class AqaraWallOutlet(SubDevice):
 
     @attr.s(auto_attribs=True)
     class props:
-        """Device specific properties"""
+        """Device specific properties."""
 
         status: str = None  # 'on' / 'off'
         load_power: int = None  # power consumption in Watt
 
     @command()
     def update(self):
-        """Update all device properties"""
+        """Update all device properties."""
         values = self.get_property_exp(self.properties)
         self._props.status = values[0]
         self._props.load_power = values[1]
 
     @command()
     def toggle(self):
-        """Toggle Aqara Wall Outlet"""
+        """Toggle Aqara Wall Outlet."""
         return self.send_arg("toggle_plug", ["channel_0", "toggle"]).pop()
 
     @command()
     def on(self):
-        """Turn on Aqara Wall Outlet"""
+        """Turn on Aqara Wall Outlet."""
         return self.send_arg("toggle_plug", ["channel_0", "on"]).pop()
 
     @command()
     def off(self):
-        """Turn off Aqara Wall Outlet"""
+        """Turn off Aqara Wall Outlet."""
         return self.send_arg("toggle_plug", ["channel_0", "off"]).pop()
 
 
 class AqaraSquareButton(SubDevice):
-    """Subdevice AqaraSquareButton specific properties and methods"""
+    """Subdevice AqaraSquareButton specific properties and methods."""
 
     properties = []
     _zigbee_model = "lumi.remote.b1acn01"
@@ -1281,7 +1281,7 @@ class AqaraSquareButton(SubDevice):
 
 
 class RemoteSwitchSingle(SubDevice):
-    """Subdevice RemoteSwitchSingle specific properties and methods"""
+    """Subdevice RemoteSwitchSingle specific properties and methods."""
 
     properties = []
     _zigbee_model = "lumi.remote.b186acn01"
@@ -1290,7 +1290,7 @@ class RemoteSwitchSingle(SubDevice):
 
 
 class RemoteSwitchDouble(SubDevice):
-    """Subdevice RemoteSwitchDouble specific properties and methods"""
+    """Subdevice RemoteSwitchDouble specific properties and methods."""
 
     properties = []
     _zigbee_model = "lumi.remote.b286acn01"

--- a/miio/gateway.py
+++ b/miio/gateway.py
@@ -653,7 +653,7 @@ class SubDevice:
 
     _zigbee_model = "unknown"
     _model = "unknown"
-    _name = "Unknown"
+    _name = "unknown"
 
     @attr.s(auto_attribs=True)
     class props:
@@ -692,6 +692,8 @@ class SubDevice:
     @property
     def name(self):
         """Return the name of the device."""
+        if self._name == "unknown":
+            self._name = self.device_type
         return f"{self._name} ({self.sid})"
 
     @property

--- a/miio/gateway.py
+++ b/miio/gateway.py
@@ -611,7 +611,9 @@ class SubDevice:
     these devices are connected through zigbee.
     """
 
+    _zigbee_model = "unknown"
     _model = "unknown"
+    _name = "Unknown"
 
     @attr.s(auto_attribs=True)
     class props:
@@ -650,12 +652,17 @@ class SubDevice:
     @property
     def name(self):
         """Return the name of the device."""
-        return f"{self.device_type}-{self.sid}"
+        return f"{self._name} ({self.sid})"
 
     @property
     def model(self):
         """Return the device model."""
         return self._model
+
+    @property
+    def zigbee_model(self):
+        """Return the zigbee device model."""
+        return self._zigbee_model
 
     @property
     def firmware_version(self):
@@ -773,7 +780,9 @@ class AqaraHT(SubDevice):
 
     accessor = "get_prop_sensor_ht"
     properties = ["temperature", "humidity", "pressure"]
-    _model = "lumi.weather.v1"
+    _zigbee_model = "lumi.weather.v1"
+    _model = "WSDCGQ11LM"
+    _name = "Weather sensor"
 
     @attr.s(auto_attribs=True)
     class props:
@@ -803,7 +812,9 @@ class SensorHT(SubDevice):
 
     accessor = "get_prop_sensor_ht"
     properties = ["temperature", "humidity", "pressure"]
+    _zigbee_model = "unknown"
     _model = "unknown"
+    _name = "Weather sensor"
 
     @attr.s(auto_attribs=True)
     class props:
@@ -832,7 +843,9 @@ class AqaraMagnet(SubDevice):
     """Subdevice AqaraMagnet specific properties and methods"""
 
     properties = ["unkown"]
-    _model = "lumi.sensor_magnet.aq2"
+    _zigbee_model = "lumi.sensor_magnet.aq2"
+    _model = "MCCGQ11LM"
+    _name = "Door sensor"
 
     @attr.s(auto_attribs=True)
     class props:
@@ -852,7 +865,9 @@ class AqaraPlug(SubDevice):
 
     accessor = "get_prop_plug"
     properties = ["power", "neutral_0", "load_power"]
+    _zigbee_model = "unknown"
     _model = "unknown"
+    _name = "Plug"
 
     @attr.s(auto_attribs=True)
     class props:
@@ -875,7 +890,9 @@ class AqaraRelayTwoChannels(SubDevice):
     """Subdevice AqaraRelayTwoChannels specific properties and methods"""
 
     properties = ["load_power", "channel_0", "channel_1"]
+    _zigbee_model = "unknown"
     _model = "unknown"
+    _name = "Relay"
 
     @attr.s(auto_attribs=True)
     class props:
@@ -919,7 +936,9 @@ class AqaraSwitchOneChannel(SubDevice):
     """Subdevice AqaraSwitchOneChannel specific properties and methods"""
 
     properties = ["neutral_0", "load_power"]
+    _zigbee_model = "unknown"
     _model = "unknown"
+    _name = "Wall switch single"
 
     @attr.s(auto_attribs=True)
     class props:
@@ -940,7 +959,9 @@ class AqaraSwitchTwoChannels(SubDevice):
     """Subdevice AqaraSwitchTwoChannels specific properties and methods"""
 
     properties = ["neutral_0", "neutral_1", "load_power"]
+    _zigbee_model = "unknown"
     _model = "unknown"
+    _name = "Wall switch double"
 
     @attr.s(auto_attribs=True)
     class props:
@@ -963,7 +984,9 @@ class AqaraWallOutlet(SubDevice):
     """Subdevice AqaraWallOutlet specific properties and methods"""
 
     properties = ["channel_0", "load_power"]
-    _model = "lumi.ctrl_86plug.aq1"
+    _zigbee_model = "lumi.ctrl_86plug.aq1"
+    _model = "QBCZ11LM"
+    _name = "Wall outlet"
 
     @attr.s(auto_attribs=True)
     class props:
@@ -999,21 +1022,27 @@ class Cube(SubDevice):
     """Subdevice Cube specific properties and methods"""
 
     properties = []
-    _model = "lumi.sensor_cube.v1"
+    _zigbee_model = "lumi.sensor_cube.v1"
+    _model = "MFKZQ01LM"
+    _name = "Cube"
 
 
 class AqaraSquareButton(SubDevice):
     """Subdevice AqaraSquareButton specific properties and methods"""
 
     properties = []
-    _model = "lumi.sensor_switch.aq3"
+    _zigbee_model = "lumi.sensor_switch.aq3"
+    _model = "WXKG12LM"
+    _name = "Button"
 
 
 class SwitchOneChannel(SubDevice):
     """Subdevice SwitchOneChannel specific properties and methods"""
 
     properties = ["neutral_0"]
-    _model = "lumi.ctrl_neutral1.v1"
+    _zigbee_model = "lumi.ctrl_neutral1.v1"
+    _model = "QBKG04LM"
+    _name = "Wall switch no neutral"
 
     @attr.s(auto_attribs=True)
     class props:
@@ -1047,18 +1076,24 @@ class RemoteSwitchSingleV1(SubDevice):
     """Subdevice RemoteSwitchSingleV1 specific properties and methods"""
 
     properties = []
-    _model = "lumi.sensor_86sw1.v1"
+    _zigbee_model = "lumi.sensor_86sw1.v1"
+    _model = "WXKG03LM 2016"
+    _name = "Remote switch single"
 
 
 class RemoteSwitchSingle(SubDevice):
     """Subdevice RemoteSwitchSingle specific properties and methods"""
 
     properties = []
-    _model = "lumi.remote.b186acn01"
+    _zigbee_model = "lumi.remote.b186acn01"
+    _model = "WXKG03LM 2018"
+    _name = "Remote switch single"
 
 
 class RemoteSwitchDouble(SubDevice):
     """Subdevice RemoteSwitchDouble specific properties and methods"""
 
     properties = []
-    _model = "lumi.remote.b286acn01"
+    _zigbee_model = "lumi.remote.b286acn01"
+    _model = "WXKG02LM 2018"
+    _name = "Remote switch double"

--- a/miio/gateway.py
+++ b/miio/gateway.py
@@ -648,6 +648,11 @@ class SubDevice:
         return self.type.name
 
     @property
+    def name(self):
+        """Return the name of the device."""
+        return f"{self.device_type}-{self.sid}"
+
+    @property
     def model(self):
         """Return the device model."""
         return self._model

--- a/miio/gateway.py
+++ b/miio/gateway.py
@@ -73,7 +73,7 @@ class DeviceType(IntEnum):
     CurtainB1 = 72  # lumi.curtain.hagl04
     LockV1 = 81  # lumi.lock.v1
     IkeaBulb82 = 82  # ikea.light.led1545g12
-    IkeaBulb83 = 83  # ikea.light.led1546g12 
+    IkeaBulb83 = 83  # ikea.light.led1546g12
     IkeaBulb84 = 84  # ikea.light.led1536g5
     IkeaBulb85 = 85  # ikea.light.led1537r6
     IkeaBulb86 = 86  # ikea.light.led1623g12
@@ -285,6 +285,14 @@ class Gateway(Device):
             # Initialize and save the subdevice, ignoring the gateway itself
             if device_type != DeviceType.Gateway:
                 self._devices[dev_info.sid] = subdevice_cls(self, dev_info)
+                if self._devices[dev_info.sid].status == {}:
+                    _LOGGER.warning(
+                        "Discovered subdevice type '%s', has no device specific properties defined, "
+                        "this device has not been fully implemented yet (model: %s, name: %s).",
+                        device_type.name,
+                        self._devices[dev_info.sid].model,
+                        self._devices[dev_info.sid].name,
+                    )
 
         return self._devices
 
@@ -706,12 +714,17 @@ class SubDevice:
             self.type = DeviceType.Unknown
 
     def __repr__(self):
-        return "<Subdevice %s: %s fw: %s bat: %s props: %s>" % (
-            self.device_type,
-            self.sid,
-            self._fw_ver,
-            self.get_battery(),
-            self.status,
+        return (
+            "<Subdevice %s: %s, model: %s, zigbee: %s, fw: %s, bat: %s, props: %s>"
+            % (
+                self.device_type,
+                self.sid,
+                self.model,
+                self.zigbee_model,
+                self.firmware_version,
+                self.get_battery(),
+                self.status,
+            )
         )
 
     @property
@@ -1190,7 +1203,7 @@ class DoorLockS1(SubDevice):
     properties = []
     _zigbee_model = "lumi.lock.aq1"
     _model = "ZNMS11LM"
-    _name = "Door lock S1" 
+    _name = "Door lock S1"
 
 
 class AqaraSquareButtonV3(SubDevice):
@@ -1484,4 +1497,3 @@ class ThermostatS2(SubDevice):
     _zigbee_model = "lumi.airrtc.tcpecn02"
     _model = "KTWKQ03ES"
     _name = "Thermostat S2"
-


### PR DESCRIPTION
In this way we can easily define how the name of subdevices schould be set in HomeAssistant. Ideally we would at some point figure out how to get the names set in the Mi Home app...
But for now use the device_type + sid as a name