### PR TITLE
AirPurifier MIoT: round temperature 

### DIFF
--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -100,7 +100,7 @@ class AirPurifierMiotStatus:
     def temperature(self) -> Optional[float]:
         """Current temperature, if available."""
         if self.data["temperature"] is not None:
-            return self.data["temperature"]
+            return round(self.data["temperature"], 1)
 
         return None
 

--- a/miio/tests/test_airpurifier_miot.py
+++ b/miio/tests/test_airpurifier_miot.py
@@ -13,7 +13,7 @@ _INITIAL_STATE = {
     "aqi": 10,
     "average_aqi": 8,
     "humidity": 62,
-    "temperature": 18.6,
+    "temperature": 18.599999,
     "fan_level": 2,
     "mode": 0,
     "led": True,
@@ -84,7 +84,7 @@ class TestAirPurifier(TestCase):
         assert status.aqi == _INITIAL_STATE["aqi"]
         assert status.average_aqi == _INITIAL_STATE["average_aqi"]
         assert status.humidity == _INITIAL_STATE["humidity"]
-        assert status.temperature == _INITIAL_STATE["temperature"]
+        assert status.temperature == 18.6
         assert status.fan_level == _INITIAL_STATE["fan_level"]
         assert status.mode == OperationMode(_INITIAL_STATE["mode"])
         assert status.led == _INITIAL_STATE["led"]


### PR DESCRIPTION
AirPurifier MIoT: round temperature to one decimal point to return value such as `20.8 °C` instead of `20.799999 °C`.

![image](https://user-images.githubusercontent.com/5679032/86586449-3cf24c80-bfcb-11ea-89d0-ac6ca32ac865.png)

This is either encountered only for certain temperatures or was caused by an update to new firmware (2.0.5.0009)