### PR TITLE
Add sphinxcontrib.apidoc to doc builds to keep the API index up-to-date

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.githubpages",
     "sphinx.ext.intersphinx",
+    "sphinxcontrib.apidoc",
     "sphinx_click.ext",
 ]
 
@@ -181,4 +182,8 @@ texinfo_documents = [
     )
 ]
 
-intersphinx_mapping = {"python": ("https://docs.python.org/3.6", None)}
+intersphinx_mapping = {"python": ("https://docs.python.org/3.8", None)}
+
+apidoc_module_dir = "../miio"
+apidoc_output_dir = "."
+apidoc_excluded_paths = ["tests"]

--- a/docs/miio.rst
+++ b/docs/miio.rst
@@ -4,244 +4,419 @@ miio package
 Submodules
 ----------
 
-miio\.airconditioningcompanion module
--------------------------------------
+miio.airconditioningcompanion module
+------------------------------------
 
 .. automodule:: miio.airconditioningcompanion
-    :members:
-    :show-inheritance:
-    :undoc-members:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-miio\.airfresh module
----------------------
+miio.airdehumidifier module
+---------------------------
+
+.. automodule:: miio.airdehumidifier
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.airfilter\_util module
+---------------------------
+
+.. automodule:: miio.airfilter_util
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.airfresh module
+--------------------
 
 .. automodule:: miio.airfresh
-    :members:
-    :show-inheritance:
-    :undoc-members:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-miio\.airhumidifier module
---------------------------
+miio.airfresh\_t2017 module
+---------------------------
+
+.. automodule:: miio.airfresh_t2017
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.airhumidifier module
+-------------------------
 
 .. automodule:: miio.airhumidifier
-    :members:
-    :show-inheritance:
-    :undoc-members:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-miio\.airpurifier module
-------------------------
+miio.airhumidifier\_jsq module
+------------------------------
+
+.. automodule:: miio.airhumidifier_jsq
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.airhumidifier\_mjjsq module
+--------------------------------
+
+.. automodule:: miio.airhumidifier_mjjsq
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.airpurifier module
+-----------------------
 
 .. automodule:: miio.airpurifier
-    :members:
-    :show-inheritance:
-    :undoc-members:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-miio\.airpurifier_miot module
+miio.airpurifier\_miot module
 -----------------------------
 
 .. automodule:: miio.airpurifier_miot
-    :members:
-    :show-inheritance:
-    :undoc-members:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-miio\.airqualitymonitor module
-------------------------------
+miio.airqualitymonitor module
+-----------------------------
 
 .. automodule:: miio.airqualitymonitor
-    :members:
-    :show-inheritance:
-    :undoc-members:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-miio\.aqaracamera module
-------------------------
-
-.. automodule:: miio.aqaracamera
-    :members:
-    :show-inheritance:
-    :undoc-members:
-
-
-miio\.ceil module
------------------
-
-.. automodule:: miio.ceil
-    :members:
-    :show-inheritance:
-    :undoc-members:
-
-miio\.chuangmi\_camera module
------------------------------
-
-.. automodule:: miio.chuangmi_camera
-    :members:
-    :show-inheritance:
-    :undoc-members:
-
-miio\.chuangmi\_ir module
--------------------------
-
-.. automodule:: miio.chuangmi_ir
-    :members:
-    :show-inheritance:
-    :undoc-members:
-
-miio\.cooker module
--------------------
-
-.. automodule:: miio.cooker
-    :members:
-    :show-inheritance:
-    :undoc-members:
-
-miio\.device module
--------------------
-
-.. automodule:: miio.device
-    :members:
-    :show-inheritance:
-    :undoc-members:
-
-miio\.miot_device module
-------------------------
-
-.. automodule:: miio.miot_device
-    :members:
-    :show-inheritance:
-    :undoc-members:
-
-miio\.discovery module
+miio.alarmclock module
 ----------------------
 
-.. automodule:: miio.discovery
-    :members:
-    :show-inheritance:
-    :undoc-members:
+.. automodule:: miio.alarmclock
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-miio\.extract\_tokens module
-----------------------------
+miio.aqaracamera module
+-----------------------
 
