### PR TITLE
Allow downloading miot spec files by model for miottemplate

### DIFF
--- a/devtools/README.md
+++ b/devtools/README.md
@@ -6,6 +6,8 @@ This directory contains tooling useful for developers
 
 This tool generates some boilerplate code for adding support for MIoT devices
 
-1. Obtain device type from http://miot-spec.org/miot-spec-v2/instances?status=all
-2. Execute `python miottemplate.py download <type>` to download the description file.
-3. Execute `python miottemplate.py generate <file>` to generate pseudo-python for the device.
+1. If you know the model, use `python miottemplate.py download <model>` to download the description file.
+  * This will download the model<->urn mapping file from http://miot-spec.org/miot-spec-v2/instances?status=all and store it locally
+  * If you know the urn, you can use `--urn` to avoid downloading the mapping file (should not be necessary)
+
+2. `python miottemplate.py print <description file>.json` prints out the siid/piid/aiid information from the spec file

--- a/devtools/containers.py
+++ b/devtools/containers.py
@@ -28,6 +28,28 @@ def indent(data, level=4):
 
 
 @dataclass
+class InstanceInfo:
+    model: str
+    status: str
+    type: str
+    version: int
+
+
+@dataclass
+class ModelMapping(DataClassJsonMixin):
+    instances: List[InstanceInfo]
+
+    def urn_for_model(self, model: str):
+        matches = [inst.type for inst in self.instances if inst.model == model]
+        if len(matches) > 1:
+            print(
+                "WARNING more than a single match for model %s: %s" % (model, matches)
+            )
+
+        return matches[0]
+
+
+@dataclass
 class Property(DataClassJsonMixin):
     iid: int
     type: str


### PR DESCRIPTION
* Modify 'download' to use model instead of urn, urn can still be passed with --urn
* Downloads and caches 'model_miotspec_mapping.json', if not available
* Add 'list' to list all entries in the mapping file

Related to #901