### PR TITLE
Loosen pinned versions

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -504,7 +504,7 @@ description = "World timezone definitions, modern and historical"
 name = "pytz"
 optional = false
 python-versions = "*"
-version = "2019.3"
+version = "2020.1"
 
 [[package]]
 category = "dev"
@@ -821,10 +821,10 @@ description = "Pure Python Multicast DNS Service Discovery Library (Bonjour/Avah
 name = "zeroconf"
 optional = false
 python-versions = "*"
-version = "0.25.1"
+version = "0.28.0"
 
 [package.dependencies]
-ifaddr = "*"
+ifaddr = ">=0.1.7"
 
 [[package]]
 category = "main"
@@ -842,7 +842,7 @@ testing = ["jaraco.itertools", "func-timeout"]
 docs = ["sphinx", "sphinx_click", "sphinxcontrib-apidoc", "sphinx_rtd_theme"]
 
 [metadata]
-content-hash = "fe0f48c710318886270f5b9d0510ffc3788e04a920b1062e779e114127605886"
+content-hash = "c8db3710e0e6341decff8d047f8d16035ef994f784c9e30335233e68d8637c08"
 python-versions = "^3.6.5"
 
 [metadata.files]
@@ -1150,8 +1150,8 @@ python-dateutil = [
     {file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"},
 ]
 pytz = [
-    {file = "pytz-2019.3-py2.py3-none-any.whl", hash = "sha256:1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d"},
-    {file = "pytz-2019.3.tar.gz", hash = "sha256:b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"},
+    {file = "pytz-2020.1-py2.py3-none-any.whl", hash = "sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed"},
+    {file = "pytz-2020.1.tar.gz", hash = "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"},
 ]
 pyyaml = [
     {file = "PyYAML-5.3.1-cp27-cp27m-win32.whl", hash = "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f"},
@@ -1253,8 +1253,8 @@ wcwidth = [
     {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
 ]
 zeroconf = [
-    {file = "zeroconf-0.25.1-py3-none-any.whl", hash = "sha256:265bc23ddcea3d76940b6bb5b85d8a5a4e20618e5e6c3da677794e7e26a0e8c5"},
-    {file = "zeroconf-0.25.1.tar.gz", hash = "sha256:9b6eb9f73410cc06d203ca510f470e23e83affbe1bd65551daea2990b9171f75"},
+    {file = "zeroconf-0.28.0-py3-none-any.whl", hash = "sha256:8c448ad37ed074ce8811c9eb2765c01714a93f977a1c04fc39fbf6f516b0566f"},
+    {file = "zeroconf-0.28.0.tar.gz", hash = "sha256:881da2ed3d7c8e0ab59fb1cc8b02b53134351941c4d8d3f3553a96700f257a03"},
 ]
 zipp = [
     {file = "zipp-3.1.0-py3-none-any.whl", hash = "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,38 +22,38 @@ miiocli = "miio.cli:create_cli"
 
 [tool.poetry.dependencies]
 python = "^3.6.5"
-click = "^7.1.1"
-cryptography = "^2.9"
+click = "^7"
+cryptography = "^2"
 construct = "^2.10.56"
-zeroconf = "^0.25.1"
-attrs = "^19.3.0"
-pytz = "^2019.3"
-appdirs = "^1.4.3"
-tqdm = "^4.45.0"
-netifaces = "^0.10.9"
-android_backup = { version = "^0.2", optional = true }
-importlib_metadata = "^1.6.0"
-croniter = "^0.3.32"
+zeroconf = "^0"
+attrs = "*"
+pytz = "*"
+appdirs = "^1"
+tqdm = "^4"
+netifaces = "^0"
+android_backup = { version = "^0", optional = true }
+importlib_metadata = "^1"
+croniter = "^0"
 
-sphinx = { version = "^3.1", optional = true }
-sphinx_click = { version = "^2.3", optional = true }
-sphinxcontrib-apidoc = { version = "^0.3.0", optional = true }
-sphinx_rtd_theme = { version = "^0.5.0", optional = true }
+sphinx = { version = "^3", optional = true }
+sphinx_click = { version = "^2", optional = true }
+sphinxcontrib-apidoc = { version = "^0", optional = true }
+sphinx_rtd_theme = { version = "^0", optional = true }
 
 [tool.poetry.extras]
 docs = ["sphinx", "sphinx_click", "sphinxcontrib-apidoc", "sphinx_rtd_theme"]
 
 [tool.poetry.dev-dependencies]
-pytest = "^5.4.1"
-pytest-cov = "^2.8.1"
-pytest-mock = "^3.1.0"
-voluptuous = "^0.11.7"
-pre-commit = "^2.2.0"
-doc8 = "^0.8.0"
-restructuredtext_lint = "^1.3.0"
-tox = "^3.14.6"
-isort = "^4.3.21"
-cffi = "^1.14.0"
+pytest = "^5"
+pytest-cov = "^2"
+pytest-mock = "^3"
+voluptuous = "^0"
+pre-commit = "^2"
+doc8 = "^0"
+restructuredtext_lint = "^1"
+tox = "^3"
+isort = "^4"
+cffi = "^1"
 
 [tool.isort]
 multi_line_output = 3


### PR DESCRIPTION
* Most of the cases depend now only on the same major version
* Special cases:
  * attrs: https://www.attrs.org/en/stable/backward-compatibility.html
  * pytz: uses YEAR.x format, considering we only use very basic API there should be no breakages
  * python ^3.6.5
  * construct ^2.10.56: was previously prone to break compatibility between any releases, but there has been no new releases for a while

Fixes #779, fixes #780