### PR TITLE
Add support for Xiaomi Air purifier 3C 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ Supported devices
 -  Xiaomi Mi Robot Vacuum V1, S5, M1S
 -  Xiaomi Mi Home Air Conditioner Companion
 -  Xiaomi Mi Smart Air Conditioner A (xiaomi.aircondition.mc1, mc2, mc4, mc5)
--  Xiaomi Mi Air Purifier
+-  Xiaomi Mi Air Purifier 2, 3H, 3C, Pro (zhimi.airpurifier.m2, mb3, mb4, v7)
 -  Xiaomi Mi Air (Purifier) Dog X3, X5, X7SM (airdog.airpurifier.x3, airdog.airpurifier.x5, airdog.airpurifier.x7sm)
 -  Xiaomi Mi Air Humidifier
 -  Xiaomi Aqara Camera

--- a/miio/__init__.py
+++ b/miio/__init__.py
@@ -21,7 +21,7 @@ from miio.airhumidifier_miot import AirHumidifierMiot
 from miio.airhumidifier_mjjsq import AirHumidifierMjjsq
 from miio.airpurifier import AirPurifier
 from miio.airpurifier_airdog import AirDogX3, AirDogX5, AirDogX7SM
-from miio.airpurifier_miot import AirPurifierMiot
+from miio.airpurifier_miot import AirPurifierMB4, AirPurifierMiot
 from miio.airqualitymonitor import AirQualityMonitor
 from miio.airqualitymonitor_miot import AirQualityMonitorCGDN1
 from miio.aqaracamera import AqaraCamera

--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -282,11 +282,38 @@ class AirPurifierMiotStatus(BasicAirPurifierMiotStatus):
 
 
 class AirPurifierMB4Status(BasicAirPurifierMiotStatus):
-    """Container for status reports from the air purifier."""
+    """
+    Container for status reports from the  Mi Air Purifier 3C (zhimi.airpurifier.mb4).
 
-    def __init__(self, data: Dict[str, Any]) -> None:
-        print(data)
-        super().__init__(data)
+    {
+        'power': True,
+        'mode': 1,
+        'aqi': 2,
+        'filter_life_remaining': 97,
+        'filter_hours_used': 100,
+        'buzzer': True,
+        'led_brightness_level': 8,
+        'child_lock': False,
+        'motor_speed': 392,
+        'favorite_rpm': 500
+    }
+
+    Response (MIoT format)
+
+    [
+        {'did': 'power', 'siid': 2, 'piid': 1, 'code': 0, 'value': True},
+        {'did': 'mode', 'siid': 2, 'piid': 4, 'code': 0, 'value': 1},
+        {'did': 'aqi', 'siid': 3, 'piid': 4, 'code': 0, 'value': 3},
+        {'did': 'filter_life_remaining', 'siid': 4, 'piid': 1, 'code': 0, 'value': 97},
+        {'did': 'filter_hours_used', 'siid': 4, 'piid': 3, 'code': 0, 'value': 100},
+        {'did': 'buzzer', 'siid': 6, 'piid': 1, 'code': 0, 'value': True},
+        {'did': 'led_brightness_level', 'siid': 7, 'piid': 2, 'code': 0, 'value': 8},
+        {'did': 'child_lock', 'siid': 8, 'piid': 1, 'code': 0, 'value': False},
+        {'did': 'motor_speed', 'siid': 9, 'piid': 1, 'code': 0, 'value': 388},
+        {'did': 'favorite_rpm', 'siid': 9, 'piid': 3, 'code': 0, 'value': 500}
+    ]
+
+    """
 
     @property
     def led_brightness_level(self) -> int:

--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -353,7 +353,6 @@ class AirPurifierMB4Status(BasicAirPurifierMiotStatus):
 class BasicAirPurifierMiot(MiotDevice):
     """Main class representing the air purifier which uses MIoT protocol."""
 
-
     @command(default_output=format_output("Powering on"))
     def on(self):
         """Power on."""