-.. automodule:: miio.extract_tokens
-    :members:
-    :show-inheritance:
-    :undoc-members:
+.. automodule:: miio.aqaracamera
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-miio\.fan module
+miio.ceil module
 ----------------
 
-.. automodule:: miio.fan
-    :members:
-    :show-inheritance:
-    :undoc-members:
+.. automodule:: miio.ceil
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-miio\.philips\_bulb module
---------------------------
+miio.ceil\_cli module
+---------------------
 
-.. automodule:: miio.philips_bulb
-    :members:
-    :show-inheritance:
-    :undoc-members:
+.. automodule:: miio.ceil_cli
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-miio\.philips\_eyecare module
------------------------------
+miio.chuangmi\_camera module
+----------------------------
 
-.. automodule:: miio.philips_eyecare
-    :members:
-    :show-inheritance:
-    :undoc-members:
+.. automodule:: miio.chuangmi_camera
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-miio\.philips\_moonlight module
--------------------------------
+miio.chuangmi\_ir module
+------------------------
 
-.. automodule:: miio.philips_moonlight
-    :members:
-    :show-inheritance:
-    :undoc-members:
+.. automodule:: miio.chuangmi_ir
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-miio\.chuangmi_plug module
+miio.chuangmi\_plug module
 --------------------------
 
 .. automodule:: miio.chuangmi_plug
-    :members:
-    :show-inheritance:
-    :undoc-members:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-miio\.protocol module
----------------------
+miio.cli module
+---------------
 
-.. automodule:: miio.protocol
-    :members:
-    :show-inheritance:
-    :undoc-members:
+.. automodule:: miio.cli
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-miio\.powerstrip module
------------------------
-
-.. automodule:: miio.powerstrip
-    :members:
-    :show-inheritance:
-    :undoc-members:
-
-miio\.vacuum module
--------------------
-
-.. automodule:: miio.vacuum
-    :members:
-    :show-inheritance:
-    :undoc-members:
-
-miio\.vacuumcontainers module
------------------------------
-
-.. automodule:: miio.vacuumcontainers
-    :members:
-    :show-inheritance:
-    :undoc-members:
-
-miio\.version module
---------------------
-
-.. automodule:: miio.version
-    :members:
-    :show-inheritance:
-    :undoc-members:
-
-miio\.waterpurifier module
---------------------------
-
-.. automodule:: miio.waterpurifier
-    :members:
-    :show-inheritance:
-    :undoc-members:
-
-miio\.wifirepeater module
+miio.click\_common module
 -------------------------
 
-.. automodule:: miio.wifirepeater
-    :members:
-    :show-inheritance:
-    :undoc-members:
+.. automodule:: miio.click_common
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-miio\.wifispeaker module
-------------------------
+miio.cooker module
+------------------
 
-.. automodule:: miio.wifispeaker
-    :members:
-    :show-inheritance:
-    :undoc-members:
+.. automodule:: miio.cooker
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-miio\.yeelight module
+miio.device module
+------------------
+
+.. automodule:: miio.device
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.discovery module
 ---------------------
 
