### PR TITLE
Add basic support for xiaomi.aircondition.mc1, mc2, mc4, mc5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,7 @@ Supported devices
 
 -  Xiaomi Mi Robot Vacuum V1, S5, M1S
 -  Xiaomi Mi Home Air Conditioner Companion
+-  Xiaomi Mi Smart Air Conditioner A (xiaomi.aircondition.mc1, mc2, mc4, mc5)
 -  Xiaomi Mi Air Purifier
 -  Xiaomi Aqara Camera
 -  Xiaomi Aqara Gateway (basic implementation, alarm, lights)

--- a/miio/__init__.py
+++ b/miio/__init__.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 from importlib_metadata import version  # type: ignore
+from miio.airconditioner_miot import AirConditionerMiot
 from miio.airconditioningcompanion import (
     AirConditioningCompanion,
     AirConditioningCompanionV3,

--- a/miio/airconditioner_miot.py
+++ b/miio/airconditioner_miot.py
@@ -287,7 +287,7 @@ class AirConditionerMiotStatus:
         return CleaningStatus(self.data["clean"])
 
     @property
-    def running_duration(self) -> timedelta:
+    def total_running_duration(self) -> timedelta:
         """Total running duration in hours."""
         return timedelta(hours=self.data["running_duration"])
 
@@ -317,7 +317,7 @@ class AirConditionerMiotStatus:
             "led=%s"
             "electricity=%s"
             "clean=%s"
-            "running_duration=%s"
+            "total_running_duration=%s"
             "fan_percent=%s"
             "timer=%s"
             % (
@@ -335,7 +335,7 @@ class AirConditionerMiotStatus:
                 self.led,
                 self.electricity,
                 self.clean,
-                self.running_duration,
+                self.total_running_duration,
                 self.fan_percent,
                 self.timer,
             )
@@ -376,7 +376,7 @@ class AirConditionerMiot(MiotDevice):
             "LED: {result.led}\n"
             "Electricity: {result.electricity}kWh\n"
             "Clean: {result.clean}\n"
-            "Running Duration: {result.running_duration}\n"
+            "Running Duration: {result.total_running_duration}\n"
             "Fan percent: {result.fan_percent}\n"
             "Timer: {result.timer}\n",
         )

--- a/miio/airconditioner_miot.py
+++ b/miio/airconditioner_miot.py
@@ -35,7 +35,7 @@ _MAPPING = {
     "clean": {"siid": 9, "piid": 1},
     "running_duration": {"siid": 9, "piid": 5},
     # Enhance (siid=10)
-    "fan_percent": {"siid": 10, "piid": 1},
+    "fan_speed_percent": {"siid": 10, "piid": 1},
     "timer": {"siid": 10, "piid": 3},
 }
 
@@ -194,7 +194,7 @@ class AirConditionerMiotStatus:
             {'did': 'electricity', 'siid': 8, 'piid': 1, 'code': 0, 'value': 0.0},
             {'did': 'clean', 'siid': 9, 'piid': 1, 'code': 0, 'value': '0,100,1,1'},
             {'did': 'running_duration', 'siid': 9, 'piid': 5, 'code': 0, 'value': 151.0},
-            {'did': 'fan_percent', 'siid': 10, 'piid': 1, 'code': 0, 'value': 101},
+            {'did': 'fan_speed_percent', 'siid': 10, 'piid': 1, 'code': 0, 'value': 101},
             {'did': 'timer', 'siid': 10, 'piid': 3, 'code': 0, 'value': '0,0,0,0'}
         ]
 
@@ -284,7 +284,7 @@ class AirConditionerMiotStatus:
     @property
     def fan_speed_percent(self) -> int:
         """Current fan speed in percent."""
-        return self.data["fan_percent"]
+        return self.data["fan_speed_percent"]
 
     @property
     def timer(self) -> TimerStatus:
@@ -509,7 +509,7 @@ class AirConditionerMiot(MiotDevice):
             raise AirConditionerMiotException(
                 "Invalid fan percent: %s" % fan_speed_percent
             )
-        return self.set_property("fan_percent", fan_speed_percent)
+        return self.set_property("fan_speed_percent", fan_speed_percent)
 
     @command(
         click.argument("minutes", type=int),

--- a/miio/airconditioner_miot.py
+++ b/miio/airconditioner_miot.py
@@ -273,7 +273,7 @@ class AirConditionerMiotStatus:
 
     @property
     def clean(self) -> CleaningStatus:
-        """TODO   """
+        """Auto clean mode indicator."""
         return CleaningStatus(self.data["clean"])
 
     @property
@@ -288,7 +288,7 @@ class AirConditionerMiotStatus:
 
     @property
     def timer(self) -> TimerStatus:
-        """Timer indicator."""
+        """Countdown timer indicator."""
         return TimerStatus(self.data["timer"])
 
     def __repr__(self) -> str:

--- a/miio/airconditioner_miot.py
+++ b/miio/airconditioner_miot.py
@@ -99,12 +99,7 @@ class CleaningStatus:
             "progress=%s, "
             "stage=%s, "
             "cancellable=%s>"
-            % (
-                self.cleaning,
-                self.progress,
-                self.stage,
-                self.cancellable,
-            )
+            % (self.cleaning, self.progress, self.stage, self.cancellable)
         )
         return s
 
