### PR TITLE
Moved access to discover message attribute inside 'if message is not None' statement

### DIFF
--- a/miio/miioprotocol.py
+++ b/miio/miioprotocol.py
@@ -59,8 +59,8 @@ class MiIOProtocol:
 
         :raises DeviceException: if the device could not be discovered."""
         m = MiIOProtocol.discover(self.ip)
-        header = m.header.value
         if m is not None:
+            header = m.header.value
             self._device_id = header.device_id
             self._device_ts = header.ts
             self._discovered = True


### PR DESCRIPTION
If `m` is None, which happens if discovery fails, then `header = m.header.value` is failing. It should be inside the check that `m` is not None