--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -285,6 +285,7 @@ class AirPurifierMB4Status(BasicAirPurifierMiotStatus):
     """Container for status reports from the air purifier."""
 
     def __init__(self, data: Dict[str, Any]) -> None:
+        print(data)
         super().__init__(data)
 
     @property
@@ -293,7 +294,7 @@ class AirPurifierMB4Status(BasicAirPurifierMiotStatus):
         return self.data["led_brightness_level"]
 
     @property
-    def favorite_level(self) -> int:
+    def favorite_rpm(self) -> int:
         """Return favorite rpm level."""
         return self.data["favorite_rpm"]
 
@@ -537,8 +538,8 @@ class AirPurifierMB4(BasicAirPurifierMiot):
         )
 
     @command(
-        click.argument("led_brightness_level", type=int),
-        default_output=format_output("Setting LED brightness level to {brightness}"),
+        click.argument("level", type=int),
+        default_output=format_output("Setting LED brightness level to {level}"),
     )
     def set_led_brightness_level(self, level: int):
         """Set led brightness level."""

--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -148,9 +148,6 @@ class BasicAirPurifierMiotStatus:
 class AirPurifierMiotStatus(BasicAirPurifierMiotStatus):
     """Container for status reports from the air purifier."""
 
-    def __init__(self, data: Dict[str, Any]) -> None:
-        super().__init__(data)
-
     @property
     def average_aqi(self) -> int:
         """Average of the air quality index."""

--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -559,7 +559,7 @@ class AirPurifierMB4(BasicAirPurifierMiot):
         default_output=format_output("Setting LED brightness level to {level}"),
     )
     def set_led_brightness_level(self, level: int):
-        """Set led brightness level."""
+        """Set led brightness level (0..8)."""
         if level < 0 or level > 8:
             raise AirPurifierMiotException("Invalid brightness level: %s" % level)
 

--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -356,16 +356,6 @@ class AirPurifierMB4Status(BasicAirPurifierMiotStatus):
 class BasicAirPurifierMiot(MiotDevice):
     """Main class representing the air purifier which uses MIoT protocol."""
 
-    def __init__(
-        self,
-        attributes: dict = [],
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-    ) -> None:
-        super().__init__(attributes, ip, token, start_id, debug, lazy_discover)
 
     @command(default_output=format_output("Powering on"))
     def on(self):

--- a/miio/tests/test_airpurifier_miot_mb4.py
+++ b/miio/tests/test_airpurifier_miot_mb4.py
@@ -70,7 +70,7 @@ class TestAirPurifier(TestCase):
         assert status.led_brightness_level == _INITIAL_STATE["led_brightness_level"]
         assert status.buzzer == _INITIAL_STATE["buzzer"]
         assert status.child_lock == _INITIAL_STATE["child_lock"]
-        assert status.favorite_rpm == _INITIAL_STATE["favorite_rpm"]
+        assert status.favorite_level == _INITIAL_STATE["favorite_rpm"]
         assert status.filter_life_remaining == _INITIAL_STATE["filter_life_remaining"]
         assert status.filter_hours_used == _INITIAL_STATE["filter_hours_used"]
         assert status.motor_speed == _INITIAL_STATE["motor_speed"]
@@ -92,15 +92,15 @@ class TestAirPurifier(TestCase):
         assert mode() == OperationMode.Fan
 
     def test_set_favorite_rpm(self):
-        def favorite_rpm():
-            return self.device.status().favorite_rpm
+        def favorite_level():
+            return self.device.status().favorite_level
 
         self.device.set_favorite_rpm(300)
-        assert favorite_rpm() == 300
+        assert favorite_level() == 300
         self.device.set_favorite_rpm(1000)
-        assert favorite_rpm() == 1000
+        assert favorite_level() == 1000
         self.device.set_favorite_rpm(2300)