@@ -172,12 +167,7 @@ class TimerStatus:
             "countdown=%s, "
             "power_on=%s, "
             "time_left=%s>"
-            % (
-                self.enabled,
-                self.countdown,
-                self.power_on,
-                self.time_left,
-            )
+            % (self.enabled, self.countdown, self.power_on, self.time_left)
         )
         return s
 
@@ -292,7 +282,7 @@ class AirConditionerMiotStatus:
         return timedelta(hours=self.data["running_duration"])
 
     @property
-    def fan_percent(self) -> int:
+    def fan_speed_percent(self) -> int:
         """Current fan speed in percent."""
         return self.data["fan_percent"]
 
@@ -318,7 +308,7 @@ class AirConditionerMiotStatus:
             "electricity=%s"
             "clean=%s"
             "total_running_duration=%s"
-            "fan_percent=%s"
+            "fan_speed_percent=%s"
             "timer=%s"
             % (
                 self.power,
@@ -336,7 +326,7 @@ class AirConditionerMiotStatus:
                 self.electricity,
                 self.clean,
                 self.total_running_duration,
-                self.fan_percent,
+                self.fan_speed_percent,
                 self.timer,
             )
         )
@@ -377,7 +367,7 @@ class AirConditionerMiot(MiotDevice):
             "Electricity: {result.electricity}kWh\n"
             "Clean: {result.clean}\n"
             "Running Duration: {result.total_running_duration}\n"
-            "Fan percent: {result.fan_percent}\n"
+            "Fan percent: {result.fan_speed_percent}\n"
             "Timer: {result.timer}\n",
         )
     )
@@ -510,14 +500,16 @@ class AirConditionerMiot(MiotDevice):
         return self.set_property("buzzer", buzzer)
 
     @command(
-        click.argument("fan_percent", type=int),
-        default_output=format_output("Setting fan percent to {fan_percent}"),
+        click.argument("percent", type=int),
+        default_output=format_output("Setting fan percent to {percent}%"),
     )
-    def set_fan_percent(self, fan_percent):
+    def set_fan_speed_percent(self, fan_speed_percent):
         """Set fan speed in percent, should be  between 1 to 100 or 101(auto)."""
