### PR TITLE
Vacuum: Implement TUI for the manual mode

### DIFF
--- a/docs/vacuum.rst
+++ b/docs/vacuum.rst
@@ -188,6 +188,43 @@ and updating from an URL requires you to pass the md5 hash of the file.
 
     mirobo update-firmware v11_003094.pkg
 
+Manual control
+~~~~~~~~~~~~~~
+
+To start the manual mode:
+
+::
+
+    mirobo manual start
+
+To move forward with velocity 0.3 for default amount of time:
+
+::
+
+    mirobo manual forward 0.3
+
+To turn 90 degrees to the right for default amount of time:
+
+::
+
+    mirobo manual right 90
+
+To stop the manual mode:
+
+::
+
+    mirobo manual stop
+
+To run the manual control TUI:
+
+.. NOTE::
+
+    Make sure you have got `curses` library installed on your system.
+
+::
+
+    mirobo manual tui
+
 
 DND functionality
 ~~~~~~~~~~~~~~~~~

--- a/miio/__init__.py
+++ b/miio/__init__.py
@@ -42,6 +42,7 @@ from miio.protocol import Message, Utils
 from miio.pwzn_relay import PwznRelay
 from miio.toiletlid import Toiletlid
 from miio.vacuum import Vacuum, VacuumException
