### PR TITLE
Add Qingping Air Monitor Lite support (cgllc.airm.cgdn1)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -131,6 +131,7 @@ Supported devices
 -  Xiaomi Xiaomi Mi Smart Space Heater S (zhimi.heater.mc2)
 -  Yeelight Dual Control Module (yeelink.switch.sw1)
 -  Scishare coffee maker (scishare.coffee.s1102)
+-  Qingping Air Monitor Lite (cgllc.airm.cgdn1)
 
 
 *Feel free to create a pull request to add support for new devices as

--- a/miio/__init__.py
+++ b/miio/__init__.py
@@ -23,6 +23,7 @@ from miio.airpurifier import AirPurifier
 from miio.airpurifier_airdog import AirDogX3, AirDogX5, AirDogX7SM
 from miio.airpurifier_miot import AirPurifierMiot
 from miio.airqualitymonitor import AirQualityMonitor
+from miio.airqualitymonitor_miot import AirQualityMonitorCGDN1
 from miio.aqaracamera import AqaraCamera
 from miio.ceil import Ceil
 from miio.chuangmi_camera import ChuangmiCamera

--- a/miio/airqualitymonitor_miot.py
+++ b/miio/airqualitymonitor_miot.py
@@ -1,0 +1,254 @@
+import enum
+import logging
+
+import click
+
+from .click_common import command, format_output
+from .exceptions import DeviceException
+from .miot_device import MiotDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+MODEL_AIRQUALITYMONITOR_CGDN1 = "cgllc.airm.cgdn1"
+
+_MAPPING_CGDN1 = {
+    # Source https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:air-monitor:0000A008:cgllc-cgdn1:1
+    # Environment
+    "humidity": {"siid": 3, "piid": 1},  # [0, 100] step 1
+    "pm25": {"siid": 3, "piid": 4},  # [0, 1000] step 1
+    "pm10": {"siid": 3, "piid": 5},  # [0, 1000] step 1
+    "temperature": {"siid": 3, "piid": 7},  # [-30, 100] step 0.00001
+    "co2": {"siid": 3, "piid": 8},  # [0, 9999] step 1
+    # Battery
+    "battery": {"siid": 4, "piid": 1},  # [0, 100] step 1
+    "charging_state": {
+        "siid": 4,
+        "piid": 2,
+    },  # 1 - Charging, 2 - Not charging, 3 - Not chargeable
+    "voltage": {"siid": 4, "piid": 3},  # [0, 65535] step 1
+    # Settings
+    "start_time": {"siid": 9, "piid": 2},  # [0, 2147483647] step 1
+    "end_time": {"siid": 9, "piid": 3},  # [0, 2147483647] step 1
+    "monitoring_frequency": {"siid": 9, "piid": 4},  # 1, 60, 300, 600, 0
+    "screen_off": {"siid": 9, "piid": 5},  # 15, 30, 60, 300, 0
+    "device_off": {"siid": 9, "piid": 6},  # 15, 30, 60, 0
+    "temperature_unit": {"siid": 9, "piid": 7},
+}
+
+
+class AirQualityMonitorMiotException(DeviceException):
+    pass
+
+
+class ChargingStateCGDN1(enum.Enum):
+    Unplugged = 0  # Not mentioned in the spec
+    Charging = 1
+    NotCharging = 2
+    NotChargable = 3
+
+
+class MonitoringFrequencyCGDN1(enum.Enum):
+    Every1Second = 1
+    Every1Minute = 60
+    Every5Minutes = 300
+    Every10Minutes = 600
+    NotSet = 0
+
+
+class ScreenOffCGDN1(enum.Enum):
+    After15Seconds = 15
+    After30Seconds = 30
+    After1Minute = 60
+    After5Minutes = 300
+    Never = 0
+
+
+class DeviceOffCGDN1(enum.Enum):
+    After15Minutes = 15
+    After30Minutes = 30
+    After1Hour = 60
+    Never = 0
+
+
+class DisplayTemeratureUnitCGDN1(enum.Enum):
+    Celcius = "c"
+    Fahrenheit = "f"
+
+
+class AirQualityMonitorCGDN1Status:
+    """Container of air quality monitor CGDN1 status."""
+
+    def __init__(self, data):
+        self.data = data
+
+    @property
+    def humidity(self) -> int:
+        """Return humidity value (0...100%)."""
+        return self.data["humidity"]
+
+    @property
+    def pm25(self) -> int:
+        """Return PM 2.5 value (0...1000ppm)."""
+        return self.data["pm25"]
+
+    @property
+    def pm10(self) -> int:
+        """Return PM 10 value (0...1000ppm)."""
+        return self.data["pm10"]
+
+    @property
+    def temperature(self) -> float:
+        """Return temperature value (-30...100°C)."""
+        return self.data["temperature"]
+
+    @property
+    def co2(self) -> int:
+        """Return co2 value (0...9999ppm)."""
+        return self.data["co2"]
+
+    @property
+    def battery(self) -> int:
+        """Return battery level (0...100%)."""
+        return self.data["battery"]
+
+    @property
+    def charging_state(self) -> ChargingStateCGDN1:
+        """Return charging state."""
+        return ChargingStateCGDN1(self.data["charging_state"])
+
+    @property
+    def monitoring_frequency(self) -> int:
+        """Return monitoring frequency time."""
+        return MonitoringFrequencyCGDN1(self.data["monitoring_frequency"])
+
+    @property
+    def screen_off(self) -> int:
+        """Return screen off time."""
+        return ScreenOffCGDN1(self.data["screen_off"])
+
+    @property
+    def device_off(self) -> int:
+        """Return device off time."""
+        return DeviceOffCGDN1(self.data["device_off"])
+
+    @property
+    def display_temperature_unit(self):
+        """Return display temperature unit."""
+        return DisplayTemeratureUnitCGDN1(self.data["temperature_unit"])
+
+    def __repr__(self) -> str:
+        s = (
+            "<AirQualityMonitorCGDN1Status humidity=%s, "
+            "pm25=%s, "
+            "pm10=%s, "
+            "temperature=%s, "
+            "co2=%s, "
+            "battery=%s, "
+            "charging_state=%s"
+            "monitoring_frequency=%s"
+            "screen_off=%s"
+            "device_off=%s"
+            "display_temerature_unit=%s>"
+            % (
+                self.humidity,
+                self.pm25,
+                self.pm10,
+                self.temperature,
+                self.co2,
+                self.battery,
+                self.charging_state,
+                self.monitoring_frequency,
+                self.screen_off,
+                self.device_off,
+                self.display_temperature_unit,
+            )
+        )
+        return s
+
+
+class AirQualityMonitorCGDN1(MiotDevice):
+    """Qingping Air Monitor Lite."""
+
+    def __init__(
+        self,
+        ip: str = None,
+        token: str = None,
+        start_id: int = 0,
+        debug: int = 0,
+        lazy_discover: bool = True,
+    ) -> None:
+        super().__init__(_MAPPING_CGDN1, ip, token, start_id, debug, lazy_discover)
+
+    @command(
+        default_output=format_output(
+            "",
+            "Humidity: {result.humidity} %\n"
+            "PM 2.5: {result.pm25} μg/m³\n"
+            "PM 10: {result.pm10} μg/m³\n"
+            "Temperature: {result.temperature} °C\n"
+            "CO₂: {result.co2} μg/m³\n"
+            "Battery: {result.battery} %\n"
+            "Charing state: {result.charging_state.name}\n"
+            "Monitoring frequency: {result.monitoring_frequency.name}\n"
+            "Screen off: {result.screen_off.name}\n"
+            "Device off: {result.device_off.name}\n"
+            "Display temperature unit: {result.display_temperature_unit.name}\n",
+        )
+    )
+    def status(self) -> AirQualityMonitorCGDN1Status:
+        """Retrieve properties."""
+
+        return AirQualityMonitorCGDN1Status(
+            {
+                prop["did"]: prop["value"] if prop["code"] == 0 else None
+                for prop in self.get_properties_for_mapping()
+            }
+        )
+
+    @command(
+        click.argument(
+            "freq",
+            type=click.Choice(MonitoringFrequencyCGDN1.__members__),
+            callback=lambda c, p, v: getattr(MonitoringFrequencyCGDN1, v),
+        ),
+        default_output=format_output("Setting monitoring frequency to {freq.name}"),
+    )
+    def set_monitoring_frequency(self, freq: MonitoringFrequencyCGDN1):
+        """Set monitoring frequency."""
+        return self.set_property("monitoring_frequency", freq.value)
+
+    @command(
+        click.argument(
+            "duration",
+            type=click.Choice(DeviceOffCGDN1.__members__),
+            callback=lambda c, p, v: getattr(DeviceOffCGDN1, v),
+        ),
+        default_output=format_output("Setting device off duration to {duration.name}"),
+    )
+    def set_device_off_duration(self, duration: DeviceOffCGDN1):
+        """Set device off duration."""
+        return self.set_property("device_off", duration.value)
+
+    @command(
+        click.argument(
+            "duration",
+            type=click.Choice(ScreenOffCGDN1.__members__),
+            callback=lambda c, p, v: getattr(ScreenOffCGDN1, v),
+        ),
+        default_output=format_output("Setting screen off duration to {duration.name}"),
+    )
+    def set_screen_off_duration(self, duration: ScreenOffCGDN1):
+        """Set screen off duration."""
+        return self.set_property("screen_off", duration.value)
+
+    @command(
+        click.argument(
+            "unit",
+            type=click.Choice(DisplayTemeratureUnitCGDN1.__members__),
+            callback=lambda c, p, v: getattr(DisplayTemeratureUnitCGDN1, v),
+        ),
+        default_output=format_output("Setting display temperature unit to {unit.name}"),
+    )
+    def set_display_temerature_unit(self, unit: DisplayTemeratureUnitCGDN1):
+        """Set display temerature unit."""
+        return self.set_property("temperature_unit", unit.value)

