### PR TITLE
Retry and timeout can be change by setting a class attribute

### DIFF
--- a/miio/device.py
+++ b/miio/device.py
@@ -117,6 +117,8 @@ class Device(metaclass=DeviceGroupMeta):
     ) -> None:
         self.ip = ip
         self.token = token
+        if hasattr(self, "timeout"):
+            timeout = self.timeout
         self._protocol = MiIOProtocol(
             ip, token, start_id, debug, lazy_discover, timeout
         )
@@ -143,6 +145,8 @@ class Device(metaclass=DeviceGroupMeta):
         :param int retry_count: How many times to retry on error
         :param dict extra_parameters: Extra top-level parameters
         """
+        if hasattr(self, "retry_count"):
+            retry_count = self.retry_count
         return self._protocol.send(
             command, parameters, retry_count, extra_parameters=extra_parameters
         )

--- a/miio/device.py
+++ b/miio/device.py
@@ -147,7 +147,7 @@ class Device(metaclass=DeviceGroupMeta):
         :param int retry_count: How many times to retry on error
         :param dict extra_parameters: Extra top-level parameters
         """
-        retry_count = retry_count if retry_count is not None else self._retry_count
+        retry_count = retry_count if retry_count is not None else self.retry_count
         return self._protocol.send(
             command, parameters, retry_count, extra_parameters=extra_parameters
         )

--- a/miio/device.py
+++ b/miio/device.py
@@ -106,6 +106,9 @@ class Device(metaclass=DeviceGroupMeta):
     This class should not be initialized directly but a device-specific class inheriting
     it should be used instead of it."""
 
+    retry_count = 3
+    timeout = 5
+
     def __init__(
         self,
         ip: str = None,
@@ -113,12 +116,11 @@ class Device(metaclass=DeviceGroupMeta):
         start_id: int = 0,
         debug: int = 0,
         lazy_discover: bool = True,
-        timeout: int = 5,
+        timeout: int = None,
     ) -> None:
         self.ip = ip
         self.token = token
-        if hasattr(self, "timeout"):
-            timeout = self.timeout
+        timeout = timeout if timeout is not None else self.timeout
         self._protocol = MiIOProtocol(
             ip, token, start_id, debug, lazy_discover, timeout
         )
@@ -127,7 +129,7 @@ class Device(metaclass=DeviceGroupMeta):
         self,
         command: str,
         parameters: Any = None,
-        retry_count=3,
+        retry_count: int = None,
         *,
         extra_parameters=None,
     ) -> Any:
@@ -145,8 +147,7 @@ class Device(metaclass=DeviceGroupMeta):
         :param int retry_count: How many times to retry on error
         :param dict extra_parameters: Extra top-level parameters
         """
-        if hasattr(self, "retry_count"):
-            retry_count = self.retry_count
+        retry_count = retry_count if retry_count is not None else self._retry_count
         return self._protocol.send(
             command, parameters, retry_count, extra_parameters=extra_parameters
         )

--- a/miio/tests/test_device.py
+++ b/miio/tests/test_device.py
@@ -17,6 +17,17 @@ def test_get_properties_splitting(mocker, max_properties):
     if max_properties is None:
         max_properties = len(properties)
     assert send.call_count == math.ceil(len(properties) / max_properties)
+    assert 5 == d._protocol._timeout
+
+
+def test_timeout_retry(mocker):
+    send = mocker.patch("miio.miioprotocol.MiIOProtocol.send")
+    d = Device("127.0.0.1", "68ffffffffffffffffffffffffffffff", timeout=4)
+    assert 4 == d._protocol._timeout
+    d.send("fake_command", [], 1)
+    send.assert_called_with("fake_command", [], 1, extra_parameters=None)
+    d.send("fake_command", [])
+    send.assert_called_with("fake_command", [], 3, extra_parameters=None)
 
 
 def test_unavailable_device_info_raises(mocker):


### PR DESCRIPTION
No breaking change
With this, each class can have its own retry and timeout setting, ie:
```
class Vacuum(Device):
   retry =  5
   timeout = 10

   ...
```
   