### PR TITLE
Add deerma.humidifier.jsq support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,7 @@ Supported devices
 -  Xiaomi Universal IR Remote Controller (Chuangmi IR)
 -  Xiaomi Mi Smart Pedestal Fan V2, V3, SA1, ZA1, ZA3, ZA4, P5, P9, P10, P11
 -  Xiaomi Rosou SS4 Ventilator (leshow.fan.ss4)
--  Xiaomi Mi Air Humidifier V1, CA1, CA4, CB1, MJJSQ, JSQ001
+-  Xiaomi Mi Air Humidifier V1, CA1, CA4, CB1, MJJSQ, JSQ, JSQ1, JSQ001
 -  Xiaomi Mi Water Purifier (Basic support: Turn on & off)
 -  Xiaomi Mi Water Purifier D1, C1 (Triple Setting)
 -  Xiaomi PM2.5 Air Quality Monitor V1, B1, S1

--- a/miio/airhumidifier_mjjsq.py
+++ b/miio/airhumidifier_mjjsq.py
@@ -12,6 +12,7 @@ from .exceptions import DeviceException
 _LOGGER = logging.getLogger(__name__)
 
 MODEL_HUMIDIFIER_MJJSQ = "deerma.humidifier.mjjsq"
+MODEL_HUMIDIFIER_JSQ = "deerma.humidifier.jsq"
 MODEL_HUMIDIFIER_JSQ1 = "deerma.humidifier.jsq1"
 
 MODEL_HUMIDIFIER_JSQ_COMMON = [
@@ -28,6 +29,7 @@ MODEL_HUMIDIFIER_JSQ_COMMON = [
 
 AVAILABLE_PROPERTIES = {
     MODEL_HUMIDIFIER_MJJSQ: MODEL_HUMIDIFIER_JSQ_COMMON,
+    MODEL_HUMIDIFIER_JSQ: MODEL_HUMIDIFIER_JSQ_COMMON,
     MODEL_HUMIDIFIER_JSQ1: MODEL_HUMIDIFIER_JSQ_COMMON + ["wet_and_protect"],
 }
 


### PR DESCRIPTION
I assume the device is the EU-version of the `deerma.humidifier.mjjsq`. The device isn't available via mDNS.