-        assert favorite_rpm() == 2300
+        assert favorite_level() == 2300
 
         with pytest.raises(AirPurifierMiotException):
             self.device.set_favorite_rpm(301)

--- a/miio/tests/test_airpurifier_miot_mb4.py
+++ b/miio/tests/test_airpurifier_miot_mb4.py
@@ -1,0 +1,141 @@
+from unittest import TestCase
+
+import pytest
+
+from miio import AirPurifierMB4
+from miio.airpurifier_miot import AirPurifierMiotException, OperationMode
+
+from .dummies import DummyMiotDevice
+
+_INITIAL_STATE = {
+    "power": True,
+    "mode": 0,
+    "aqi": 10,
+    "filter_life_remaining": 80,
+    "filter_hours_used": 682,
+    "buzzer": False,
+    "led_brightness_level": 4,
+    "child_lock": False,
+    "motor_speed": 354,
+    "favorite_rpm": 500,
+}
+
+
+class DummyAirPurifierMiot(DummyMiotDevice, AirPurifierMB4):
+    def __init__(self, *args, **kwargs):
+        self.state = _INITIAL_STATE
+        self.return_values = {
+            "get_prop": self._get_state,
+            "set_power": lambda x: self._set_state("power", x),
+            "set_mode": lambda x: self._set_state("mode", x),
+            "set_buzzer": lambda x: self._set_state("buzzer", x),
+            "set_child_lock": lambda x: self._set_state("child_lock", x),
+            "set_level_favorite_rpm": lambda x: self._set_state(
+                "favorite_level_rpm", x
+            ),
+            "reset_filter1": lambda x: (
+                self._set_state("f1_hour_used", [0]),
+                self._set_state("filter1_life", [100]),
+            ),
+        }
+        super().__init__(*args, **kwargs)
+
+
+@pytest.fixture(scope="function")
+def airpurifier(request):
+    request.cls.device = DummyAirPurifierMiot()
+
+
+@pytest.mark.usefixtures("airpurifier")
+class TestAirPurifier(TestCase):
+    def test_on(self):
+        self.device.off()  # ensure off
+        assert self.device.status().is_on is False
+
+        self.device.on()
+        assert self.device.status().is_on is True
+
+    def test_off(self):
+        self.device.on()  # ensure on
+        assert self.device.status().is_on is True
+
+        self.device.off()
+        assert self.device.status().is_on is False
+
+    def test_status(self):
+        status = self.device.status()
+        assert status.is_on is _INITIAL_STATE["power"]
+        assert status.aqi == _INITIAL_STATE["aqi"]
+        assert status.mode == OperationMode(_INITIAL_STATE["mode"])
+        assert status.led_brightness_level == _INITIAL_STATE["led_brightness_level"]
+        assert status.buzzer == _INITIAL_STATE["buzzer"]
+        assert status.child_lock == _INITIAL_STATE["child_lock"]
+        assert status.favorite_rpm == _INITIAL_STATE["favorite_rpm"]
+        assert status.filter_life_remaining == _INITIAL_STATE["filter_life_remaining"]
+        assert status.filter_hours_used == _INITIAL_STATE["filter_hours_used"]
+        assert status.motor_speed == _INITIAL_STATE["motor_speed"]
+
+    def test_set_mode(self):
+        def mode():
+            return self.device.status().mode
+
+        self.device.set_mode(OperationMode.Auto)
+        assert mode() == OperationMode.Auto
+
+        self.device.set_mode(OperationMode.Silent)
+        assert mode() == OperationMode.Silent
+
+        self.device.set_mode(OperationMode.Favorite)
+        assert mode() == OperationMode.Favorite
+
+        self.device.set_mode(OperationMode.Fan)
+        assert mode() == OperationMode.Fan
+
+    def test_set_favorite_rpm(self):
+        def favorite_rpm():
+            return self.device.status().favorite_rpm
+
+        self.device.set_favorite_rpm(300)
+        assert favorite_rpm() == 300
+        self.device.set_favorite_rpm(1000)
+        assert favorite_rpm() == 1000
+        self.device.set_favorite_rpm(2300)
+        assert favorite_rpm() == 2300
+
+        with pytest.raises(AirPurifierMiotException):
+            self.device.set_favorite_rpm(301)
+
+        with pytest.raises(AirPurifierMiotException):
+            self.device.set_favorite_rpm(290)
+
+        with pytest.raises(AirPurifierMiotException):
+            self.device.set_favorite_rpm(2310)
+
+    def test_set_led_brightness_level(self):
+        def led_brightness_level():
+            return self.device.status().led_brightness_level
+
+        self.device.set_led_brightness_level(0)
+        assert led_brightness_level() == 0
+
+        self.device.set_led_brightness_level(4)
+        assert led_brightness_level() == 4
+
+        self.device.set_led_brightness_level(8)
+        assert led_brightness_level() == 8
+
+        with pytest.raises(AirPurifierMiotException):
+            self.device.set_led_brightness_level(-1)
+
+        with pytest.raises(AirPurifierMiotException):
+            self.device.set_led_brightness_level(9)
+
+    def test_set_child_lock(self):
+        def child_lock():
+            return self.device.status().child_lock
+
+        self.device.set_child_lock(True)
+        assert child_lock() is True
+
+        self.device.set_child_lock(False)
+        assert child_lock() is False

