### PR TITLE
Make EnumType default to incasesensitive for cli tool

### DIFF
--- a/miio/airconditioningcompanion.py
+++ b/miio/airconditioningcompanion.py
@@ -403,12 +403,12 @@ class AirConditioningCompanion(Device):
 
     @command(
         click.argument("model", type=str),
-        click.argument("power", type=EnumType(Power, False)),
-        click.argument("operation_mode", type=EnumType(OperationMode, False)),
+        click.argument("power", type=EnumType(Power)),
+        click.argument("operation_mode", type=EnumType(OperationMode)),
         click.argument("target_temperature", type=int),
-        click.argument("fan_speed", type=EnumType(FanSpeed, False)),
-        click.argument("swing_mode", type=EnumType(SwingMode, False)),
-        click.argument("led", type=EnumType(Led, False)),
+        click.argument("fan_speed", type=EnumType(FanSpeed)),
+        click.argument("swing_mode", type=EnumType(SwingMode)),
+        click.argument("led", type=EnumType(Led)),
         default_output=format_output("Sending a configuration to the air conditioner"),
     )
     def send_configuration(

--- a/miio/airdehumidifier.py
+++ b/miio/airdehumidifier.py
@@ -253,7 +253,7 @@ class AirDehumidifier(Device):
         return self.send("set_power", ["off"])
 
     @command(
-        click.argument("mode", type=EnumType(OperationMode, False)),
+        click.argument("mode", type=EnumType(OperationMode)),
         default_output=format_output("Setting mode to '{mode.value}'"),
     )
     def set_mode(self, mode: OperationMode):
@@ -268,7 +268,7 @@ class AirDehumidifier(Device):
             raise
 
     @command(
-        click.argument("fan_speed", type=EnumType(FanSpeed, False)),
+        click.argument("fan_speed", type=EnumType(FanSpeed)),
         default_output=format_output("Setting fan level to {fan_level}"),
     )
     def set_fan_speed(self, fan_speed: FanSpeed):

--- a/miio/airfresh.py
+++ b/miio/airfresh.py
@@ -243,7 +243,7 @@ class AirFresh(Device):
         return self.send("set_power", ["off"])
 
     @command(
-        click.argument("mode", type=EnumType(OperationMode, False)),
+        click.argument("mode", type=EnumType(OperationMode)),
         default_output=format_output("Setting mode to '{mode.value}'"),
     )
     def set_mode(self, mode: OperationMode):
@@ -264,7 +264,7 @@ class AirFresh(Device):
             return self.send("set_led", ["off"])
 
     @command(
-        click.argument("brightness", type=EnumType(LedBrightness, False)),
+        click.argument("brightness", type=EnumType(LedBrightness)),
         default_output=format_output("Setting LED brightness to {brightness}"),
     )
     def set_led_brightness(self, brightness: LedBrightness):

--- a/miio/airfresh_t2017.py
+++ b/miio/airfresh_t2017.py
@@ -295,7 +295,7 @@ class AirFreshT2017(Device):
         return self.send("set_power", ["off"])
 
     @command(
-        click.argument("mode", type=EnumType(OperationMode, False)),
+        click.argument("mode", type=EnumType(OperationMode)),
         default_output=format_output("Setting mode to '{mode.value}'"),
     )
     def set_mode(self, mode: OperationMode):
@@ -316,7 +316,7 @@ class AirFreshT2017(Device):
             return self.send("set_display", ["off"])
 
     @command(
-        click.argument("orientation", type=EnumType(DisplayOrientation, False)),
+        click.argument("orientation", type=EnumType(DisplayOrientation)),
         default_output=format_output("Setting orientation to '{orientation.value}'"),
     )
     def set_display_orientation(self, orientation: DisplayOrientation):
@@ -324,7 +324,7 @@ class AirFreshT2017(Device):
         return self.send("set_screen_direction", [orientation.value])
 
     @command(
-        click.argument("level", type=EnumType(PtcLevel, False)),
+        click.argument("level", type=EnumType(PtcLevel)),
         default_output=format_output("Setting ptc level to '{level.value}'"),
     )
     def set_ptc_level(self, level: PtcLevel):

--- a/miio/airhumidifier.py
+++ b/miio/airhumidifier.py
@@ -326,7 +326,7 @@ class AirHumidifier(Device):
         return self.send("set_power", ["off"])
 
     @command(
-        click.argument("mode", type=EnumType(OperationMode, False)),
+        click.argument("mode", type=EnumType(OperationMode)),
         default_output=format_output("Setting mode to '{mode.value}'"),
     )
     def set_mode(self, mode: OperationMode):
@@ -341,7 +341,7 @@ class AirHumidifier(Device):
             raise
 
     @command(
-        click.argument("brightness", type=EnumType(LedBrightness, False)),
+        click.argument("brightness", type=EnumType(LedBrightness)),
         default_output=format_output("Setting LED brightness to {brightness}"),
     )
     def set_led_brightness(self, brightness: LedBrightness):

--- a/miio/airhumidifier_jsq.py
+++ b/miio/airhumidifier_jsq.py
@@ -229,7 +229,7 @@ class AirHumidifierJsq(Device):
         return self.send("set_start", [0])
 
     @command(
-        click.argument("mode", type=EnumType(OperationMode, False)),
+        click.argument("mode", type=EnumType(OperationMode)),
         default_output=format_output("Setting mode to '{mode.value}'"),
     )
     def set_mode(self, mode: OperationMode):
@@ -243,7 +243,7 @@ class AirHumidifierJsq(Device):
         return self.send("set_mode", [value])
 
     @command(
-        click.argument("brightness", type=EnumType(LedBrightness, False)),
+        click.argument("brightness", type=EnumType(LedBrightness)),
         default_output=format_output("Setting LED brightness to {brightness}"),
     )
     def set_led_brightness(self, brightness: LedBrightness):

--- a/miio/airhumidifier_miot.py
+++ b/miio/airhumidifier_miot.py
@@ -326,7 +326,7 @@ class AirHumidifierMiot(MiotDevice):
         return self.set_property("target_humidity", humidity)
 
     @command(
-        click.argument("mode", type=EnumType(OperationMode, False)),
+        click.argument("mode", type=EnumType(OperationMode)),
         default_output=format_output("Setting mode to '{mode.value}'"),
     )
     def set_mode(self, mode: OperationMode):
@@ -334,7 +334,7 @@ class AirHumidifierMiot(MiotDevice):
         return self.set_property("mode", mode.value)
 
     @command(
-        click.argument("brightness", type=EnumType(LedBrightness, False)),
+        click.argument("brightness", type=EnumType(LedBrightness)),
         default_output=format_output("Setting LED brightness to {brightness}"),
     )
     def set_led_brightness(self, brightness: LedBrightness):

--- a/miio/airhumidifier_mjjsq.py
+++ b/miio/airhumidifier_mjjsq.py
@@ -182,7 +182,7 @@ class AirHumidifierMjjsq(Device):
         return self.send("Set_OnOff", [0])
 
     @command(
-        click.argument("mode", type=EnumType(OperationMode, False)),
+        click.argument("mode", type=EnumType(OperationMode)),
         default_output=format_output("Setting mode to '{mode.value}'"),
     )
     def set_mode(self, mode: OperationMode):

--- a/miio/airpurifier.py
+++ b/miio/airpurifier.py
@@ -424,7 +424,7 @@ class AirPurifier(Device):
         return self.send("set_power", ["off"])
 
     @command(
-        click.argument("mode", type=EnumType(OperationMode, False)),
+        click.argument("mode", type=EnumType(OperationMode)),
         default_output=format_output("Setting mode to '{mode.value}'"),
     )
     def set_mode(self, mode: OperationMode):
@@ -447,7 +447,7 @@ class AirPurifier(Device):
         return self.send("set_level_favorite", [level])  # 0 ... 17
 
     @command(
-        click.argument("brightness", type=EnumType(LedBrightness, False)),
+        click.argument("brightness", type=EnumType(LedBrightness)),
         default_output=format_output("Setting LED brightness to {brightness}"),
     )
     def set_led_brightness(self, brightness: LedBrightness):

--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -348,7 +348,7 @@ class AirPurifierMiot(MiotDevice):
         return self.set_property("buzzer_volume", volume)
 
     @command(
-        click.argument("mode", type=EnumType(OperationMode, False)),
+        click.argument("mode", type=EnumType(OperationMode)),
         default_output=format_output("Setting mode to '{mode.value}'"),
     )
     def set_mode(self, mode: OperationMode):
@@ -369,7 +369,7 @@ class AirPurifierMiot(MiotDevice):
         return self.set_property("favorite_level", level)
 
     @command(
-        click.argument("brightness", type=EnumType(LedBrightness, False)),
+        click.argument("brightness", type=EnumType(LedBrightness)),
         default_output=format_output("Setting LED brightness to {brightness}"),
     )
     def set_led_brightness(self, brightness: LedBrightness):

--- a/miio/alarmclock.py
+++ b/miio/alarmclock.py
@@ -90,9 +90,7 @@ class AlarmClock(Device):
         """
         return HourlySystem(self.send("get_hourly_system")[0])
 
-    @command(
-        click.argument("brightness", type=EnumType(HourlySystem, casesensitive=False))
-    )
+    @command(click.argument("brightness", type=EnumType(HourlySystem)))
     def set_hourly_system(self, hs: HourlySystem):
         return self.send("set_hourly_system", [hs.value])
 
@@ -126,9 +124,7 @@ class AlarmClock(Device):
 
     @command(
         click.argument(
-            "alarm_type",
-            type=EnumType(AlarmType, casesensitive=False),
-            default=AlarmType.Alarm.name,
+            "alarm_type", type=EnumType(AlarmType), default=AlarmType.Alarm.name
         )
     )
     def get_ring(self, alarm_type: AlarmType):
@@ -136,8 +132,8 @@ class AlarmClock(Device):
         return RingTone(self.send("get_ring", [{"type": alarm_type.value}]).pop())
 
     @command(
-        click.argument("alarm_type", type=EnumType(AlarmType, casesensitive=False)),
-        click.argument("tone", type=EnumType(Tone, casesensitive=False)),
+        click.argument("alarm_type", type=EnumType(AlarmType)),
+        click.argument("tone", type=EnumType(Tone)),
     )
     def set_ring(self, alarm_type: AlarmType, ring: RingTone):
         """Set alarm tone.

--- a/miio/chuangmi_camera.py
+++ b/miio/chuangmi_camera.py
@@ -327,7 +327,7 @@ class ChuangmiCamera(Device):
         return self.send("set_night_mode", [2])
 
     @command(
-        click.argument("direction", type=EnumType(Direction, False)),
+        click.argument("direction", type=EnumType(Direction)),
         default_output=format_output("Rotating to direction '{direction.name}'"),
     )
     def rotate(self, direction: Direction):
@@ -340,7 +340,7 @@ class ChuangmiCamera(Device):
         return self.send("alarm_sound")
 
     @command(
-        click.argument("sensitivity", type=EnumType(MotionDetectionSensitivity, False)),
+        click.argument("sensitivity", type=EnumType(MotionDetectionSensitivity)),
         default_output=format_output("Setting motion sensitivity '{sensitivity.name}'"),
     )
     def set_motion_sensitivity(self, sensitivity: MotionDetectionSensitivity):
@@ -353,7 +353,7 @@ class ChuangmiCamera(Device):
         )
 
     @command(
-        click.argument("mode", type=EnumType(HomeMonitoringMode, False)),
+        click.argument("mode", type=EnumType(HomeMonitoringMode)),
         click.argument("start-hour", default=10),
         click.argument("start-minute", default=0),
         click.argument("end-hour", default=17),
@@ -378,23 +378,21 @@ class ChuangmiCamera(Device):
             [mode, start_hour, start_minute, end_hour, end_minute, notify, interval],
         )
 
