### PR TITLE
miiocli: remove network & AP information from info output

### DIFF
--- a/miio/device.py
+++ b/miio/device.py
@@ -166,9 +166,7 @@ class Device(metaclass=DeviceGroupMeta):
             "",
             "Model: {result.model}\n"
             "Hardware version: {result.hardware_version}\n"
-            "Firmware version: {result.firmware_version}\n"
-            "Network: {result.network_interface}\n"
-            "AP: {result.accesspoint}\n",
+            "Firmware version: {result.firmware_version}\n",
         )
     )
     def info(self) -> DeviceInfo:


### PR DESCRIPTION
This removes identifiable information from the info output to make it safer to paste the output on the internet:
* AP information leaks geolocation
* Network information leaks internal network structure

This affects only `miiocli`, if these infos are needed it is simple to use debug verbosity to check them.