+.. automodule:: miio.discovery
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.exceptions module
+----------------------
+
+.. automodule:: miio.exceptions
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.extract\_tokens module
+---------------------------
+
+.. automodule:: miio.extract_tokens
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.fan module
+---------------
+
+.. automodule:: miio.fan
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.gateway module
+-------------------
+
+.. automodule:: miio.gateway
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.heater module
+------------------
+
+.. automodule:: miio.heater
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.miioprotocol module
+------------------------
+
+.. automodule:: miio.miioprotocol
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.miot\_device module
+------------------------
+
+.. automodule:: miio.miot_device
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.parse\_ast module
+----------------------
+
+.. automodule:: miio.parse_ast
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.philips\_bulb module
+-------------------------
+
+.. automodule:: miio.philips_bulb
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.philips\_eyecare module
+----------------------------
+
+.. automodule:: miio.philips_eyecare
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.philips\_eyecare\_cli module
+---------------------------------
+
+.. automodule:: miio.philips_eyecare_cli
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.philips\_moonlight module
+------------------------------
+
+.. automodule:: miio.philips_moonlight
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.philips\_rwread module
+---------------------------
+
+.. automodule:: miio.philips_rwread
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.plug\_cli module
+---------------------
+
+.. automodule:: miio.plug_cli
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.powerstrip module
+----------------------
+
+.. automodule:: miio.powerstrip
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.protocol module
+--------------------
+
+.. automodule:: miio.protocol
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.pwzn\_relay module
+-----------------------
+
+.. automodule:: miio.pwzn_relay
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.toiletlid module
+---------------------
+
+.. automodule:: miio.toiletlid
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.updater module
+-------------------
+
+.. automodule:: miio.updater
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.utils module
+-----------------
+
+.. automodule:: miio.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.vacuum module
+------------------
+
+.. automodule:: miio.vacuum
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.vacuum\_cli module
+-----------------------
+
+.. automodule:: miio.vacuum_cli
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.vacuumcontainers module
+----------------------------
+
+.. automodule:: miio.vacuumcontainers
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.viomivacuum module
+-----------------------
+
+.. automodule:: miio.viomivacuum
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.waterpurifier module
+-------------------------
+
+.. automodule:: miio.waterpurifier
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.wifirepeater module
+------------------------
+
+.. automodule:: miio.wifirepeater
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.wifispeaker module
+-----------------------
+
+.. automodule:: miio.wifispeaker
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+miio.yeelight module
+--------------------
+
 .. automodule:: miio.yeelight
-    :members:
-    :show-inheritance:
-    :undoc-members:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
 Module contents
 ---------------
 
 .. automodule:: miio
-    :members:
-    :show-inheritance:
-    :undoc-members:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,7 +2,7 @@
 category = "main"
 description = "A configurable sidebar-enabled Sphinx theme"
 name = "alabaster"
-optional = true
+optional = false
 python-versions = "*"
 version = "0.7.12"
 
@@ -49,7 +49,7 @@ tests = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.i
 category = "main"
 description = "Internationalization utilities"
 name = "babel"
-optional = true
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "2.8.0"
 
@@ -60,7 +60,7 @@ pytz = ">=2015.7"
 category = "main"
 description = "Python package for providing Mozilla's CA Bundle."
 name = "certifi"
-optional = true
+optional = false
 python-versions = "*"
 version = "2020.6.20"
 
@@ -216,7 +216,7 @@ license = ["editdistance"]
 category = "main"
 description = "Internationalized Domain Names in Applications (IDNA)"
 name = "idna"
-optional = true
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "2.10"
 
@@ -232,7 +232,7 @@ version = "0.1.7"
 category = "main"
 description = "Getting image size from png/jpeg/jpeg2000/gif file"
 name = "imagesize"
-optional = true
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.2.0"
 
@@ -286,7 +286,7 @@ xdg_home = ["appdirs (>=1.4.0)"]
 category = "main"
 description = "A very fast and expressive template engine."
 name = "jinja2"
-optional = true
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "2.11.2"
 
@@ -300,7 +300,7 @@ i18n = ["Babel (>=0.8)"]
 category = "main"
 description = "Safely add untrusted strings to HTML/XML markup."
 name = "markupsafe"
-optional = true
+optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
 version = "1.1.1"
 
@@ -518,7 +518,7 @@ version = "5.3.1"
 category = "main"
 description = "Python HTTP for Humans."
 name = "requests"
-optional = true
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "2.24.0"
 
@@ -555,7 +555,7 @@ version = "1.15.0"
 category = "main"
 description = "This package provides 26 stemmers for 25 languages generated from Snowball algorithms."
 name = "snowballstemmer"
-optional = true
+optional = false
 python-versions = "*"
 version = "2.0.0"
 
@@ -563,7 +563,7 @@ version = "2.0.0"
 category = "main"
 description = "Python documentation generator"
 name = "sphinx"
-optional = true
+optional = false
 python-versions = ">=3.5"
 version = "3.1.2"
 
@@ -605,9 +605,21 @@ sphinx = ">=1.5,<4.0"
 
 [[package]]
 category = "main"
