### PR TITLE
Throwing GatewayException in get_illumination

### DIFF
--- a/miio/gateway.py
+++ b/miio/gateway.py
@@ -386,7 +386,7 @@ class Gateway(Device):
             raise GatewayException(
                 "Got an exception while getting gateway illumination"
             ) from ex
-    
+
 
 class GatewayDevice(Device):
     """

--- a/miio/gateway.py
+++ b/miio/gateway.py
@@ -380,8 +380,13 @@ class Gateway(Device):
     @command()
     def get_illumination(self):
         """Get illumination. In lux?"""
-        return self.send("get_illumination").pop()
-
+        try:
+            return self.send("get_illumination").pop()
+        except Exception as ex:
+            raise GatewayException(
+                "Got an exception while getting gateway illumination"
+            ) from ex
+    
 
 class GatewayDevice(Device):
     """


### PR DESCRIPTION
I'm not sure if the GatewayException type is only suitable for SubDevice or is also allowed here, but it is the exception HA expects in this case:
https://github.com/home-assistant/core/blob/985e4e1bd942ef4ab56617a77f59baeec10649c5/homeassistant/components/xiaomi_miio/sensor.py#L320:L325