### PR TITLE
Remove __json__ boilerplate code from all status containers

### DIFF
--- a/miio/airconditioningcompanion.py
+++ b/miio/airconditioningcompanion.py
@@ -265,9 +265,6 @@ class AirConditioningCompanionStatus:
         )
         return s
 
-    def __json__(self):
-        return self.data
-
 
 class AirConditioningCompanion(Device):
     """Main class representing Xiaomi Air Conditioning Companion V1 and V2."""

--- a/miio/airconditioningcompanionMCN.py
+++ b/miio/airconditioningcompanionMCN.py
@@ -118,9 +118,6 @@ class AirConditioningCompanionStatus:
         )
         return s
 
-    def __json__(self):
-        return self.data
-
 
 class AirConditioningCompanionMcn02(Device):
     """Main class representing Xiaomi Air Conditioning Companion V1 and V2."""

--- a/miio/airdehumidifier.py
+++ b/miio/airdehumidifier.py
@@ -184,9 +184,6 @@ class AirDehumidifierStatus:
         )
         return s
 
-    def __json__(self):
-        return self.data
-
 
 class AirDehumidifier(Device):
     """Implementation of Xiaomi Mi Air Dehumidifier."""

--- a/miio/airfresh.py
+++ b/miio/airfresh.py
@@ -257,9 +257,6 @@ class AirFreshStatus:
         )
         return s
 
-    def __json__(self):
-        return self.data
-
 
 class AirFresh(Device):
     """Main class representing the air fresh."""

--- a/miio/airfresh_t2017.py
+++ b/miio/airfresh_t2017.py
@@ -230,9 +230,6 @@ class AirFreshStatus:
         )
         return s
 
-    def __json__(self):
-        return self.data
-
 
 class AirFreshT2017(Device):
     """Main class representing the air fresh t2017."""

--- a/miio/airhumidifier.py
+++ b/miio/airhumidifier.py
@@ -248,9 +248,6 @@ class AirHumidifierStatus:
         )
         return s
 
-    def __json__(self):
-        return self.data
-
 
 class AirHumidifier(Device):
     """Implementation of Xiaomi Mi Air Humidifier."""

--- a/miio/airhumidifier_jsq.py
+++ b/miio/airhumidifier_jsq.py
@@ -151,9 +151,6 @@ class AirHumidifierStatus:
         )
         return s
 
