### PR TITLE
fan: Ability to disable delayed turn off functionality

### DIFF
--- a/miio/fan.py
+++ b/miio/fan.py
@@ -548,7 +548,7 @@ class Fan(Device):
     def delay_off(self, seconds: int):
         """Set delay off seconds."""
 
-        if seconds < 1:
+        if seconds < 0:
             raise FanException("Invalid value for a delayed turn off: %s" % seconds)
 
         return self.send("set_poweroff_time", [seconds])
@@ -755,7 +755,7 @@ class FanP5(Device):
     def delay_off(self, minutes: int):
         """Set delay off minutes."""
 
-        if minutes < 1:
+        if minutes < 0:
             raise FanException("Invalid value for a delayed turn off: %s" % minutes)
 
         return self.send("s_t_off", [minutes])

--- a/miio/tests/test_fan.py
+++ b/miio/tests/test_fan.py
@@ -512,12 +512,11 @@ class TestFanV3(TestCase):
         assert delay_off_countdown() == 100
         self.device.delay_off(200)
         assert delay_off_countdown() == 200
+        self.device.delay_off(0)
+        assert delay_off_countdown() == 0
 
         with pytest.raises(FanException):
             self.device.delay_off(-1)
-
-        with pytest.raises(FanException):
-            self.device.delay_off(0)
 
 
 class DummyFanSA1(DummyDevice, Fan):
@@ -728,12 +727,11 @@ class TestFanSA1(TestCase):
         assert delay_off_countdown() == 100
         self.device.delay_off(200)
         assert delay_off_countdown() == 200
+        self.device.delay_off(0)
+        assert delay_off_countdown() == 0
 
         with pytest.raises(FanException):
             self.device.delay_off(-1)
-
-        with pytest.raises(FanException):
-            self.device.delay_off(0)
 
 
 class DummyFanP5(DummyDevice, FanP5):
@@ -911,9 +909,8 @@ class TestFanP5(TestCase):
         assert delay_off_countdown() == 100
         self.device.delay_off(200)
         assert delay_off_countdown() == 200
+        self.device.delay_off(0)
+        assert delay_off_countdown() == 0
 
         with pytest.raises(FanException):
             self.device.delay_off(-1)
-
-        with pytest.raises(FanException):
-            self.device.delay_off(0)

--- a/miio/tests/test_fan.py
+++ b/miio/tests/test_fan.py
@@ -259,12 +259,11 @@ class TestFanV2(TestCase):
         assert delay_off_countdown() == 100
         self.device.delay_off(200)
         assert delay_off_countdown() == 200
+        self.device.delay_off(0)
+        assert delay_off_countdown() == 0
 
         with pytest.raises(FanException):
             self.device.delay_off(-1)
-
-        with pytest.raises(FanException):
-            self.device.delay_off(0)
 
 
 class DummyFanV3(DummyDevice, Fan):


### PR DESCRIPTION
When 0 is passed, delay turn off is disabled. Before this, if delay off was set, it could not be unset.