--- a/miio/tests/test_airpurifier_miot_mb4.py
+++ b/miio/tests/test_airpurifier_miot_mb4.py
@@ -30,9 +30,7 @@ class DummyAirPurifierMiot(DummyMiotDevice, AirPurifierMB4):
             "set_mode": lambda x: self._set_state("mode", x),
             "set_buzzer": lambda x: self._set_state("buzzer", x),
             "set_child_lock": lambda x: self._set_state("child_lock", x),
-            "set_level_favorite_rpm": lambda x: self._set_state(
-                "favorite_level_rpm", x
-            ),
+            "set_favorite_rpm": lambda x: self._set_state("favorite_rpm", x),
             "reset_filter1": lambda x: (
                 self._set_state("f1_hour_used", [0]),
                 self._set_state("filter1_life", [100]),
@@ -70,7 +68,7 @@ class TestAirPurifier(TestCase):
         assert status.led_brightness_level == _INITIAL_STATE["led_brightness_level"]
         assert status.buzzer == _INITIAL_STATE["buzzer"]
         assert status.child_lock == _INITIAL_STATE["child_lock"]
-        assert status.favorite_level == _INITIAL_STATE["favorite_rpm"]
+        assert status.favorite_rpm == _INITIAL_STATE["favorite_rpm"]
         assert status.filter_life_remaining == _INITIAL_STATE["filter_life_remaining"]
         assert status.filter_hours_used == _INITIAL_STATE["filter_hours_used"]
         assert status.motor_speed == _INITIAL_STATE["motor_speed"]
@@ -92,15 +90,15 @@ class TestAirPurifier(TestCase):
         assert mode() == OperationMode.Fan
 
     def test_set_favorite_rpm(self):
-        def favorite_level():
-            return self.device.status().favorite_level
+        def favorite_rpm():
+            return self.device.status().favorite_rpm
 
         self.device.set_favorite_rpm(300)
-        assert favorite_level() == 300
+        assert favorite_rpm() == 300
         self.device.set_favorite_rpm(1000)
-        assert favorite_level() == 1000
+        assert favorite_rpm() == 1000
         self.device.set_favorite_rpm(2300)
-        assert favorite_level() == 2300
+        assert favorite_rpm() == 2300
 
         with pytest.raises(AirPurifierMiotException):
             self.device.set_favorite_rpm(301)


### PR DESCRIPTION
This PR adds support for Air purifier 3C (`zhimi.airpurifier.mb4`) which according to  [specification](https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:air-purifier:0000A007:zhimi-mb4:2) provides only a subset of i.e. mb3 functionalities. 