+from miio.vacuum_tui import VacuumTUI
 from miio.vacuumcontainers import (
     CleaningDetails,
     CleaningSummary,

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -168,12 +168,22 @@ class Vacuum(Device):
         self.manual_seqnum = 0
         return self.send("app_rc_end")
 
+    MANUAL_ROTATION_MAX = 180
+    MANUAL_ROTATION_MIN = -MANUAL_ROTATION_MAX
+    MANUAL_VELOCITY_MAX = 0.3
+    MANUAL_VELOCITY_MIN = -MANUAL_VELOCITY_MAX
+    MANUAL_DURATION_DEFAULT = 1500
+
     @command(
         click.argument("rotation", type=int),
         click.argument("velocity", type=float),
-        click.argument("duration", type=int, required=False, default=1500),
+        click.argument(
+            "duration", type=int, required=False, default=MANUAL_DURATION_DEFAULT
+        ),
     )
-    def manual_control_once(self, rotation: int, velocity: float, duration: int = 1500):
+    def manual_control_once(
+        self, rotation: int, velocity: float, duration: int = MANUAL_DURATION_DEFAULT
+    ):
         """Starts the remote control mode and executes
         the action once before deactivating the mode."""
         number_of_tries = 3
@@ -191,18 +201,23 @@ class Vacuum(Device):
     @command(
         click.argument("rotation", type=int),
         click.argument("velocity", type=float),
-        click.argument("duration", type=int, required=False, default=1500),
+        click.argument(
+            "duration", type=int, required=False, default=MANUAL_DURATION_DEFAULT
+        ),
     )
-    def manual_control(self, rotation: int, velocity: float, duration: int = 1500):
+    def manual_control(
+        self, rotation: int, velocity: float, duration: int = MANUAL_DURATION_DEFAULT
+    ):
         """Give a command over manual control interface."""
-        if rotation < -180 or rotation > 180:
+        if rotation < self.MANUAL_ROTATION_MIN or rotation > self.MANUAL_ROTATION_MAX:
             raise DeviceException(
-                "Given rotation is invalid, should " "be ]-180, 180[, was %s" % rotation
+                "Given rotation is invalid, should be ]%s, %s[, was %s"
+                % (self.MANUAL_ROTATION_MIN, self.MANUAL_ROTATION_MAX, rotation)
             )
-        if velocity < -0.3 or velocity > 0.3:
+        if velocity < self.MANUAL_VELOCITY_MIN or velocity > self.MANUAL_VELOCITY_MAX:
             raise DeviceException(
-                "Given velocity is invalid, should "
-                "be ]-0.3, 0.3[, was: %s" % velocity
+                "Given velocity is invalid, should be ]%s, %s[, was: %s"
+                % (self.MANUAL_VELOCITY_MIN, self.MANUAL_VELOCITY_MAX, velocity)
             )
 
         self.manual_seqnum += 1

--- a/miio/vacuum_cli.py
+++ b/miio/vacuum_cli.py
@@ -233,6 +233,13 @@ def manual(vac: miio.Vacuum):
 
 @manual.command()
 @pass_dev
+def tui(vac: miio.Vacuum):
+    """TUI for the manual mode."""
+    miio.VacuumTUI(vac).run()
+
+
+@manual.command()
+@pass_dev
 def start(vac: miio.Vacuum):  # noqa: F811  # redef of start
     """Activate the manual mode."""
     click.echo("Activating manual controls")

--- a/miio/vacuum_tui.py
+++ b/miio/vacuum_tui.py
@@ -1,7 +1,7 @@
 try:
     import curses
-except ImportError:  # curses unavailable
-    pass
+except ImportError:
+    curses = None
 
 import enum
 from typing import Tuple
@@ -24,6 +24,9 @@ class Control(enum.Enum):
 
 class VacuumTUI:
     def __init__(self, vac: Vacuum):
+        if curses is None:
+            raise ImportError("curses library is not available")
+
         self.vac = vac
         self.rot = 0
         self.rot_delta = 30

--- a/miio/vacuum_tui.py
+++ b/miio/vacuum_tui.py
@@ -1,0 +1,101 @@
+try:
+    import curses
+except ImportError:  # curses unavailable
+    pass
+
+import enum
+from typing import Tuple
+
+from .vacuum import Vacuum
+
+
+class Control(enum.Enum):
+
+    Quit = "q"
+    Forward = "w"
+    ForwardFast = "W"
+    Backward = "s"
+    BackwardFast = "S"
+    Left = "a"
+    LeftFast = "A"
+    Right = "d"
+    RightFast = "D"
+
+
+class VacuumTUI:
+    def __init__(self, vac: Vacuum):
+        self.vac = vac
+        self.rot = 0
+        self.rot_delta = 30
+        self.rot_min = Vacuum.MANUAL_ROTATION_MIN
+        self.rot_max = Vacuum.MANUAL_ROTATION_MAX
+        self.vel = 0.0
+        self.vel_delta = 0.1
+        self.vel_min = Vacuum.MANUAL_VELOCITY_MIN
+        self.vel_max = Vacuum.MANUAL_VELOCITY_MAX
+        self.dur = 10 * 1000
+
+    def run(self) -> None:
+        self.vac.manual_start()
+        try:
+            curses.wrapper(self.main)
+        finally:
+            self.vac.manual_stop()
+
+    def main(self, screen) -> None:
+        screen.addstr("Use wasd to control the device.\n")
+        screen.addstr("Hold shift to enable fast mode.\n")
+        screen.addstr("Press q to quit.\n")
+        screen.refresh()
+        self.loop(screen)
+
+    def loop(self, win) -> None:
+        done = False
+        while not done:
+            key = win.getkey()
+            text, done = self.handle_key(key)
+            win.clear()
+            win.addstr(text)
+            win.refresh()
+
+    def handle_key(self, key: str) -> Tuple[str, bool]:
+        try:
+            ctl = Control(key)
+        except ValueError as e:
+            return "Ignoring %s: %s.\n" % (key, e), False
+
+        done = self.dispatch_control(ctl)
+        return self.info(), done
+
+    def dispatch_control(self, ctl: Control) -> bool:
+        if ctl == Control.Quit:
+            return True
+
+        if ctl == Control.Forward:
+            self.vel = min(self.vel + self.vel_delta, self.vel_max)
+        elif ctl == Control.ForwardFast:
+            self.vel = 0 if self.vel < 0 else self.vel_max
+
+        elif ctl == Control.Backward:
+            self.vel = max(self.vel - self.vel_delta, self.vel_min)
+        elif ctl == Control.BackwardFast:
+            self.vel = 0 if self.vel > 0 else self.vel_min
+
+        elif ctl == Control.Left:
+            self.rot = min(self.rot + self.rot_delta, self.rot_max)
+        elif ctl == Control.LeftFast:
+            self.rot = 0 if self.rot < 0 else self.rot_max
+
+        elif ctl == Control.Right:
+            self.rot = max(self.rot - self.rot_delta, self.rot_min)
+        elif ctl == Control.RightFast:
+            self.rot = 0 if self.rot > 0 else self.rot_min
+
+        else:
+            raise RuntimeError("unreachable")
+
+        self.vac.manual_control(rotation=self.rot, velocity=self.vel, duration=self.dur)
+        return False
+
+    def info(self) -> str:
+        return "Rotation=%s\nVelocity=%s\n" % (self.rot, self.vel)


### PR DESCRIPTION
I recently discovered this project and would like to thank you - it is awesome :)

I played with it a bit and noticed that the vacuum manual mode is difficult to use interactively via CLI. One has to enter somewhat lengthy (more than a char) commands and arguments, which might feel clumsy if a real-time response from the device is desired.

This PR adds a tiny `curses` based TUI to allow for a real-time movement control. I have not thoroughly explored the repo, so the proposed solution might not be optimal.