### PR TITLE
Fix fan speed property of the dmaker.fan.p11

### DIFF
--- a/miio/fan_miot.py
+++ b/miio/fan_miot.py
@@ -47,7 +47,7 @@ MIOT_MAPPING = {
         "mode": {"siid": 2, "piid": 3},
         "swing_mode": {"siid": 2, "piid": 4},
         "swing_mode_angle": {"siid": 2, "piid": 5},
-        # "status": {"siid": 2, "piid": 6},
+        "fan_speed": {"siid": 2, "piid": 6},
         "light": {"siid": 4, "piid": 1},
         "buzzer": {"siid": 5, "piid": 1},
         # "device_fault": {"siid": 6, "piid": 2},


### PR DESCRIPTION
I own this fan(dmaker.fan.p11) and it seems that siid:2 piid:6, which is named as 'status' is actually fan speed of 1~100.

https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:fan:0000A005:dmaker-p11:1
{"iid":6,"type":"urn:miot-spec-v2:property:status:00000007:dmaker-p11:1","description":"Status","format":"uint8","access":["read","notify"],"unit":"none","value-range":[1,100,1]}

Therefore, the fix should be made.