+description = "A Sphinx extension for running 'sphinx-apidoc' on each build"
+name = "sphinxcontrib-apidoc"
+optional = false
+python-versions = "*"
+version = "0.3.0"
+
+[package.dependencies]
+Sphinx = ">=1.6.0"
+pbr = "*"
+
+[[package]]
+category = "main"
 description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books"
 name = "sphinxcontrib-applehelp"
-optional = true
+optional = false
 python-versions = ">=3.5"
 version = "1.0.2"
 
@@ -619,7 +631,7 @@ test = ["pytest"]
 category = "main"
 description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document."
 name = "sphinxcontrib-devhelp"
-optional = true
+optional = false
 python-versions = ">=3.5"
 version = "1.0.2"
 
@@ -631,7 +643,7 @@ test = ["pytest"]
 category = "main"
 description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
 name = "sphinxcontrib-htmlhelp"
-optional = true
+optional = false
 python-versions = ">=3.5"
 version = "1.0.3"
 
@@ -643,7 +655,7 @@ test = ["pytest", "html5lib"]
 category = "main"
 description = "A sphinx extension which renders display math in HTML via JavaScript"
 name = "sphinxcontrib-jsmath"
-optional = true
+optional = false
 python-versions = ">=3.5"
 version = "1.0.1"
 
@@ -654,7 +666,7 @@ test = ["pytest", "flake8", "mypy"]
 category = "main"
 description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp document."
 name = "sphinxcontrib-qthelp"
-optional = true
+optional = false
 python-versions = ">=3.5"
 version = "1.0.3"
 
@@ -666,7 +678,7 @@ test = ["pytest"]
 category = "main"
 description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)."
 name = "sphinxcontrib-serializinghtml"
-optional = true
+optional = false
 python-versions = ">=3.5"
 version = "1.1.4"
 
@@ -738,7 +750,7 @@ dev = ["py-make (>=0.1.0)", "twine", "argopt", "pydoc-markdown"]
 category = "main"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 name = "urllib3"
-optional = true
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 version = "1.25.9"
 
@@ -813,10 +825,10 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [extras]
-docs = ["sphinx", "sphinx_click"]
+docs = ["sphinx", "sphinx_click", "sphinxcontrib-apidoc"]
 
 [metadata]
-content-hash = "ac85ba27a4011574728896038652bc9a3671620a8f5dd080c6fede22b3831eeb"
+content-hash = "23e5d6c1a4702823bdb5031e34a305121dd68af1bad551053342d35f62c4bd7f"
 python-versions = "^3.6.5"
 
 [metadata.files]
@@ -1162,6 +1174,10 @@ sphinx = [
 sphinx-click = [
     {file = "sphinx-click-2.3.2.tar.gz", hash = "sha256:1b649ebe9f7a85b78ef6545d1dc258da5abca850ac6375be104d484a6334a728"},
     {file = "sphinx_click-2.3.2-py2.py3-none-any.whl", hash = "sha256:06952d5de6cbe2cb7d6dc656bc471652d2b484cf1e1b2d65edb7f4f2e867c7f6"},
+]
+sphinxcontrib-apidoc = [
+    {file = "sphinxcontrib-apidoc-0.3.0.tar.gz", hash = "sha256:729bf592cf7b7dd57c4c05794f732dc026127275d785c2a5494521fdde773fb9"},
+    {file = "sphinxcontrib_apidoc-0.3.0-py2.py3-none-any.whl", hash = "sha256:6671a46b2c6c5b0dca3d8a147849d159065e50443df79614f921b42fbd15cb09"},
 ]
 sphinxcontrib-applehelp = [
     {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,10 @@ croniter = "^0.3.32"
 
 sphinx = { version = "^3.1", optional = true }
 sphinx_click = { version = "^2.3", optional = true }
+sphinxcontrib-apidoc = { version = "^0.3.0", optional = true }
 
 [tool.poetry.extras]
-docs = ["sphinx", "sphinx_click"]
+docs = ["sphinx", "sphinx_click", "sphinxcontrib-apidoc"]
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.4.1"


### PR DESCRIPTION
This makes doc builds to update the index file for API docs, making it unnecessary to manually keep `miio.rst` up-to-date when new modules get added.