### PR TITLE
Fix PTC support of the dmaker.airfresh.t2017

### DIFF
--- a/miio/airfresh_t2017.py
+++ b/miio/airfresh_t2017.py
@@ -49,7 +49,6 @@ class OperationMode(enum.Enum):
 
 
 class PtcLevel(enum.Enum):
-    Off = "off"
     Low = "low"
     Medium = "medium"
     High = "high"
@@ -319,6 +318,19 @@ class AirFreshT2017(Device):
     def set_display_orientation(self, orientation: DisplayOrientation):
         """Set display orientation."""
         return self.send("set_screen_direction", [orientation.value])
+
+    @command(
+        click.argument("ptc", type=bool),
+        default_output=format_output(
+            lambda led: "Turning on ptc" if led else "Turning off ptc"
+        ),
+    )
+    def set_ptc(self, ptc: bool):
+        """Turn ptc on/off."""
+        if ptc:
+            return self.send("set_ptc_on", ["on"])
+        else:
+            return self.send("set_ptc_on", ["off"])
 
     @command(
         click.argument("level", type=EnumType(PtcLevel)),

--- a/miio/airfresh_t2017.py
+++ b/miio/airfresh_t2017.py
@@ -327,10 +327,7 @@ class AirFreshT2017(Device):
     )
     def set_ptc(self, ptc: bool):
         """Turn ptc on/off."""
-        if ptc:
-            return self.send("set_ptc_on", ["on"])
-        else:
-            return self.send("set_ptc_on", ["off"])
+        return self.send("set_ptc_on", [ptc])
 
     @command(
         click.argument("level", type=EnumType(PtcLevel)),

--- a/miio/tests/test_airfresh_t2017.py
+++ b/miio/tests/test_airfresh_t2017.py
@@ -47,6 +47,7 @@ class DummyAirFreshT2017(DummyDevice, AirFreshT2017):
             "set_display": lambda x: self._set_state("display", [(x[0] == "on")]),
             "set_screen_direction": lambda x: self._set_state("screen_direction", x),
             "set_ptc_level": lambda x: self._set_state("ptc_level", x),
+            "set_ptc_on": lambda x: self._set_state("ptc_on", x),
             "set_favourite_speed": lambda x: self._set_state("favourite_speed", x),
             "set_filter_reset": lambda x: self._set_filter_reset(x),
         }
@@ -201,12 +202,20 @@ class TestAirFreshT2017(TestCase):
         with pytest.raises(AirFreshException):
             self.device.set_favorite_speed(301)
 
+    def test_set_ptc(self):
+        def ptc():
+            return self.device.status().ptc
+
+        self.device.set_ptc(True)
+        assert ptc() is True
+
+        self.device.set_ptc(False)
+        assert ptc() is False
+
     def test_set_ptc_level(self):
         def ptc_level():
             return self.device.status().ptc_level
 
-        self.device.set_ptc_level(PtcLevel.Off)
-        assert ptc_level() == PtcLevel.Off
         self.device.set_ptc_level(PtcLevel.Low)
         assert ptc_level() == PtcLevel.Low
         self.device.set_ptc_level(PtcLevel.Medium)


### PR DESCRIPTION
Breaking change: `PtcLevel.Off` removed. Method `set_ptc(True)` / `set_ptc(False)` introduced.