### PR TITLE
Prepare 0.5.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+
+## [0.5.2.1](https://github.com/rytilahti/python-miio/tree/0.5.2.1) (2020-07-03)
+
+A quick minor fix for vacuum gen1 fan speed detection.
+
+[Full Changelog](https://github.com/rytilahti/python-miio/compare/0.5.2...0.5.2.1)
+
+**Merged pull requests:**
+
+- vacuum: Catch DeviceInfoUnavailableException for model detection [\#748](https://github.com/rytilahti/python-miio/pull/748) ([rytilahti](https://github.com/rytilahti))
+
 ## [0.5.2](https://github.com/rytilahti/python-miio/tree/0.5.2) (2020-07-03)
 
 This release brings several improvements to the gateway support, thanks to @starkillerOG as well as some minor improvements and fixes to some other parts.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -30,7 +30,7 @@ git commit -av
 5. Tag a release (and add short changelog as a tag commit message)
 
 ```bash
-git tag -a 0.3.1
+git tag -a $NEW_RELEASE
 ```
 
 6. Push to git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "python-miio"
-version = "0.5.2"
+version = "0.5.2.1"
 description = "Python library for interfacing with Xiaomi smart appliances"
 authors = ["Teemu R <tpr@iki.fi>"]
 repository = "https://github.com/rytilahti/python-miio"


### PR DESCRIPTION
A quick minor fix for vacuum gen1 fan speed detection.

[Full Changelog](https://github.com/rytilahti/python-miio/compare/0.5.2...0.5.2.1)

**Merged pull requests:**

- vacuum: Catch DeviceInfoUnavailableException for model detection [\#748](https://github.com/rytilahti/python-miio/pull/748) ([rytilahti](https://github.com/rytilahti))