-    @command(default_output=format_output("Clearing NAS directory"),)
+    @command(default_output=format_output("Clearing NAS directory"))
     def clear_nas_dir(self):
         """Clear NAS directory"""
-        return self.send("nas_clear_dir", [[]],)
+        return self.send("nas_clear_dir", [[]])
 
-    @command(default_output=format_output("Getting NAS config info"),)
+    @command(default_output=format_output("Getting NAS config info"))
     def get_nas_config(self):
         """Get NAS config info"""
-        return self.send("nas_get_config", {},)
+        return self.send("nas_get_config", {})
 
     @command(
-        click.argument("state", type=EnumType(NASState, False)),
+        click.argument("state", type=EnumType(NASState)),
         click.argument("share"),
-        click.argument("sync-interval", type=EnumType(NASSyncInterval, False)),
-        click.argument(
-            "video-retention-time", type=EnumType(NASVideoRetentionTime, False)
-        ),
+        click.argument("sync-interval", type=EnumType(NASSyncInterval)),
+        click.argument("video-retention-time", type=EnumType(NASVideoRetentionTime)),
         default_output=format_output("Setting NAS config to '{state.name}'"),
     )
     def set_nas_config(

--- a/miio/click_common.py
+++ b/miio/click_common.py
@@ -63,7 +63,7 @@ class ExceptionHandlerGroup(click.Group):
 
 
 class EnumType(click.Choice):
-    def __init__(self, enumcls, casesensitive=True):
+    def __init__(self, enumcls, casesensitive=False):
         choices = enumcls.__members__
 
         if not casesensitive:

--- a/miio/fan.py
+++ b/miio/fan.py
@@ -455,7 +455,7 @@ class Fan(Device):
         return self.send("set_speed_level", [speed])
 
     @command(
-        click.argument("direction", type=EnumType(MoveDirection, False)),
+        click.argument("direction", type=EnumType(MoveDirection)),
         default_output=format_output("Rotating the fan to the {direction}"),
     )
     def set_rotate(self, direction: MoveDirection):
@@ -489,7 +489,7 @@ class Fan(Device):
             return self.send("set_angle_enable", ["off"])
 
     @command(
-        click.argument("brightness", type=EnumType(LedBrightness, False)),
+        click.argument("brightness", type=EnumType(LedBrightness)),
         default_output=format_output("Setting LED brightness to {brightness}"),
     )
     def set_led_brightness(self, brightness: LedBrightness):
@@ -663,7 +663,7 @@ class FanP5(Device):
         return self.send("s_power", [False])
 
     @command(
-        click.argument("mode", type=EnumType(OperationMode, False)),
+        click.argument("mode", type=EnumType(OperationMode)),
         default_output=format_output("Setting mode to '{mode.value}'"),
     )
     def set_mode(self, mode: OperationMode):
@@ -761,7 +761,7 @@ class FanP5(Device):
         return self.send("s_t_off", [minutes])
 
     @command(
-        click.argument("direction", type=EnumType(MoveDirection, False)),
+        click.argument("direction", type=EnumType(MoveDirection)),
         default_output=format_output("Rotating the fan to the {direction}"),
     )
     def set_rotate(self, direction: MoveDirection):

--- a/miio/heater.py
+++ b/miio/heater.py
@@ -223,7 +223,7 @@ class Heater(Device):
         return self.send("set_target_temperature", [temperature])
 
     @command(
-        click.argument("brightness", type=EnumType(Brightness, False)),
+        click.argument("brightness", type=EnumType(Brightness)),
         default_output=format_output("Setting display brightness to {brightness}"),
     )
     def set_brightness(self, brightness: Brightness):

--- a/miio/philips_rwread.py
+++ b/miio/philips_rwread.py
@@ -202,7 +202,7 @@ class PhilipsRwread(Device):
         return self.send("enable_flm", [int(motion_detection)])
 
     @command(
-        click.argument("sensitivity", type=EnumType(MotionDetectionSensitivity, False)),
+        click.argument("sensitivity", type=EnumType(MotionDetectionSensitivity)),
         default_output=format_output(
             "Setting motion detection sensitivity to {sensitivity}"
         ),

--- a/miio/powerstrip.py
+++ b/miio/powerstrip.py
@@ -213,7 +213,7 @@ class PowerStrip(Device):
         return self.send("set_power", ["off"])
 
     @command(
-        click.argument("mode", type=EnumType(PowerMode, False)),
+        click.argument("mode", type=EnumType(PowerMode)),
         default_output=format_output("Setting mode to {mode}"),
     )
     def set_power_mode(self, mode: PowerMode):

--- a/miio/toiletlid.py
+++ b/miio/toiletlid.py
@@ -130,7 +130,7 @@ class Toiletlid(Device):
         return self.send("nozzle_clean", ["on"])
 
     @command(
-        click.argument("color", type=EnumType(AmbientLightColor, False)),
+        click.argument("color", type=EnumType(AmbientLightColor)),
         click.argument("xiaomi_id", type=str, default=""),
         default_output=format_output(
             "Set the ambient light to {color} color the next time you start it."

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -12,7 +12,13 @@ import click
 import pytz
 from appdirs import user_cache_dir
 
-from .click_common import DeviceGroup, GlobalContextObject, LiteralParamType, command
+from .click_common import (
+    DeviceGroup,
+    EnumType,
+    GlobalContextObject,
+    LiteralParamType,
+    command,
+)
 from .device import Device
 from .exceptions import DeviceException, DeviceInfoUnavailableException
 from .vacuumcontainers import (
@@ -666,7 +672,7 @@ class Vacuum(Device):
         """Get water flow setting."""
         return WaterFlow(self.send("get_water_box_custom_mode")[0])
 
-    @command(click.argument("waterflow", type=WaterFlow))
+    @command(click.argument("waterflow", type=EnumType(WaterFlow)))
     def set_waterflow(self, waterflow: WaterFlow):
         """Set water flow setting."""
         return self.send("set_water_box_custom_mode", [waterflow.value])

--- a/miio/viomivacuum.py
+++ b/miio/viomivacuum.py
@@ -276,7 +276,7 @@ class ViomiVacuum(Device):
         """Pause cleaning."""
         self.send("set_mode_withroom", [0, 2, 0])
 
-    @command(click.argument("speed", type=EnumType(ViomiVacuumSpeed, False)))
+    @command(click.argument("speed", type=EnumType(ViomiVacuumSpeed)))
     def set_fan_speed(self, speed: ViomiVacuumSpeed):
         """Set fanspeed [silent, standard, medium, turbo]."""
         self.send("set_suction", [speed.value])
@@ -292,7 +292,7 @@ class ViomiVacuum(Device):
         self.send("set_charge", [1])
 
     @command(
-        click.argument("direction", type=EnumType(ViomiMovementDirection, False)),
+        click.argument("direction", type=EnumType(ViomiMovementDirection)),
         click.option(
             "--duration",
             type=float,
@@ -308,12 +308,12 @@ class ViomiVacuum(Device):
             time.sleep(0.1)
         self.send("set_direction", [ViomiMovementDirection.Stop.value])
 
-    @command(click.argument("mode", type=EnumType(ViomiMode, False)))
+    @command(click.argument("mode", type=EnumType(ViomiMode)))
     def clean_mode(self, mode):
         """Set the cleaning mode."""
         self.send("set_mop", [mode.value])
 
-    @command(click.argument("mop_mode", type=EnumType(ViomiMopMode, False)))
+    @command(click.argument("mop_mode", type=EnumType(ViomiMopMode)))
     def mop_mode(self, mop_mode):
         self.send("set_moproute", [mop_mode.value])
 
@@ -352,12 +352,12 @@ class ViomiVacuum(Device):
             [0 if disable else 1, start_hr, start_min, end_hr, end_min],
         )
 
-    @command(click.argument("language", type=EnumType(ViomiLanguage, False)))
+    @command(click.argument("language", type=EnumType(ViomiLanguage)))
     def set_language(self, language: ViomiLanguage):
         """Set the device's audio language."""
         return self.send("set_language", [language.value])
 
-    @command(click.argument("state", type=EnumType(ViomiLedState, False)))
+    @command(click.argument("state", type=EnumType(ViomiLedState)))
     def led(self, state: ViomiLedState):
         """Switch the button leds on or off."""
         return self.send("set_light", [state.value])


### PR DESCRIPTION
There were no cases where the case-sensitivity is deliberately wanted, so it makes sense to clean this up.

This also fixes the issue with vacuum's set_waterbox which was not defined as EnumType (see #786).