-    def __json__(self):
-        return self.data
-
 
 class AirHumidifierJsq(Device):
     """

--- a/miio/airhumidifier_miot.py
+++ b/miio/airhumidifier_miot.py
@@ -241,9 +241,6 @@ class AirHumidifierMiotStatus:
         )
         return s
 
-    def __json__(self):
-        return self.data
-
 
 class AirHumidifierMiot(MiotDevice):
     """Main class representing the air humidifier which uses MIoT protocol."""

--- a/miio/airhumidifier_mjjsq.py
+++ b/miio/airhumidifier_mjjsq.py
@@ -128,9 +128,6 @@ class AirHumidifierStatus:
         )
         return s
 
-    def __json__(self):
-        return self.data
-
 
 class AirHumidifierMjjsq(Device):
     def __init__(

--- a/miio/airpurifier.py
+++ b/miio/airpurifier.py
@@ -334,9 +334,6 @@ class AirPurifierStatus:
         )
         return s
 
-    def __json__(self):
-        return self.data
-
 
 class AirPurifier(Device):
     """Main class representing the air purifier."""

--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -248,9 +248,6 @@ class AirPurifierMiotStatus:
         )
         return s
 
-    def __json__(self):
-        return self.data
-
 
 class AirPurifierMiot(MiotDevice):
     """Main class representing the air purifier which uses MIoT protocol."""

--- a/miio/airqualitymonitor.py
+++ b/miio/airqualitymonitor.py
@@ -177,9 +177,6 @@ class AirQualityMonitorStatus:
         )
         return s
 
-    def __json__(self):
-        return self.data
-
 
 class AirQualityMonitor(Device):
     """Xiaomi PM2.5 Air Quality Monitor."""

--- a/miio/aqaracamera.py
+++ b/miio/aqaracamera.py
@@ -177,9 +177,6 @@ class CameraStatus:
         )
         return s
 
-    def __json__(self):
-        return self.data
-
 
 class AqaraCamera(Device):
     """Main class representing the Xiaomi Aqara Camera."""

--- a/miio/ceil.py
+++ b/miio/ceil.py
@@ -87,9 +87,6 @@ class CeilStatus:
         )
         return s
 
-    def __json__(self):
-        return self.data
-
 
 class Ceil(Device):
     """Main class representing Xiaomi Philips LED Ceiling Lamp."""

--- a/miio/chuangmi_camera.py
+++ b/miio/chuangmi_camera.py
@@ -178,9 +178,6 @@ class CameraStatus:
         )
         return s
 
-    def __json__(self):
-        return self.data
-
 
 class ChuangmiCamera(Device):
     """Main class representing the Xiaomi Chuangmi Camera."""

--- a/miio/chuangmi_plug.py
+++ b/miio/chuangmi_plug.py
@@ -100,9 +100,6 @@ class ChuangmiPlugStatus:
         )
         return s
 
-    def __json__(self):
-        return self.data
-
 
 class ChuangmiPlug(Device):
     """Main class representing the Chuangmi Plug."""

--- a/miio/click_common.py
+++ b/miio/click_common.py
@@ -304,8 +304,11 @@ def json_output(pretty=False):
                 return
 
             get_json_data_func = getattr(result, "__json__", None)
+            data_variable = getattr(result, "data", None)
             if get_json_data_func is not None:
                 result = get_json_data_func()
+            elif data_variable is not None:
+                result = data_variable
             click.echo(json.dumps(result, indent=indent))
 
         return wrap

--- a/miio/cooker.py
+++ b/miio/cooker.py
@@ -146,9 +146,6 @@ class TemperatureHistory:
         s = "<TemperatureHistory temperatures=%s>" % str(self.data)
         return s
 
-    def __json__(self):
-        return self.data
-
 
 class CookerCustomizations:
     def __init__(self, custom: str):

--- a/miio/device.py
+++ b/miio/device.py
@@ -55,9 +55,6 @@ class DeviceInfo:
             self.data["token"],
         )
 
-    def __json__(self):
-        return self.data
-
     @property
     def network_interface(self):
         """Information about network configuration."""

--- a/miio/fan.py
+++ b/miio/fan.py
@@ -272,9 +272,6 @@ class FanStatus:
         )
         return s
 
-    def __json__(self):
-        return self.data
-
 
 class FanStatusP5:
     """Container for status reports from the Xiaomi Mi Smart Pedestal Fan DMaker P5."""
@@ -362,9 +359,6 @@ class FanStatusP5:
             )
         )
         return s
-
-    def __json__(self):
-        return self.data
 
 
 class Fan(Device):

--- a/miio/heater.py
+++ b/miio/heater.py
@@ -148,9 +148,6 @@ class HeaterStatus:
         )
         return s
 
-    def __json__(self):
-        return self.data
-
 
 class Heater(Device):
     """Main class representing the Smartmi Zhimi Heater."""

--- a/miio/philips_bulb.py
+++ b/miio/philips_bulb.py
@@ -81,9 +81,6 @@ class PhilipsBulbStatus:
         )
         return s
 
-    def __json__(self):
-        return self.data
-
 
 class PhilipsWhiteBulb(Device):
     """Main class representing Xiaomi Philips White LED Ball Lamp."""

--- a/miio/philips_eyecare.py
+++ b/miio/philips_eyecare.py
@@ -99,9 +99,6 @@ class PhilipsEyecareStatus:
         )
         return s
 
-    def __json__(self):
-        return self.data
-
 
 class PhilipsEyecare(Device):
     """Main class representing Xiaomi Philips Eyecare Smart Lamp 2."""

--- a/miio/philips_moonlight.py
+++ b/miio/philips_moonlight.py
@@ -105,9 +105,6 @@ class PhilipsMoonlightStatus:
         )
         return s
 
-    def __json__(self):
-        return self.data
-
 
 class PhilipsMoonlight(Device):
     """Main class representing Xiaomi Philips Zhirui Bedside Lamp.

--- a/miio/philips_rwread.py
+++ b/miio/philips_rwread.py
@@ -101,9 +101,6 @@ class PhilipsRwreadStatus:
         )
         return s
 
-    def __json__(self):
-        return self.data
-
 
 class PhilipsRwread(Device):
     """Main class representing Xiaomi Philips RW Read."""

--- a/miio/powerstrip.py
+++ b/miio/powerstrip.py
@@ -157,9 +157,6 @@ class PowerStripStatus:
         )
         return s
 
