### PR TITLE
Add preliminary issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Version information (please complete the following information):**
+ - OS: [e.g.Linux]
+ - python-miio: [Use `miiocli --version` or `pip show python-miio`]
+
+**Device information:**
+If the issue is specific to a device [Use `miiocli device --ip <ip address> --token <token>`]:
+  - Model: 
+  - Hardware version:
+  - Firmware version:
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. 
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Console output**
+If applicable, add console output to help explain your problem.
+If the issue is about communication with a specific device, consider including the output using the `--debug` flag.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,29 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Device information:**
+If the enhancement is device-specific, please include also the following information.
+
+  - Name(s) of the device:
+  - Link:
+
+Use `miiocli device --ip <ip address> --token <token>`.
+
+  - Model: [e.g., lumi.gateway.v3]
+  - Hardware version:
+  - Firmware version:
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/new-device.md
+++ b/.github/ISSUE_TEMPLATE/new-device.md
@@ -1,0 +1,24 @@
+---
+name: New device
+about: Request to add support for a new, unsupported device
+title: ''
+labels: new device
+assignees: ''
+
+---
+
+Before submitting a new request, use the search to see if there is an existing issue for the device.
+
+**Device information:**
+
+  - Name(s) of the device:
+  - Link:
+
+Use `miiocli device --ip <ip address> --token <token>`.
+
+  - Model: [e.g., lumi.gateway.v3]
+  - Hardware version:
+  - Firmware version:
+
+**Additional context**
+If you know already about potential commands or any other useful information to add support for the device, please add that information here.


### PR DESCRIPTION
Streamline issue reporting by adding some templates with the information that should be included.