### PR TITLE
Add generic __repr__ for Device class

### DIFF
--- a/miio/alarmclock.py
+++ b/miio/alarmclock.py
@@ -66,9 +66,6 @@ class RingTone:
             self.smart_clock,
         )
 
-    def __str__(self):
-        return self.__repr__()
-
 
 class AlarmClock(Device):
     """

--- a/miio/device.py
+++ b/miio/device.py
@@ -127,7 +127,7 @@ class Device(metaclass=DeviceGroupMeta):
         parameters: Any = None,
         retry_count=3,
         *,
-        extra_parameters=None
+        extra_parameters=None,
     ) -> Any:
         """Send a command to the device.
 
@@ -249,3 +249,6 @@ class Device(metaclass=DeviceGroupMeta):
             )
 
         return values
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__ }: {self.ip} (token: {self.token})>"

--- a/miio/yeelight.py
+++ b/miio/yeelight.py
@@ -267,6 +267,3 @@ class Yeelight(Device):
         """Set the scene."""
         raise NotImplementedError("Setting the scene is not implemented yet.")
         # return self.send("set_scene", [scene, *vals])
-
-    def __str__(self):
-        return "<Yeelight at %s: %s>" % (self.ip, self.token)


### PR DESCRIPTION
Example output:
```
>>> from miio import Vacuum
>>> x = Vacuum("192.168.xx.xx", "48794cxx")
>>> x
<Vacuum: 192.168.xx.xx (token: 48794cxx)>
```

Thanks to @darckly's #868 for the reminder to add this.