### PR TITLE
Stopgap fix for miottemplate

### DIFF
--- a/devtools/containers.py
+++ b/devtools/containers.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import List
+from typing import Any, Dict, List, Optional
 
 from dataclasses_json import DataClassJsonMixin, config
 
@@ -35,15 +35,17 @@ class Property(DataClassJsonMixin):
     format: str
     access: List[str]
 
-    value_list: List = field(
+    value_list: Optional[List[Dict]] = field(
         default_factory=list, metadata=config(field_name="value-list")
     )
-    value_range: List = field(default=None, metadata=config(field_name="value-range"))
+    value_range: Optional[List[int]] = field(
+        default=None, metadata=config(field_name="value-range")
+    )
 
-    unit: str = None
+    unit: Optional[str] = None
 
     def __repr__(self):
-        return f"piid: {self.iid} ({self.description}): ({self.format}, unit: {self.unit}) (acc: {self.access}, value-list: {self.value_list}, value-range: {self.value_range})"
+        return f"piid: {self.iid} ({self.description}): ({self.format}, unit: {self.unit}) (acc: {self.access})"
 
     def __str__(self):
         return self.__repr__()
@@ -111,14 +113,11 @@ class Action(DataClassJsonMixin):
     iid: int
     type: str
     description: str
-    out: List = field(default_factory=list)
-    in_: List = field(default_factory=list, metadata=config(field_name="in"))
+    out: List[Any] = field(default_factory=list)
+    in_: List[Any] = field(default_factory=list, metadata=config(field_name="in"))
 
     def __repr__(self):
         return f"aiid {self.iid} {self.description}: in: {self.in_} -> out: {self.out}"
-
-    def __str__(self):
-        return self.__repr__()
 
     def pretty_name(self):
         return pretty_name(self.description)
@@ -136,13 +135,10 @@ class Event(DataClassJsonMixin):
     iid: int
     type: str
     description: str
-    arguments: List
+    arguments: List[int]
 
     def __repr__(self):
         return f"eiid {self.iid} ({self.description}): (args: {self.arguments})"
-
-    def __str__(self):
-        return self.__repr__()
 
 
 @dataclass
@@ -156,9 +152,6 @@ class Service(DataClassJsonMixin):
 
     def __repr__(self):
         return f"siid {self.iid}: ({self.description}): {len(self.properties)} props, {len(self.actions)} actions"
-
-    def __str__(self):
-        return self.__repr__()
 
     def as_code(self):
         s = ""

--- a/devtools/miottemplate.py
+++ b/devtools/miottemplate.py
@@ -21,6 +21,34 @@ class Generator:
     def __init__(self, data):
         self.data = data
 
+    def print_infos(self):
+        dev = Device.from_json(self.data)
+        click.echo(
+            f"Device '{dev.type}': {dev.description} with {len(dev.services)} services"
+        )
+        for serv in dev.services:
+            click.echo(f"\n* Service {serv}")
+
+            if serv.properties:
+                click.echo("\n\t## Properties ##")
+                for prop in serv.properties:
+                    click.echo(f"\t\tsiid {serv.iid}: {prop}")
+                    if prop.value_list:
+                        for value in prop.value_list:
+                            click.echo(f"\t\t\t{value}")
+                    if prop.value_range:
+                        click.echo(f"\t\t\tRange: {prop.value_range}")
+
+            if serv.actions:
+                click.echo("\n\t## Actions ##")
+                for act in serv.actions:
+                    click.echo(f"\t\tsiid {serv.iid}: {act}")
+
+            if serv.events:
+                click.echo("\n\t## Events ##")
+                for evt in serv.events:
+                    click.echo(f"\t\tsiid {serv.iid}: {evt}")
+
     def generate(self):
         dev = Device.from_json(self.data)
 
@@ -42,9 +70,22 @@ class Generator:
 @click.argument("file", type=click.File())
 def generate(file):
     """Generate pseudo-code python for given file."""
+    raise NotImplementedError(
+        "Disabled until miot support gets improved, please use print command instead"
+    )
     data = file.read()
     gen = Generator(data)
     print(gen.generate())
+
+
+@cli.command()
+@click.argument("file", type=click.File())
+def print(file):
+    """Print out device information (props, actions, events)."""
+    data = file.read()
+    gen = Generator(data)
+
+    gen.print_infos()
 
 
 @cli.command()


### PR DESCRIPTION
* Fix issue with bare Lists (fixes #885), this used to work in some previous dataclasses-json versions but not anymore. Also, make some fields optional.
* Disables code generation as it is not useful until miot support gets improved.
* Add print command to print out the information necessary to add support for new devices.