### PR TITLE
Vacuum: add fan speed preset for gen1 firmwares 3.5.8+

### DIFF
--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -66,12 +66,14 @@ class FanspeedV2(enum.Enum):
     Turbo = 104
     Gentle = 105
 
+
 class FanspeedV3(enum.Enum):
     Silent = 38
     Standard = 60
     Medium = 75
     Turbo = 100
 
+    
 class FanspeedE2(enum.Enum):
     # Original names from the app: Gentle, Silent, Standard, Strong, Max
     Gentle = 41
@@ -508,7 +510,7 @@ class Vacuum(Device):
             version = tuple(map(int, version.split(".")))
             if version >= (3, 5, 8):
                 self._fanspeeds = FanspeedV3
-            elif version >= (3, 5, 7):
+            elif version == (3, 5, 7):
                 self._fanspeeds = FanspeedV2
             else:
                 self._fanspeeds = FanspeedV1

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -66,6 +66,11 @@ class FanspeedV2(enum.Enum):
     Turbo = 104
     Gentle = 105
 
+class FanspeedV3(enum.Enum):
+    Silent = 38
+    Standard = 60
+    Medium = 75
+    Turbo = 100
 
 class FanspeedE2(enum.Enum):
     # Original names from the app: Gentle, Silent, Standard, Strong, Max
@@ -501,7 +506,9 @@ class Vacuum(Device):
             fw_version = info.firmware_version
             version, build = fw_version.split("_")
             version = tuple(map(int, version.split(".")))
-            if version >= (3, 5, 7):
+            if version >= (3, 5, 8):
+                self._fanspeeds = FanspeedV3
+            elif version >= (3, 5, 7):
                 self._fanspeeds = FanspeedV2
             else:
                 self._fanspeeds = FanspeedV1

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -73,7 +73,7 @@ class FanspeedV3(enum.Enum):
     Medium = 75
     Turbo = 100
 
-    
+
 class FanspeedE2(enum.Enum):
     # Original names from the app: Gentle, Silent, Standard, Strong, Max
     Gentle = 41


### PR DESCRIPTION
Create a new class of fan speed for Firmware 3.5.8:
Silent = 38
Standard = 60
Turbo = 75
Max =100
Tested and functional with Xiaomi Vacuum Robot V1

Closes #860