### PR TITLE
Export MiotDevice for miio module

### DIFF
--- a/miio/__init__.py
+++ b/miio/__init__.py
@@ -38,6 +38,7 @@ from miio.fan_miot import FanMiot, FanP9, FanP10, FanP11
 from miio.gateway import Gateway
 from miio.heater import Heater
 from miio.huizuo import Huizuo
+from miio.miot_device import MiotDevice
 from miio.philips_bulb import PhilipsBulb, PhilipsWhiteBulb
 from miio.philips_eyecare import PhilipsEyecare
 from miio.philips_moonlight import PhilipsMoonlight


### PR DESCRIPTION
Is there a rule for adding classes to the `__init__.py`?