### PR TITLE
Correct importlib_metadata python_version bounds

### DIFF
--- a/miio/__init__.py
+++ b/miio/__init__.py
@@ -1,5 +1,11 @@
 # flake8: noqa
-from importlib_metadata import version  # type: ignore
+try:
+    # python 3.7 and earlier
+    from importlib_metadata import version  # type: ignore
+except ImportError:
+    # python 3.8 and later
+    from importlib.metadata import version  # type: ignore
+
 from miio.airconditioningcompanion import (
     AirConditioningCompanion,
     AirConditioningCompanionV3,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ appdirs = "^1"
 tqdm = "^4"
 netifaces = "^0"
 android_backup = { version = "^0", optional = true }
-importlib_metadata = "^1"
+importlib_metadata = { version = "^1", markers = "python_version <= '3.7'" }
 croniter = "^0"
 
 sphinx = { version = "^3", optional = true }


### PR DESCRIPTION
importlib_metadata is a backport of the python 3.8 stdlib library

https://importlib-metadata.readthedocs.io/en/latest/

related: https://github.com/NixOS/nixpkgs/pull/99585