-    def __json__(self):
-        return self.data
-
 
 class PowerStrip(Device):
     """Main class representing the smart power strip."""

--- a/miio/pwzn_relay.py
+++ b/miio/pwzn_relay.py
@@ -102,9 +102,6 @@ class PwznRelayStatus:
         )
         return s
 
-    def __json__(self):
-        return self.data
-
 
 class PwznRelay(Device):
     """Main class representing the PWZN Relay."""

--- a/miio/vacuumcontainers.py
+++ b/miio/vacuumcontainers.py
@@ -186,9 +186,6 @@ class VacuumStatus:
         s += "cleaned %s m² in %s>" % (self.clean_area, self.clean_time)
         return s
 
-    def __json__(self):
-        return self.data
-
 
 class CleaningSummary:
     """Contains summarized information about available cleaning runs."""
@@ -227,9 +224,6 @@ class CleaningSummary:
             "<CleaningSummary: %s times, total time: %s, total area: %s, ids: %s>"
             % (self.count, self.total_duration, self.total_area, self.ids)  # noqa: E501
         )
-
-    def __json__(self):
-        return self.data
 
 
 class CleaningDetails:
@@ -284,9 +278,6 @@ class CleaningDetails:
             self.complete,
             self.area,
         )
-
-    def __json__(self):
-        return self.data
 
 
 class ConsumableStatus:
@@ -361,9 +352,6 @@ class ConsumableStatus:
             )
         )
 
-    def __json__(self):
-        return self.data
-
 
 class DNDStatus:
     """A container for the do-not-disturb status."""
@@ -394,9 +382,6 @@ class DNDStatus:
             self.start,
             self.end,
         )
-
-    def __json__(self):
-        return self.data
 
 
 class Timer:
@@ -454,9 +439,6 @@ class Timer:
             self.cron,
         )
 
-    def __json__(self):
-        return self.data
-
 
 class SoundStatus:
     """Container for sound status."""
@@ -478,9 +460,6 @@ class SoundStatus:
             self.current,
             self.being_installed,
         )
-
-    def __json__(self):
-        return self.data
 
 
 class SoundInstallState(IntEnum):
@@ -544,9 +523,6 @@ class SoundInstallStatus:
             " - progress: %s>" % (self.sid, self.state, self.error, self.progress)
         )
 
-    def __json__(self):
-        return self.data
-
 
 class CarpetModeStatus:
     """Container for carpet mode status."""
@@ -590,6 +566,3 @@ class CarpetModeStatus:
                 self.current_integral,
             )
         )
-
-    def __json__(self):
-        return self.data

--- a/miio/viomivacuum.py
+++ b/miio/viomivacuum.py
@@ -100,9 +100,6 @@ class ViomiConsumableStatus(ConsumableStatus):
             )
         )
 
-    def __json__(self):
-        return self.data
-
 
 class ViomiVacuumSpeed(Enum):
     Silent = 0

--- a/miio/waterpurifier.py
+++ b/miio/waterpurifier.py
@@ -130,9 +130,6 @@ class WaterPurifierStatus:
             )
         )
 
-    def __json__(self):
-        return self.data
-
 
 class WaterPurifier(Device):
     """Main class representing the waiter purifier."""

--- a/miio/wifirepeater.py
+++ b/miio/wifirepeater.py
@@ -46,9 +46,6 @@ class WifiRepeaterStatus:
         )
         return s
 
-    def __json__(self):
-        return self.data
-
 
 class WifiRepeaterConfiguration:
     def __init__(self, data):
@@ -78,9 +75,6 @@ class WifiRepeaterConfiguration:
             "ssid_hidden=%s>" % (self.ssid, self.password, self.ssid_hidden)
         )
         return s
-
-    def __json__(self):
-        return self.data
 
 
 class WifiRepeater(Device):

--- a/miio/wifispeaker.py
+++ b/miio/wifispeaker.py
@@ -117,9 +117,6 @@ class WifiSpeakerStatus:
 
         return s
 
-    def __json__(self):
-        return self.data
-
 
 class WifiSpeaker(Device):
     """Device class for Xiaomi Smart Wifi Speaker."""


### PR DESCRIPTION
All implementations were simply returning the `data` for this request,
and forgetting to add this boilerplate piece causes problems like shown in #816.

This commit adds a lookup for `data` variable which should be consistent within all containers.
For the time being, this behavior can still be overridden by manually defining `__json__`.

Fixes #816