-        if fan_percent < 1 or fan_percent > 101:
-            raise AirConditionerMiotException("Invalid fan percent: %s" % fan_percent)
-        return self.set_property("fan_percent", fan_percent)
+        if fan_speed_percent < 1 or fan_speed_percent > 101:
+            raise AirConditionerMiotException(
+                "Invalid fan percent: %s" % fan_speed_percent
+            )
+        return self.set_property("fan_percent", fan_speed_percent)
 
     @command(
         click.argument("minutes", type=int),

--- a/miio/airconditioner_miot.py
+++ b/miio/airconditioner_miot.py
@@ -1,0 +1,403 @@
+import enum
+import logging
+from typing import Any, Dict
+
+import click
+
+from .click_common import EnumType, command, format_output
+from .exceptions import DeviceException
+from .miot_device import MiotDevice
+
+_LOGGER = logging.getLogger(__name__)
+_MAPPING = {
+    # Source http://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:air-conditioner:0000A004:xiaomi-mc4:1
+    # Air Conditioner (siid=2)
+    "power": {"siid": 2, "piid": 1},
+    "mode": {"siid": 2, "piid": 2},
+    "target_temperature": {"siid": 2, "piid": 4},
+    "eco": {"siid": 2, "piid": 7},
+    "heater": {"siid": 2, "piid": 9},
+    "dryer": {"siid": 2, "piid": 10},
+    "sleep_mode": {"siid": 2, "piid": 11},
+    # Fan Control (siid=3)
+    "fan_level": {"siid": 3, "piid": 2},
+    "vertical_swing": {"siid": 3, "piid": 4},
+    # Environment (siid=4)
+    "temperature": {"siid": 4, "piid": 7},
+    # Alarm (siid=5)
+    "buzzer": {"siid": 5, "piid": 1},
+    # Indicator Light (siid=6)
+    "led": {"siid": 6, "piid": 1},
+    # Electricity (siid=8)
+    "electricity": {"siid": 8, "piid": 1},
+    # Maintenance (siid=9)
+    "clean": {"siid": 9, "piid": 1},
+    "running_duration": {"siid": 9, "piid": 5},
+    # Enhance (siid=10)
+    "fan_percent": {"siid": 10, "piid": 1},
+    "timer": {"siid": 10, "piid": 3},
+}
+
+
+class AirConditionerMiotException(DeviceException):
+    pass
+
+
+class OperationMode(enum.Enum):
+    Cool = 2
+    Dry = 3
+    Fan = 4
+    Heat = 5
+
+
+class FanLevel(enum.Enum):
+    Auto = 0
+    Level1 = 1
+    Level2 = 2
+    Level3 = 3
+    Level4 = 4
+    Level5 = 5
+    Level6 = 6
+    Level7 = 7
+
+
+class AirConditionerMiotStatus:
+    """Container for status reports from the air conditioner which uses MIoT protocol."""
+
+    def __init__(self, data: Dict[str, Any]) -> None:
+        self.data = data
+
+    @property
+    def is_on(self) -> bool:
+        """True if the device is turned on."""
+        return self.data["power"]
+
+    @property
+    def power(self) -> str:
+        """Current power state."""
+        return "on" if self.is_on else "off"
+
+    @property
+    def mode(self) -> OperationMode:
+        """Current operation mode."""
+        return OperationMode(self.data["mode"])
+
+    @property
+    def target_temperature(self) -> float:
+        """Target temperature in Celsius."""
+        return self.data["target_temperature"]
+
+    @property
+    def eco(self) -> bool:
+        """True if ECO mode is on."""
+        return self.data["eco"]
+
+    @property
+    def heater(self) -> bool:
+        """True if aux heat mode is on."""
+        return self.data["heater"]
+
+    @property
+    def dryer(self) -> bool:
+        """True if aux dryer mode is on."""
+        return self.data["dryer"]
+
+    @property
+    def sleep_mode(self) -> bool:
+        """True if sleep mode is on."""
+        return self.data["sleep_mode"]
+
+    @property
+    def fan_level(self) -> FanLevel:
+        """Current Fan level."""
+        return FanLevel(self.data["fan_level"])
+
+    @property
+    def vertical_swing(self) -> bool:
+        """True if vertical swing is on."""
+        return self.data["vertical_swing"]
+
+    @property
+    def temperature(self) -> float:
+        """Current ambient temperature in Celsius."""
+        return self.data["temperature"]
+
+    @property
+    def buzzer(self) -> bool:
+        """True if buzzer is on."""
+        return self.data["buzzer"]
+
+    @property
+    def led(self) -> bool:
+        """True if LED is on."""
+        return self.data["led"]
+
+    @property
+    def electricity(self) -> float:
+        """Power consumption accumulation in kWh."""
+        return self.data["electricity"]
+
+    @property
+    def clean(self) -> str:
+        """Auto clean mode indicator."""
+        return self.data["clean"]
+
+    @property
+    def running_duration(self) -> float:
+        """Total running duration in hours."""
+        return self.data["running_duration"]
+
+    @property
+    def fan_percent(self) -> int:
+        """Current fan level in percent."""
+        return self.data["fan_percent"]
+
+    @property
+    def timer(self) -> str:
+        """Timer indicator."""
+        return self.data["timer"]
+
+    def __repr__(self) -> str:
+        s = (
+            "<AirConditionerMiotStatus power=%s, "
+            "mode=%s, "
+            "target_temperature=%s, "
+            "eco=%s, "
+            "heater=%s, "
+            "dryer=%s, "
+            "sleep_mode=%s, "
+            "fan_level=%s, "
+            "vertical_swing=%s, "
+            "temperature=%s, "
+            "buzzer=%s, "
+            "led=%s"
+            "electricity=%s"
+            "clean=%s"
+            "running_duration=%s"
+            "fan_percent=%s"
+            "timer=%s"
+            % (
+                self.power,
+                self.mode,
+                self.target_temperature,
+                self.eco,
+                self.heater,
+                self.dryer,
+                self.sleep_mode,
+                self.fan_level,
+                self.vertical_swing,
+                self.temperature,
+                self.buzzer,
+                self.led,
+                self.electricity,
+                self.clean,
+                self.running_duration,
+                self.fan_percent,
+                self.timer,
+            )
+        )
+        return s
+
+    def __json__(self):
+        return self.data
+
+
+class AirConditionerMiot(MiotDevice):
+    """Main class representing the air conditioner which uses MIoT protocol."""
+
+    def __init__(
+        self,
+        ip: str = None,
+        token: str = None,
+        start_id: int = 0,
+        debug: int = 0,
+        lazy_discover: bool = True,
+    ) -> None:
+        super().__init__(_MAPPING, ip, token, start_id, debug, lazy_discover)
+
+    @command(
+        default_output=format_output(
+            "",
+            "Power: {result.power}\n"
+            "Mode: {result.mode}\n"
+            "Target Temperature: {result.target_temperature} ℃\n"
+            "ECO Mode: {result.eco}\n"
+            "Heater: {result.heater}\n"
+            "Dryer: {result.dryer}\n"
+            "Sleep Mode: {result.sleep_mode}\n"
+            "Fan Level: {result.fan_level}\n"
+            "Vertical Swing: {result.vertical_swing}\n"
+            "Room Temperature: {result.temperature} ℃\n"
+            "Buzzer: {result.buzzer}\n"
+            "LED: {result.led}\n"
+            "Electricity: {result.electricity}kWh\n"
+            "Clean: {result.clean}\n"
+            "Running Duration: {result.running_duration}h\n"
+            "Fan percent: {result.fan_percent}\n"
+            "Timer: {result.timer}\n",
+        )
+    )
+    def status(self) -> AirConditionerMiotStatus:
+        """Retrieve properties."""
+
+        return AirConditionerMiotStatus(
+            {
+                prop["did"]: prop["value"] if prop["code"] == 0 else None
+                for prop in self.get_properties_for_mapping()
+            }
+        )
+
+    @command(default_output=format_output("Powering on"))
+    def on(self):
+        """Power on."""
+        return self.set_property("power", True)
+
+    @command(default_output=format_output("Powering off"))
+    def off(self):
+        """Power off."""
+        return self.set_property("power", False)
+
+    @command(
+        click.argument("mode", type=EnumType(OperationMode, False)),
+        default_output=format_output("Setting operation mode to '{mode.value}'"),
+    )
+    def set_mode(self, mode: OperationMode):
+        """Set operation mode."""
+        return self.set_property("mode", mode.value)
+
+    @command(
+        click.argument("target_temperature", type=float),
+        default_output=format_output(
+            "Setting target temperature to {target_temperature}"
+        ),
+    )
+    def set_target_temperature(self, target_temperature: float):
+        """Set target temperature in Celsius."""
+        if (
+            target_temperature < 16.0
+            or target_temperature > 31.0
+            or target_temperature % 0.5 != 0
+        ):
+            raise AirConditionerMiotException(
+                "Invalid target temperature: %s" % target_temperature
+            )
+        return self.set_property("target_temperature", target_temperature)
+
+    @command(
+        click.argument("eco", type=bool),
+        default_output=format_output(
+            lambda eco: "Turning on ECO mode" if eco else "Turning off ECO mode"
+        ),
+    )
+    def set_eco(self, eco: bool):
+        """Turn ECO mode on/off."""
+        return self.set_property("eco", eco)
+
+    @command(
+        click.argument("heater", type=bool),
+        default_output=format_output(
+            lambda heater: "Turning on heater" if heater else "Turning off heater"
+        ),
+    )
+    def set_heater(self, heater: bool):
+        """Turn aux heater mode on/off."""
+        return self.set_property("heater", heater)
+
+    @command(
+        click.argument("dryer", type=bool),
+        default_output=format_output(
+            lambda dryer: "Turning on dryer" if dryer else "Turning off dryer"
+        ),
+    )
+    def set_dryer(self, dryer: bool):
+        """Turn aux dryer mode on/off."""
+        return self.set_property("dryer", dryer)
+
+    @command(
+        click.argument("sleep_mode", type=bool),
+        default_output=format_output(
+            lambda sleep_mode: "Turning on sleep mode"
+            if sleep_mode
+            else "Turning off sleep mode"
+        ),
+    )
+    def set_sleep_mode(self, sleep_mode: bool):
+        """Turn sleep mode on/off."""
+        return self.set_property("sleep_mode", sleep_mode)
+
+    @command(
+        click.argument("fan_level", type=EnumType(FanLevel, False)),
+        default_output=format_output("Setting fan level to {fan_level}"),
+    )
+    def set_fan_level(self, fan_level: FanLevel):
+        """Set fan level."""
+        return self.set_property("fan_level", fan_level.value)
+
+    @command(
+        click.argument("vertical_swing", type=bool),
+        default_output=format_output(
+            lambda vertical_swing: "Turning on vertical swing"
+            if vertical_swing
+            else "Turning off vertical swing"
+        ),
+    )
+    def set_vertical_swing(self, vertical_swing: bool):
+        """Turn vertical swing on/off."""
+        return self.set_property("vertical_swing", vertical_swing)
+
+    @command(
+        click.argument("led", type=bool),
+        default_output=format_output(
+            lambda led: "Turning on LED" if led else "Turning off LED"
+        ),
+    )
+    def set_led(self, led: bool):
+        """Turn led on/off."""
+        return self.set_property("led", led)
+
+    @command(
+        click.argument("buzzer", type=bool),
+        default_output=format_output(
+            lambda buzzer: "Turning on buzzer" if buzzer else "Turning off buzzer"
+        ),
+    )
+    def set_buzzer(self, buzzer: bool):
+        """Set buzzer on/off."""
+        return self.set_property("buzzer", buzzer)
+
+    @command(
+        click.argument("fan_percent", type=int),
+        default_output=format_output("Setting fan percent to {fan_percent}"),
+    )
+    def set_fan_percent(self, fan_percent):
+        """Set fan level in percent, should be  between 1 to 100 or 101(auto)."""
+        if fan_percent < 1 or fan_percent > 101:
+            raise AirConditionerMiotException("Invalid fan percent: %s" % fan_percent)
+        return self.set_property("fan_percent", fan_percent)
+
+    @command(
+        click.argument("minutes", type=int),
+        click.argument("delay_on", type=bool),
+        default_output=format_output(
+            lambda minutes, delay_on: "Setting timer to delay on after "
+            + str(minutes)
+            + " minutes"
+            if delay_on
+            else "Setting timer to delay off after " + str(minutes) + " minutes"
+        ),
+    )
+    def set_timer(self, minutes, delay_on):
+        """Set timer."""
+        return self.set_property(
+            "timer", ",".join(["1", str(minutes), str(int(delay_on))])
+        )
+
+    @command(
+        click.argument("clean", type=bool),
+        default_output=format_output(
+            lambda clean: "Begin auto cleanning" if clean else "Abort auto cleaning"
+        ),
+    )
+    def set_clean(self, clean):
+        """Set clean mode."""
+        return self.set_property("clean", str(int(clean)))

--- a/miio/airconditioner_miot.py
+++ b/miio/airconditioner_miot.py
@@ -258,7 +258,7 @@ class AirConditionerMiot(MiotDevice):
         return self.set_property("power", False)
 
     @command(
-        click.argument("mode", type=EnumType(OperationMode, False)),
+        click.argument("mode", type=EnumType(OperationMode)),
         default_output=format_output("Setting operation mode to '{mode.value}'"),
     )
     def set_mode(self, mode: OperationMode):
@@ -326,7 +326,7 @@ class AirConditionerMiot(MiotDevice):
         return self.set_property("sleep_mode", sleep_mode)
 
     @command(
-        click.argument("fan_level", type=EnumType(FanLevel, False)),
+        click.argument("fan_level", type=EnumType(FanLevel)),
         default_output=format_output("Setting fan level to {fan_level}"),
     )
     def set_fan_level(self, fan_level: FanLevel):

--- a/miio/discovery.py
+++ b/miio/discovery.py
@@ -8,6 +8,7 @@ from typing import Callable, Dict, Optional, Union  # noqa: F401
 import zeroconf
 
 from . import (
+    AirConditionerMiot,
     AirConditioningCompanion,
     AirConditioningCompanionMcn02,
     AirFresh,
@@ -100,6 +101,10 @@ DEVICE_MAP = {
     "qmi-powerstrip-v1": partial(PowerStrip, model=MODEL_POWER_STRIP_V1),
     "zimi-powerstrip-v2": partial(PowerStrip, model=MODEL_POWER_STRIP_V2),
     "zimi-clock-myk01": AlarmClock,
+    "xiaomi.aircondition.mc1": AirConditionerMiot,
+    "xiaomi.aircondition.mc2": AirConditionerMiot,
+    "xiaomi.aircondition.mc4": AirConditionerMiot,
+    "xiaomi.aircondition.mc5": AirConditionerMiot,
     "zhimi-airpurifier-m1": AirPurifier,  # mini model
     "zhimi-airpurifier-m2": AirPurifier,  # mini model 2
     "zhimi-airpurifier-ma1": AirPurifier,  # ms model

--- a/miio/tests/test_airconditioner_miot.py
+++ b/miio/tests/test_airconditioner_miot.py
@@ -5,8 +5,10 @@ import pytest
 from miio import AirConditionerMiot
 from miio.airconditioner_miot import (
     AirConditionerMiotException,
-    FanLevel,
+    CleaningStatus,
+    FanSpeed,
     OperationMode,
+    TimerStatus,
 )
 
 from .dummies import DummyMiotDevice
@@ -19,7 +21,7 @@ _INITIAL_STATE = {
     "heater": True,
     "dryer": False,
     "sleep_mode": False,
-    "fan_level": FanLevel.Level7,
+    "fan_speed": FanSpeed.Level7,
     "vertical_swing": True,
     "temperature": 27.5,
     "buzzer": True,
@@ -46,7 +48,7 @@ class DummyAirConditionerMiot(DummyMiotDevice, AirConditionerMiot):
             "set_heater": lambda x: self._set_state("heater", x),
             "set_dryer": lambda x: self._set_state("dryer", x),
             "set_sleep_mode": lambda x: self._set_state("sleep_mode", x),
-            "set_fan_level": lambda x: self._set_state("fan_level", x),
+            "set_fan_speed": lambda x: self._set_state("fan_speed", x),
             "set_vertical_swing": lambda x: self._set_state("vertical_swing", x),
             "set_temperature": lambda x: self._set_state("temperature", x),
             "set_buzzer": lambda x: self._set_state("buzzer", x),
@@ -88,14 +90,14 @@ class TestAirConditioner(TestCase):
         assert status.heater == _INITIAL_STATE["heater"]
         assert status.dryer == _INITIAL_STATE["dryer"]
         assert status.sleep_mode == _INITIAL_STATE["sleep_mode"]
-        assert status.fan_level == FanLevel(_INITIAL_STATE["fan_level"])
+        assert status.fan_speed == FanSpeed(_INITIAL_STATE["fan_speed"])
         assert status.vertical_swing == _INITIAL_STATE["vertical_swing"]
         assert status.temperature == _INITIAL_STATE["temperature"]
         assert status.buzzer == _INITIAL_STATE["buzzer"]
         assert status.led == _INITIAL_STATE["led"]
-        assert status.clean == _INITIAL_STATE["clean"]
+        assert repr(status.clean) == repr(CleaningStatus(_INITIAL_STATE["clean"]))
         assert status.fan_percent == _INITIAL_STATE["fan_percent"]
-        assert status.timer == _INITIAL_STATE["timer"]
+        assert repr(status.timer) == repr(TimerStatus(_INITIAL_STATE["timer"]))
 
     def test_set_mode(self):
         def mode():
@@ -171,33 +173,33 @@ class TestAirConditioner(TestCase):
         self.device.set_sleep_mode(False)
         assert sleep_mode() is False
 
-    def test_set_fan_level(self):
-        def fan_level():
-            return self.device.status().fan_level
+    def test_set_fan_speed(self):
+        def fan_speed():
+            return self.device.status().fan_speed
 
-        self.device.set_fan_level(FanLevel.Auto)
-        assert fan_level() == FanLevel.Auto
+        self.device.set_fan_speed(FanSpeed.Auto)
+        assert fan_speed() == FanSpeed.Auto
 
-        self.device.set_fan_level(FanLevel.Level1)
-        assert fan_level() == FanLevel.Level1
+        self.device.set_fan_speed(FanSpeed.Level1)
+        assert fan_speed() == FanSpeed.Level1
 
-        self.device.set_fan_level(FanLevel.Level2)
-        assert fan_level() == FanLevel.Level2
+        self.device.set_fan_speed(FanSpeed.Level2)
+        assert fan_speed() == FanSpeed.Level2
 
-        self.device.set_fan_level(FanLevel.Level3)
-        assert fan_level() == FanLevel.Level3
+        self.device.set_fan_speed(FanSpeed.Level3)
+        assert fan_speed() == FanSpeed.Level3
 
-        self.device.set_fan_level(FanLevel.Level4)
-        assert fan_level() == FanLevel.Level4
+        self.device.set_fan_speed(FanSpeed.Level4)
+        assert fan_speed() == FanSpeed.Level4
 
-        self.device.set_fan_level(FanLevel.Level5)
-        assert fan_level() == FanLevel.Level5
+        self.device.set_fan_speed(FanSpeed.Level5)
+        assert fan_speed() == FanSpeed.Level5
 
-        self.device.set_fan_level(FanLevel.Level6)
-        assert fan_level() == FanLevel.Level6
+        self.device.set_fan_speed(FanSpeed.Level6)
+        assert fan_speed() == FanSpeed.Level6
 
-        self.device.set_fan_level(FanLevel.Level7)
-        assert fan_level() == FanLevel.Level7
+        self.device.set_fan_speed(FanSpeed.Level7)
+        assert fan_speed() == FanSpeed.Level7
 
     def test_set_vertical_swing(self):
         def vertical_swing():
@@ -246,7 +248,7 @@ class TestAirConditioner(TestCase):
 
     def test_set_timer(self):
         def timer():
-            return self.device.status().timer
+            return self.device.status().data["timer"]
 
         self.device.set_timer(60, True)
         assert timer() == "1,60,1"
@@ -256,7 +258,7 @@ class TestAirConditioner(TestCase):
 
     def test_set_clean(self):
         def clean():
-            return self.device.status().clean
+            return self.device.status().data["clean"]
 
         self.device.set_clean(True)
         assert clean() == "1"

--- a/miio/tests/test_airconditioner_miot.py
+++ b/miio/tests/test_airconditioner_miot.py
@@ -29,7 +29,7 @@ _INITIAL_STATE = {
     "electricity": 0.0,
     "clean": "0,100,1,1",
     "running_duration": 100.4,
-    "fan_percent": 90,
+    "fan_speed_percent": 90,
     "timer": "0,0,0,0",
 }
 
@@ -54,7 +54,7 @@ class DummyAirConditionerMiot(DummyMiotDevice, AirConditionerMiot):
             "set_buzzer": lambda x: self._set_state("buzzer", x),
             "set_led": lambda x: self._set_state("led", x),
             "set_clean": lambda x: self._set_state("clean", x),
-            "set_fan_percent": lambda x: self._set_state("fan_percent", x),
+            "set_fan_speed_percent": lambda x: self._set_state("fan_speed_percent", x),
             "set_timer": lambda x, y: self._set_state("timer", x, y),
         }
         super().__init__(*args, **kwargs)
@@ -96,7 +96,7 @@ class TestAirConditioner(TestCase):
         assert status.buzzer == _INITIAL_STATE["buzzer"]
         assert status.led == _INITIAL_STATE["led"]
         assert repr(status.clean) == repr(CleaningStatus(_INITIAL_STATE["clean"]))
-        assert status.fan_percent == _INITIAL_STATE["fan_percent"]
+        assert status.fan_speed_percent == _INITIAL_STATE["fan_speed_percent"]
         assert repr(status.timer) == repr(TimerStatus(_INITIAL_STATE["timer"]))
 
     def test_set_mode(self):
@@ -231,20 +231,20 @@ class TestAirConditioner(TestCase):
         self.device.set_buzzer(False)
         assert buzzer() is False
 
-    def test_set_fan_percent(self):
-        def fan_percent():
-            return self.device.status().fan_percent
+    def test_set_fan_speed_percent(self):
+        def fan_speed_percent():
+            return self.device.status().fan_speed_percent
 
-        self.device.set_fan_percent(1)
-        assert fan_percent() == 1
-        self.device.set_fan_percent(101)
-        assert fan_percent() == 101
-
-        with pytest.raises(AirConditionerMiotException):
-            self.device.set_fan_percent(102)
+        self.device.set_fan_speed_percent(1)
+        assert fan_speed_percent() == 1
+        self.device.set_fan_speed_percent(101)
+        assert fan_speed_percent() == 101
 
         with pytest.raises(AirConditionerMiotException):
-            self.device.set_fan_percent(0)
+            self.device.set_fan_speed_percent(102)
+
+        with pytest.raises(AirConditionerMiotException):
+            self.device.set_fan_speed_percent(0)
 
     def test_set_timer(self):
         def timer():

--- a/miio/tests/test_airconditioner_miot.py
+++ b/miio/tests/test_airconditioner_miot.py
@@ -1,0 +1,265 @@
+from unittest import TestCase
+
+import pytest
+
+from miio import AirConditionerMiot
+from miio.airconditioner_miot import (
+    AirConditionerMiotException,
+    FanLevel,
+    OperationMode,
+)
+
+from .dummies import DummyMiotDevice
+
+_INITIAL_STATE = {
+    "power": False,
+    "mode": OperationMode.Cool,
+    "target_temperature": 24,
+    "eco": True,
+    "heater": True,
+    "dryer": False,
+    "sleep_mode": False,
+    "fan_level": FanLevel.Level7,
+    "vertical_swing": True,
+    "temperature": 27.5,
+    "buzzer": True,
+    "led": False,
+    "electricity": 0.0,
+    "clean": "0,100,1,1",
+    "running_duration": 100.4,
+    "fan_percent": 90,
+    "timer": "0,0,0,0",
+}
+
+
+class DummyAirConditionerMiot(DummyMiotDevice, AirConditionerMiot):
+    def __init__(self, *args, **kwargs):
+        self.state = _INITIAL_STATE
+        self.return_values = {
+            "get_prop": self._get_state,
+            "set_power": lambda x: self._set_state("power", x),
+            "set_mode": lambda x: self._set_state("mode", x),
+            "set_target_temperature": lambda x: self._set_state(
+                "target_temperature", x
+            ),
+            "set_eco": lambda x: self._set_state("eco", x),
+            "set_heater": lambda x: self._set_state("heater", x),
+            "set_dryer": lambda x: self._set_state("dryer", x),
+            "set_sleep_mode": lambda x: self._set_state("sleep_mode", x),
+            "set_fan_level": lambda x: self._set_state("fan_level", x),
+            "set_vertical_swing": lambda x: self._set_state("vertical_swing", x),
+            "set_temperature": lambda x: self._set_state("temperature", x),
+            "set_buzzer": lambda x: self._set_state("buzzer", x),
+            "set_led": lambda x: self._set_state("led", x),
+            "set_clean": lambda x: self._set_state("clean", x),
+            "set_fan_percent": lambda x: self._set_state("fan_percent", x),
+            "set_timer": lambda x, y: self._set_state("timer", x, y),
+        }
+        super().__init__(*args, **kwargs)
+
+
+@pytest.fixture(scope="function")
+def airconditionermiot(request):
+    request.cls.device = DummyAirConditionerMiot()
+
+
+@pytest.mark.usefixtures("airconditionermiot")
+class TestAirConditioner(TestCase):
+    def test_on(self):
+        self.device.off()  # ensure off
+        assert self.device.status().is_on is False
+
+        self.device.on()
+        assert self.device.status().is_on is True
+
+    def test_off(self):
+        self.device.on()  # ensure on
+        assert self.device.status().is_on is True
+
+        self.device.off()
+        assert self.device.status().is_on is False
+
+    def test_status(self):
+        status = self.device.status()
+        assert status.is_on == _INITIAL_STATE["power"]
+        assert status.mode == OperationMode(_INITIAL_STATE["mode"])
+        assert status.target_temperature == _INITIAL_STATE["target_temperature"]
+        assert status.eco == _INITIAL_STATE["eco"]
+        assert status.heater == _INITIAL_STATE["heater"]
+        assert status.dryer == _INITIAL_STATE["dryer"]
+        assert status.sleep_mode == _INITIAL_STATE["sleep_mode"]
+        assert status.fan_level == FanLevel(_INITIAL_STATE["fan_level"])
+        assert status.vertical_swing == _INITIAL_STATE["vertical_swing"]
+        assert status.temperature == _INITIAL_STATE["temperature"]
+        assert status.buzzer == _INITIAL_STATE["buzzer"]
+        assert status.led == _INITIAL_STATE["led"]
+        assert status.clean == _INITIAL_STATE["clean"]
+        assert status.fan_percent == _INITIAL_STATE["fan_percent"]
+        assert status.timer == _INITIAL_STATE["timer"]
+
+    def test_set_mode(self):
+        def mode():
+            return self.device.status().mode
+
+        self.device.set_mode(OperationMode.Cool)
+        assert mode() == OperationMode.Cool
+
+        self.device.set_mode(OperationMode.Dry)
+        assert mode() == OperationMode.Dry
+
+        self.device.set_mode(OperationMode.Fan)
+        assert mode() == OperationMode.Fan
+
+        self.device.set_mode(OperationMode.Heat)
+        assert mode() == OperationMode.Heat
+
+    def test_set_target_temperature(self):
+        def target_temperature():
+            return self.device.status().target_temperature
+
+        self.device.set_target_temperature(16.0)
+        assert target_temperature() == 16.0
+        self.device.set_target_temperature(31.0)
+        assert target_temperature() == 31.0
+
+        with pytest.raises(AirConditionerMiotException):
+            self.device.set_target_temperature(15.5)
+
+        with pytest.raises(AirConditionerMiotException):
+            self.device.set_target_temperature(24.6)
+
+        with pytest.raises(AirConditionerMiotException):
+            self.device.set_target_temperature(31.5)
+
+    def test_set_eco(self):
+        def eco():
+            return self.device.status().eco
+
+        self.device.set_eco(True)
+        assert eco() is True
+
+        self.device.set_eco(False)
+        assert eco() is False
+
+    def test_set_heater(self):
+        def heater():
+            return self.device.status().heater
+
+        self.device.set_heater(True)
+        assert heater() is True
+
+        self.device.set_heater(False)
+        assert heater() is False
+
+    def test_set_dryer(self):
+        def dryer():
+            return self.device.status().dryer
+
+        self.device.set_dryer(True)
+        assert dryer() is True
+
+        self.device.set_dryer(False)
+        assert dryer() is False
+
+    def test_set_sleep_mode(self):
+        def sleep_mode():
+            return self.device.status().sleep_mode
+
+        self.device.set_sleep_mode(True)
+        assert sleep_mode() is True
+
+        self.device.set_sleep_mode(False)
+        assert sleep_mode() is False
+
+    def test_set_fan_level(self):
+        def fan_level():
+            return self.device.status().fan_level
+
+        self.device.set_fan_level(FanLevel.Auto)
+        assert fan_level() == FanLevel.Auto
+
+        self.device.set_fan_level(FanLevel.Level1)
+        assert fan_level() == FanLevel.Level1
+
+        self.device.set_fan_level(FanLevel.Level2)
+        assert fan_level() == FanLevel.Level2
+
+        self.device.set_fan_level(FanLevel.Level3)
+        assert fan_level() == FanLevel.Level3
+
+        self.device.set_fan_level(FanLevel.Level4)
+        assert fan_level() == FanLevel.Level4
+
+        self.device.set_fan_level(FanLevel.Level5)
+        assert fan_level() == FanLevel.Level5
+
+        self.device.set_fan_level(FanLevel.Level6)
+        assert fan_level() == FanLevel.Level6
+
+        self.device.set_fan_level(FanLevel.Level7)
+        assert fan_level() == FanLevel.Level7
+
+    def test_set_vertical_swing(self):
+        def vertical_swing():
+            return self.device.status().vertical_swing
+
+        self.device.set_vertical_swing(True)
+        assert vertical_swing() is True
+
+        self.device.set_vertical_swing(False)
+        assert vertical_swing() is False
+
+    def test_set_led(self):
+        def led():
+            return self.device.status().led
+
+        self.device.set_led(True)
+        assert led() is True
+
+        self.device.set_led(False)
+        assert led() is False
+
+    def test_set_buzzer(self):
+        def buzzer():
+            return self.device.status().buzzer
+
+        self.device.set_buzzer(True)
+        assert buzzer() is True
+
+        self.device.set_buzzer(False)
+        assert buzzer() is False
+
+    def test_set_fan_percent(self):
+        def fan_percent():
+            return self.device.status().fan_percent
+
+        self.device.set_fan_percent(1)
+        assert fan_percent() == 1
+        self.device.set_fan_percent(101)
+        assert fan_percent() == 101
+
+        with pytest.raises(AirConditionerMiotException):
+            self.device.set_fan_percent(102)
+
+        with pytest.raises(AirConditionerMiotException):
+            self.device.set_fan_percent(0)
+
+    def test_set_timer(self):
+        def timer():
+            return self.device.status().timer
+
+        self.device.set_timer(60, True)
+        assert timer() == "1,60,1"
+
+        self.device.set_timer(120, False)
+        assert timer() == "1,120,0"
+
+    def test_set_clean(self):
+        def clean():
+            return self.device.status().clean
+
+        self.device.set_clean(True)
+        assert clean() == "1"
+
+        self.device.set_clean(False)
+        assert clean() == "0"


### PR DESCRIPTION
This commit introduced basic support and tests for MIoT device
Xiaomi Mi Smart Air Conditioner A including xiaomi.aircondition.mc1,
mc2, mc4 and mc5 since they are nearly the same in miot-spec.

Tested on my xiaomi.aircondition.mc4. All properties and function work
except property `electricity' keeps zero.

Device miot-spec:
http://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:air-conditioner:0000A004:xiaomi-mc4:1

Device Mi Home plugin:
https://cdn.cnbj1.fds.api.mi-img.com/rn-plugins/2020-08-25/signed_10043_1000595_66_ANDROID_bundle_d8d30e612b4b0722e4a74744614f3c53.zip