--- a/miio/airqualitymonitor_miot.py
+++ b/miio/airqualitymonitor_miot.py
@@ -79,7 +79,7 @@ class DeviceOffCGDN1(enum.Enum):  # Official spec options
     Never = 0
 
 
-class DisplayTemeratureUnitCGDN1(enum.Enum):
+class DisplayTemperatureUnitCGDN1(enum.Enum):
     Celcius = "c"
     Fahrenheit = "f"
 
@@ -163,7 +163,7 @@ class AirQualityMonitorCGDN1Status:
     @property
     def display_temperature_unit(self):
         """Return display temperature unit."""
-        return DisplayTemeratureUnitCGDN1(self.data["temperature_unit"])
+        return DisplayTemperatureUnitCGDN1(self.data["temperature_unit"])
 
     def __repr__(self) -> str:
         s = (
@@ -177,7 +177,7 @@ class AirQualityMonitorCGDN1Status:
             "monitoring_frequency=%s"
             "screen_off=%s"
             "device_off=%s"
-            "display_temerature_unit=%s>"
+            "display_temperature_unit=%s>"
             % (
                 self.humidity,
                 self.pm25,
@@ -207,9 +207,9 @@ class AirQualityMonitorCGDN1(MiotDevice):
         lazy_discover: bool = True,
     ) -> None:
         super().__init__(_MAPPING_CGDN1, ip, token, start_id, debug, lazy_discover)
-        self._monitoring_frequency_options = MonitoringFrequencyCGDN1
-        self._screen_off_options = ScreenOffCGDN1
-        self._device_off_options = DeviceOffCGDN1
+        self.monitoring_frequency_options = MonitoringFrequencyCGDN1
+        self.screen_off_options = ScreenOffCGDN1
+        self.device_off_options = DeviceOffCGDN1
 
     @command(
         default_output=format_output(
@@ -276,11 +276,11 @@ class AirQualityMonitorCGDN1(MiotDevice):
     @command(
         click.argument(
             "unit",
-            type=click.Choice(DisplayTemeratureUnitCGDN1.__members__),
-            callback=lambda c, p, v: getattr(DisplayTemeratureUnitCGDN1, v),
+            type=click.Choice(DisplayTemperatureUnitCGDN1.__members__),
+            callback=lambda c, p, v: getattr(DisplayTemperatureUnitCGDN1, v),
         ),
         default_output=format_output("Setting display temperature unit to {unit.name}"),
     )
-    def set_display_temerature_unit(self, unit: DisplayTemeratureUnitCGDN1):
-        """Set display temerature unit."""
+    def set_display_temperature_unit(self, unit: DisplayTemperatureUnitCGDN1):
+        """Set display temperature unit."""
         return self.set_property("temperature_unit", unit.value)

--- a/miio/airqualitymonitor_miot.py
+++ b/miio/airqualitymonitor_miot.py
@@ -109,9 +109,6 @@ class AirQualityMonitorCGDN1Status:
 
     def __init__(self, data):
         self.data = data
-        self._monitoring_frequency_options = MonitoringFrequencyCGDN1
-        self._screen_off_options = ScreenOffCGDN1
-        self._device_off_options = DeviceOffCGDN1
 
     @property
     def humidity(self) -> int:
@@ -210,6 +207,9 @@ class AirQualityMonitorCGDN1(MiotDevice):
         lazy_discover: bool = True,
     ) -> None:
         super().__init__(_MAPPING_CGDN1, ip, token, start_id, debug, lazy_discover)
+        self._monitoring_frequency_options = MonitoringFrequencyCGDN1
+        self._screen_off_options = ScreenOffCGDN1
+        self._device_off_options = DeviceOffCGDN1
 
     @command(
         default_output=format_output(

--- a/miio/airqualitymonitor_miot.py
+++ b/miio/airqualitymonitor_miot.py
@@ -40,7 +40,7 @@ class AirQualityMonitorMiotException(DeviceException):
     pass
 
 
-class ChargingStateCGDN1(enum.Enum):
+class ChargingState(enum.Enum):
     Unplugged = 0  # Not mentioned in the spec
     Charging = 1
     NotCharging = 2
@@ -112,9 +112,9 @@ class AirQualityMonitorCGDN1Status:
         return self.data["battery"]
 
     @property
-    def charging_state(self) -> ChargingStateCGDN1:
+    def charging_state(self) -> ChargingState:
         """Return charging state."""
-        return ChargingStateCGDN1(self.data["charging_state"])
+        return ChargingState(self.data["charging_state"])
 
     @property
     def monitoring_frequency(self) -> int:

--- a/miio/airqualitymonitor_miot.py
+++ b/miio/airqualitymonitor_miot.py
@@ -207,9 +207,6 @@ class AirQualityMonitorCGDN1(MiotDevice):
         lazy_discover: bool = True,
     ) -> None:
         super().__init__(_MAPPING_CGDN1, ip, token, start_id, debug, lazy_discover)
-        self.monitoring_frequency_options = MonitoringFrequencyCGDN1
-        self.screen_off_options = ScreenOffCGDN1
-        self.device_off_options = DeviceOffCGDN1
 
     @command(
         default_output=format_output(

--- a/miio/airqualitymonitor_miot.py
+++ b/miio/airqualitymonitor_miot.py
@@ -85,7 +85,27 @@ class DisplayTemeratureUnitCGDN1(enum.Enum):
 
 
 class AirQualityMonitorCGDN1Status:
-    """Container of air quality monitor CGDN1 status."""
+    """
+    Container of air quality monitor CGDN1 status.
+
+    {
+      'humidity': 34,
+      'pm25': 18,
+      'pm10': 21,
+      'temperature': 22.8,
+      'co2': 468,
+      'battery': 37,
+      'charging_state': 0,
+      'voltage': 3564,
+      'start_time': 0,
+      'end_time': 0,
+      'monitoring_frequency': 1,
+      'screen_off': 300,
+      'device_off': 60,
+      'temperature_unit': 'c'
+    }
+
+    """
 
     def __init__(self, data):
         self.data = data

--- a/miio/airqualitymonitor_miot.py
+++ b/miio/airqualitymonitor_miot.py
@@ -188,7 +188,7 @@ class AirQualityMonitorCGDN1(MiotDevice):
             "Temperature: {result.temperature} °C\n"
             "CO₂: {result.co2} μg/m³\n"
             "Battery: {result.battery} %\n"
-            "Charing state: {result.charging_state.name}\n"
+            "Charging state: {result.charging_state.name}\n"
             "Monitoring frequency: {result.monitoring_frequency.name}\n"
             "Screen off: {result.screen_off.name}\n"
             "Device off: {result.device_off.name}\n"

--- a/miio/tests/test_airqualitymonitor_miot.py
+++ b/miio/tests/test_airqualitymonitor_miot.py
@@ -4,7 +4,7 @@ import pytest
 
 from miio import AirQualityMonitorCGDN1
 from miio.airqualitymonitor_miot import (
-    ChargingStateCGDN1,
+    ChargingState,
     DeviceOffCGDN1,
     DisplayTemeratureUnitCGDN1,
     MonitoringFrequencyCGDN1,
@@ -63,9 +63,7 @@ class TestAirQualityMonitor(TestCase):
         assert status.temperature is _INITIAL_STATE["temperature"]
         assert status.co2 is _INITIAL_STATE["co2"]
         assert status.battery is _INITIAL_STATE["battery"]
-        assert status.charging_state is ChargingStateCGDN1(
-            _INITIAL_STATE["charging_state"]
-        )
+        assert status.charging_state is ChargingState(_INITIAL_STATE["charging_state"])
         assert status.monitoring_frequency is MonitoringFrequencyCGDN1(
             _INITIAL_STATE["monitoring_frequency"]
         )

--- a/miio/tests/test_airqualitymonitor_miot.py
+++ b/miio/tests/test_airqualitymonitor_miot.py
@@ -6,7 +6,7 @@ from miio import AirQualityMonitorCGDN1
 from miio.airqualitymonitor_miot import (
     AirQualityMonitorMiotException,
     ChargingState,
-    DisplayTemeratureUnitCGDN1,
+    DisplayTemperatureUnitCGDN1,
 )
 
 from .dummies import DummyMiotDevice
@@ -39,7 +39,7 @@ class DummyAirQualityMonitorCGDN1(DummyMiotDevice, AirQualityMonitorCGDN1):
             ),
             "set_device_off_duration": lambda x: self._set_state("device_off", x),
             "set_screen_off_duration": lambda x: self._set_state("screen_off", x),
-            "set_display_temerature_unit": lambda x: self._set_state(
+            "set_display_temperature_unit": lambda x: self._set_state(
                 "temperature_unit", x
             ),
         }
@@ -65,7 +65,7 @@ class TestAirQualityMonitor(TestCase):
         assert status.monitoring_frequency is _INITIAL_STATE["monitoring_frequency"]
         assert status.screen_off is _INITIAL_STATE["screen_off"]
         assert status.device_off is _INITIAL_STATE["device_off"]
-        assert status.display_temperature_unit is DisplayTemeratureUnitCGDN1(
+        assert status.display_temperature_unit is DisplayTemperatureUnitCGDN1(
             _INITIAL_STATE["temperature_unit"]
         )
 
@@ -126,12 +126,12 @@ class TestAirQualityMonitor(TestCase):
         with pytest.raises(AirQualityMonitorMiotException):
             self.device.set_screen_off_duration(301)
 
-    def test_set_display_temerature_unit(self):
-        def display_temerature_unit():
+    def test_set_display_temperature_unit(self):
+        def display_temperature_unit():
             return self.device.status().display_temperature_unit
 
-        self.device.set_display_temerature_unit(DisplayTemeratureUnitCGDN1.Celcius)
-        assert display_temerature_unit() == DisplayTemeratureUnitCGDN1.Celcius
+        self.device.set_display_temperature_unit(DisplayTemperatureUnitCGDN1.Celcius)
+        assert display_temperature_unit() == DisplayTemperatureUnitCGDN1.Celcius
 
-        self.device.set_display_temerature_unit(DisplayTemeratureUnitCGDN1.Fahrenheit)
-        assert display_temerature_unit() == DisplayTemeratureUnitCGDN1.Fahrenheit
+        self.device.set_display_temperature_unit(DisplayTemperatureUnitCGDN1.Fahrenheit)
+        assert display_temperature_unit() == DisplayTemperatureUnitCGDN1.Fahrenheit

--- a/miio/tests/test_airqualitymonitor_miot.py
+++ b/miio/tests/test_airqualitymonitor_miot.py
@@ -4,11 +4,9 @@ import pytest
 
 from miio import AirQualityMonitorCGDN1
 from miio.airqualitymonitor_miot import (
+    AirQualityMonitorMiotException,
     ChargingState,
-    DeviceOffCGDN1,
     DisplayTemeratureUnitCGDN1,
-    MonitoringFrequencyCGDN1,
-    ScreenOffCGDN1,
 )
 
 from .dummies import DummyMiotDevice
@@ -64,67 +62,69 @@ class TestAirQualityMonitor(TestCase):
         assert status.co2 is _INITIAL_STATE["co2"]
         assert status.battery is _INITIAL_STATE["battery"]
         assert status.charging_state is ChargingState(_INITIAL_STATE["charging_state"])
-        assert status.monitoring_frequency is MonitoringFrequencyCGDN1(
-            _INITIAL_STATE["monitoring_frequency"]
-        )
-        assert status.screen_off is ScreenOffCGDN1(_INITIAL_STATE["screen_off"])
+        assert status.monitoring_frequency is _INITIAL_STATE["monitoring_frequency"]
+        assert status.screen_off is _INITIAL_STATE["screen_off"]
+        assert status.device_off is _INITIAL_STATE["device_off"]
         assert status.display_temperature_unit is DisplayTemeratureUnitCGDN1(
             _INITIAL_STATE["temperature_unit"]
         )
 
-    def test_set_monitoring_frequency(self):
+    def test_set_monitoring_frequency_duration(self):
         def monitoring_frequency():
             return self.device.status().monitoring_frequency
 
-        self.device.set_monitoring_frequency(MonitoringFrequencyCGDN1.Every1Second)
-        assert monitoring_frequency() == MonitoringFrequencyCGDN1.Every1Second
+        self.device.set_monitoring_frequency_duration(0)
+        assert monitoring_frequency() == 0
 
-        self.device.set_monitoring_frequency(MonitoringFrequencyCGDN1.Every1Minute)
-        assert monitoring_frequency() == MonitoringFrequencyCGDN1.Every1Minute
+        self.device.set_monitoring_frequency_duration(290)
+        assert monitoring_frequency() == 290
 
-        self.device.set_monitoring_frequency(MonitoringFrequencyCGDN1.Every5Minutes)
-        assert monitoring_frequency() == MonitoringFrequencyCGDN1.Every5Minutes
+        self.device.set_monitoring_frequency_duration(600)
+        assert monitoring_frequency() == 600
 
-        self.device.set_monitoring_frequency(MonitoringFrequencyCGDN1.Every10Minutes)
-        assert monitoring_frequency() == MonitoringFrequencyCGDN1.Every10Minutes
+        with pytest.raises(AirQualityMonitorMiotException):
+            self.device.set_monitoring_frequency_duration(-1)
 
-        self.device.set_monitoring_frequency(MonitoringFrequencyCGDN1.NotSet)
-        assert monitoring_frequency() == MonitoringFrequencyCGDN1.NotSet
+        with pytest.raises(AirQualityMonitorMiotException):
+            self.device.set_monitoring_frequency_duration(601)
 
     def test_set_device_off_duration(self):
         def device_off_duration():
             return self.device.status().device_off
 
-        self.device.set_device_off_duration(DeviceOffCGDN1.After15Minutes)
-        assert device_off_duration() == DeviceOffCGDN1.After15Minutes
+        self.device.set_device_off_duration(0)
+        assert device_off_duration() == 0
 
-        self.device.set_device_off_duration(DeviceOffCGDN1.After30Minutes)
-        assert device_off_duration() == DeviceOffCGDN1.After30Minutes
+        self.device.set_device_off_duration(29)
+        assert device_off_duration() == 29
 
-        self.device.set_device_off_duration(DeviceOffCGDN1.After1Hour)
-        assert device_off_duration() == DeviceOffCGDN1.After1Hour
+        self.device.set_device_off_duration(60)
+        assert device_off_duration() == 60
 
-        self.device.set_device_off_duration(DeviceOffCGDN1.Never)
-        assert device_off_duration() == DeviceOffCGDN1.Never
+        with pytest.raises(AirQualityMonitorMiotException):
+            self.device.set_device_off_duration(-1)
+
+        with pytest.raises(AirQualityMonitorMiotException):
+            self.device.set_device_off_duration(61)
 
     def test_set_screen_off_duration(self):
         def screen_off_duration():
             return self.device.status().screen_off
 
-        self.device.set_screen_off_duration(ScreenOffCGDN1.After15Seconds)
-        assert screen_off_duration() == ScreenOffCGDN1.After15Seconds
+        self.device.set_screen_off_duration(0)
+        assert screen_off_duration() == 0
 
-        self.device.set_screen_off_duration(ScreenOffCGDN1.After30Seconds)
-        assert screen_off_duration() == ScreenOffCGDN1.After30Seconds
+        self.device.set_screen_off_duration(140)
+        assert screen_off_duration() == 140
 
-        self.device.set_screen_off_duration(ScreenOffCGDN1.After1Minute)
-        assert screen_off_duration() == ScreenOffCGDN1.After1Minute
+        self.device.set_screen_off_duration(300)
+        assert screen_off_duration() == 300
 
-        self.device.set_screen_off_duration(ScreenOffCGDN1.After5Minutes)
-        assert screen_off_duration() == ScreenOffCGDN1.After5Minutes
+        with pytest.raises(AirQualityMonitorMiotException):
+            self.device.set_screen_off_duration(-1)
 
-        self.device.set_screen_off_duration(ScreenOffCGDN1.Never)
-        assert screen_off_duration() == ScreenOffCGDN1.Never
+        with pytest.raises(AirQualityMonitorMiotException):
+            self.device.set_screen_off_duration(301)
 
     def test_set_display_temerature_unit(self):
         def display_temerature_unit():

--- a/miio/tests/test_airqualitymonitor_miot.py
+++ b/miio/tests/test_airqualitymonitor_miot.py
@@ -1,0 +1,139 @@
+from unittest import TestCase
+
+import pytest
+
+from miio import AirQualityMonitorCGDN1
+from miio.airqualitymonitor_miot import (
+    ChargingStateCGDN1,
+    DeviceOffCGDN1,
+    DisplayTemeratureUnitCGDN1,
+    MonitoringFrequencyCGDN1,
+    ScreenOffCGDN1,
+)
+
+from .dummies import DummyMiotDevice
+
+_INITIAL_STATE = {
+    "humidity": 34,
+    "pm25": 10,
+    "pm10": 15,
+    "temperature": 18.599999,
+    "co2": 620,
+    "battery": 20,
+    "charging_state": 2,
+    "voltage": 26,
+    "start_time": 0,
+    "end_time": 0,
+    "monitoring_frequency": 1,
+    "screen_off": 15,
+    "device_off": 30,
+    "temperature_unit": "c",
+}
+
+
+class DummyAirQualityMonitorCGDN1(DummyMiotDevice, AirQualityMonitorCGDN1):
+    def __init__(self, *args, **kwargs):
+        self.state = _INITIAL_STATE
+        self.return_values = {
+            "get_prop": self._get_state,
+            "set_monitoring_frequency": lambda x: self._set_state(
+                "monitoring_frequency", x
+            ),
+            "set_device_off_duration": lambda x: self._set_state("device_off", x),
+            "set_screen_off_duration": lambda x: self._set_state("screen_off", x),
+            "set_display_temerature_unit": lambda x: self._set_state(
+                "temperature_unit", x
+            ),
+        }
+        super().__init__(*args, **kwargs)
+
+
+@pytest.fixture(scope="function")
+def airqualitymonitorcgdn1(request):
+    request.cls.device = DummyAirQualityMonitorCGDN1()
+
+
+@pytest.mark.usefixtures("airqualitymonitorcgdn1")
+class TestAirQualityMonitor(TestCase):
+    def test_status(self):
+        status = self.device.status()
+        assert status.humidity is _INITIAL_STATE["humidity"]
+        assert status.pm25 is _INITIAL_STATE["pm25"]
+        assert status.pm10 is _INITIAL_STATE["pm10"]
+        assert status.temperature is _INITIAL_STATE["temperature"]
+        assert status.co2 is _INITIAL_STATE["co2"]
+        assert status.battery is _INITIAL_STATE["battery"]
+        assert status.charging_state is ChargingStateCGDN1(
+            _INITIAL_STATE["charging_state"]
+        )
+        assert status.monitoring_frequency is MonitoringFrequencyCGDN1(
+            _INITIAL_STATE["monitoring_frequency"]
+        )
+        assert status.screen_off is ScreenOffCGDN1(_INITIAL_STATE["screen_off"])
+        assert status.display_temperature_unit is DisplayTemeratureUnitCGDN1(
+            _INITIAL_STATE["temperature_unit"]
+        )
+
+    def test_set_monitoring_frequency(self):
+        def monitoring_frequency():
+            return self.device.status().monitoring_frequency
+
+        self.device.set_monitoring_frequency(MonitoringFrequencyCGDN1.Every1Second)
+        assert monitoring_frequency() == MonitoringFrequencyCGDN1.Every1Second
+
+        self.device.set_monitoring_frequency(MonitoringFrequencyCGDN1.Every1Minute)
+        assert monitoring_frequency() == MonitoringFrequencyCGDN1.Every1Minute
+
+        self.device.set_monitoring_frequency(MonitoringFrequencyCGDN1.Every5Minutes)
+        assert monitoring_frequency() == MonitoringFrequencyCGDN1.Every5Minutes
+
+        self.device.set_monitoring_frequency(MonitoringFrequencyCGDN1.Every10Minutes)
+        assert monitoring_frequency() == MonitoringFrequencyCGDN1.Every10Minutes
+
+        self.device.set_monitoring_frequency(MonitoringFrequencyCGDN1.NotSet)
+        assert monitoring_frequency() == MonitoringFrequencyCGDN1.NotSet
+
+    def test_set_device_off_duration(self):
+        def device_off_duration():
+            return self.device.status().device_off
+
+        self.device.set_device_off_duration(DeviceOffCGDN1.After15Minutes)
+        assert device_off_duration() == DeviceOffCGDN1.After15Minutes
+
+        self.device.set_device_off_duration(DeviceOffCGDN1.After30Minutes)
+        assert device_off_duration() == DeviceOffCGDN1.After30Minutes
+
+        self.device.set_device_off_duration(DeviceOffCGDN1.After1Hour)
+        assert device_off_duration() == DeviceOffCGDN1.After1Hour
+
+        self.device.set_device_off_duration(DeviceOffCGDN1.Never)
+        assert device_off_duration() == DeviceOffCGDN1.Never
+
+    def test_set_screen_off_duration(self):
+        def screen_off_duration():
+            return self.device.status().screen_off
+
+        self.device.set_screen_off_duration(ScreenOffCGDN1.After15Seconds)
+        assert screen_off_duration() == ScreenOffCGDN1.After15Seconds
+
+        self.device.set_screen_off_duration(ScreenOffCGDN1.After30Seconds)
+        assert screen_off_duration() == ScreenOffCGDN1.After30Seconds
+
+        self.device.set_screen_off_duration(ScreenOffCGDN1.After1Minute)
+        assert screen_off_duration() == ScreenOffCGDN1.After1Minute
+
+        self.device.set_screen_off_duration(ScreenOffCGDN1.After5Minutes)
+        assert screen_off_duration() == ScreenOffCGDN1.After5Minutes
+
+        self.device.set_screen_off_duration(ScreenOffCGDN1.Never)
+        assert screen_off_duration() == ScreenOffCGDN1.Never
+
+    def test_set_display_temerature_unit(self):
+        def display_temerature_unit():
+            return self.device.status().display_temperature_unit
+
+        self.device.set_display_temerature_unit(DisplayTemeratureUnitCGDN1.Celcius)
+        assert display_temerature_unit() == DisplayTemeratureUnitCGDN1.Celcius
+
+        self.device.set_display_temerature_unit(DisplayTemeratureUnitCGDN1.Fahrenheit)
+        assert display_temerature_unit() == DisplayTemeratureUnitCGDN1.Fahrenheit


### PR DESCRIPTION
This PR adds support for Qingping Air Monitor Lite support (`cgllc.airm.cgdn1`).

Specification: https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:air-monitor:0000A008:cgllc-cgdn1:1

Closes: https://github.com/rytilahti/python-miio/issues/879

Support `start_time` and `end_time` has been intentionally omitted in this PR and can be added in the other one. I didn't check whether the time zone is necessary to compute the current time. If yes, I wasn't able to read `time_zone` from my device, but `cgllc-cgdn1:2` spec mentions that property. What's more Xiaomi Home reads somehow this property from the device.

Another thing is I had no idea what `0` regarding `monitoring_frequency` could mean.