### PR TITLE
Resume zoned clean from error state

### DIFF
--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -112,7 +112,7 @@ class Vacuum(Device):
     def resume_or_start(self):
         """A shortcut for resuming or starting cleaning."""
         status = self.status()
-        if status.in_zone_cleaning and status.is_paused:
+        if status.in_zone_cleaning and (status.is_paused or status.got_error):
             return self.resume_zoned_clean()
 
         return self.start()


### PR DESCRIPTION
Resume zoned clean if currently in zoned clean and in error state. 

Right now, zoned clean resume is only supported when in paused state. This should also occur in the error state.