### PR TITLE
Add "enable_telnet" to gateway

### DIFF
--- a/miio/gateway.py
+++ b/miio/gateway.py
@@ -10,7 +10,7 @@ import click
 
 from .click_common import EnumType, command, format_output
 from .device import Device
-from .exceptions import DeviceException
+from .exceptions import DeviceException, DeviceError
 from .utils import brightness_and_color_to_int, int_to_brightness, int_to_rgb
 
 _LOGGER = logging.getLogger(__name__)
@@ -335,7 +335,14 @@ class Gateway(Device):
     @command()
     def enable_telnet(self):
         """Enable root telnet acces to the operating system, use login "admin" or "app", no password."""
-        return self.send("enable_telnet_service")
+        try:
+            return self.send("enable_telnet_service")
+        except DeviceError:
+            _LOGGER.error(
+                "Gateway model '%s' does not (yet) support enabling the telnet interface",
+                self.model,
+            )
+            return None
 
     @command()
     def timezone(self):

--- a/miio/gateway.py
+++ b/miio/gateway.py
@@ -333,6 +333,11 @@ class Gateway(Device):
         return self.send("set_lumi_dpf_aes_key", [key])
 
     @command()
+    def enable_telnet(self):
+        """Enable root telnet acces to the operating system, use login "admin" or "app", no password."""
+        return self.send("enable_telnet_service")
+
+    @command()
     def timezone(self):
         """Get current timezone."""
         return self.get_prop("tzone_sec")

--- a/miio/gateway.py
+++ b/miio/gateway.py
@@ -10,7 +10,7 @@ import click
 
 from .click_common import EnumType, command, format_output
 from .device import Device
-from .exceptions import DeviceException, DeviceError
+from .exceptions import DeviceError, DeviceException
 from .utils import brightness_and_color_to_int, int_to_brightness, int_to_rgb
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
Apperently you can enable the telnet service on xiaomi gateways to get root acces into the operating system of the gateway.
Have not tested it myself (do not (yet) want to mess with the operating system).
But everything is discussed in this HomeAssistant community post: https://community.home-assistant.io/t/xiaomi-mijia-smart-multi-mode-gateway-zndmwg03lm-support/159586/61

It has been tried and succeded for multiple users as it seems in the community post.