### PR TITLE
Improve MiotDevice API (get_property_by, set_property_by, call_action, call_action_by)

### DIFF
--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -62,12 +62,13 @@ The connectivity will get restored by device's internal watchdog restarting the 
 Roborock Vacuum not detected
 ----------------------------
 
-It seems that a Roborock vacuum connected through the Roborock app (and not the Xiaomi Home app) won't allow control over local network, even with a valid token, leading to the following exception:
+It seems that a Roborock vacuum connected through the Roborock app (and not the Xiaomi Home app) won't allow control over local network,
+ even with a valid token, leading to the following exception:
 
 .. code-block:: text
 
     mirobo.device.DeviceException: Unable to discover the device x.x.x.x
-    
+
 Resetting the device's wifi and pairing it again with the Xiaomi Home app should solve the issue.
 
 .. hint::

--- a/miio/airconditioner_miot.py
+++ b/miio/airconditioner_miot.py
@@ -337,15 +337,7 @@ class AirConditionerMiotStatus:
 class AirConditionerMiot(MiotDevice):
     """Main class representing the air conditioner which uses MIoT protocol."""
 
-    def __init__(
-        self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-    ) -> None:
-        super().__init__(_MAPPING, ip, token, start_id, debug, lazy_discover)
+    mapping = _MAPPING
 
     @command(
         default_output=format_output(

--- a/miio/airhumidifier_miot.py
+++ b/miio/airhumidifier_miot.py
@@ -277,15 +277,7 @@ class AirHumidifierMiotStatus:
 class AirHumidifierMiot(MiotDevice):
     """Main class representing the air humidifier which uses MIoT protocol."""
 
-    def __init__(
-        self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-    ) -> None:
-        super().__init__(_MAPPING, ip, token, start_id, debug, lazy_discover)
+    mapping = _MAPPING
 
     @command(
         default_output=format_output(

--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -437,15 +437,7 @@ class BasicAirPurifierMiot(MiotDevice):
 class AirPurifierMiot(BasicAirPurifierMiot):
     """Main class representing the air purifier which uses MIoT protocol."""
 
-    def __init__(
-        self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-    ) -> None:
-        super().__init__(_MAPPING, ip, token, start_id, debug, lazy_discover)
+    mapping = _MAPPING
 
     @command(
         default_output=format_output(

--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -533,17 +533,7 @@ class AirPurifierMiot(BasicAirPurifierMiot):
 class AirPurifierMB4(BasicAirPurifierMiot):
     """Main class representing the air purifier which uses MIoT protocol."""
 
-    def __init__(
-        self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-    ) -> None:
-        super().__init__(
-            _MODEL_AIRPURIFIER_MB4, ip, token, start_id, debug, lazy_discover
-        )
+    mapping = _MODEL_AIRPURIFIER_MB4
 
     @command(
         default_output=format_output(

--- a/miio/airqualitymonitor_miot.py
+++ b/miio/airqualitymonitor_miot.py
@@ -198,15 +198,7 @@ class AirQualityMonitorCGDN1Status:
 class AirQualityMonitorCGDN1(MiotDevice):
     """Qingping Air Monitor Lite."""
 
-    def __init__(
-        self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-    ) -> None:
-        super().__init__(_MAPPING_CGDN1, ip, token, start_id, debug, lazy_discover)
+    mapping = _MAPPING_CGDN1
 
     @command(
         default_output=format_output(

--- a/miio/curtain_youpin.py
+++ b/miio/curtain_youpin.py
@@ -138,15 +138,7 @@ class CurtainStatus:
 class CurtainMiot(MiotDevice):
     """Main class representing the lumi.curtain.hagl05 curtain."""
 
-    def __init__(
-        self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-    ) -> None:
-        super().__init__(_MAPPING, ip, token, start_id, debug, lazy_discover)
+    mapping = _MAPPING
 
     @command(
         default_output=format_output(

--- a/miio/fan_miot.py
+++ b/miio/fan_miot.py
@@ -167,6 +167,8 @@ class FanStatusMiot:
 
 
 class FanMiot(MiotDevice):
+    mapping = MIOT_MAPPING[MODEL_FAN_P10]
+
     def __init__(
         self,
         ip: str = None,
@@ -179,9 +181,9 @@ class FanMiot(MiotDevice):
         if model not in MIOT_MAPPING:
             raise FanException("Invalid FanMiot model: %s" % model)
 
+        super().__init__(ip, token, start_id, debug, lazy_discover)
         self.model = model
 
-        super().__init__(MIOT_MAPPING[model], ip, token, start_id, debug, lazy_discover)
 
     @command(
         default_output=format_output(
@@ -320,36 +322,12 @@ class FanMiot(MiotDevice):
 
 
 class FanP9(FanMiot):
-    def __init__(
-        self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-    ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover, model=MODEL_FAN_P9)
+    mapping = MIOT_MAPPING[MODEL_FAN_P9]
 
 
 class FanP10(FanMiot):
-    def __init__(
-        self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-    ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover, model=MODEL_FAN_P10)
+    mapping = MIOT_MAPPING[MODEL_FAN_P10]
 
 
 class FanP11(FanMiot):
-    def __init__(
-        self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-    ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover, model=MODEL_FAN_P11)
+    mapping = MIOT_MAPPING[MODEL_FAN_P11]

--- a/miio/fan_miot.py
+++ b/miio/fan_miot.py
@@ -184,7 +184,6 @@ class FanMiot(MiotDevice):
         super().__init__(ip, token, start_id, debug, lazy_discover)
         self.model = model
 
-
     @command(
         default_output=format_output(
             "",

--- a/miio/heater_miot.py
+++ b/miio/heater_miot.py
@@ -125,15 +125,7 @@ class HeaterMiotStatus:
 class HeaterMiot(MiotDevice):
     """Main class representing the Xiaomi Smart Space Heater S (zhimi.heater.mc2)."""
 
-    def __init__(
-        self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-    ) -> None:
-        super().__init__(_MAPPING, ip, token, start_id, debug, lazy_discover)
+    mapping = _MAPPING
 
     @command(
         default_output=format_output(

--- a/miio/huizuo.py
+++ b/miio/huizuo.py
@@ -233,6 +233,8 @@ class Huizuo(MiotDevice):
     If your device does't support some properties, the 'None' will be returned
     """
 
+    mapping = _MAPPING
+
     def __init__(
         self,
         ip: str = None,
@@ -244,15 +246,15 @@ class Huizuo(MiotDevice):
     ) -> None:
 
         if model in MODELS_WITH_FAN_WY:
-            _MAPPING.update(_ADDITIONAL_MAPPING_FAN_WY)
+            self.mapping.update(_ADDITIONAL_MAPPING_FAN_WY)
         if model in MODELS_WITH_FAN_WY2:
-            _MAPPING.update(_ADDITIONAL_MAPPING_FAN_WY2)
+            self.mapping.update(_ADDITIONAL_MAPPING_FAN_WY2)
         if model in MODELS_WITH_SCENES:
-            _MAPPING.update(_ADDITIONAL_MAPPING_SCENE)
+            self.mapping.update(_ADDITIONAL_MAPPING_SCENE)
         if model in MODELS_WITH_HEATER:
-            _MAPPING.update(_ADDITIONAL_MAPPING_HEATER)
+            self.mapping.update(_ADDITIONAL_MAPPING_HEATER)
 
-        super().__init__(_MAPPING, ip, token, start_id, debug, lazy_discover)
+        super().__init__(ip, token, start_id, debug, lazy_discover)
 
         if model in MODELS_SUPPORTED:
             self.model = model

--- a/miio/miot_device.py
+++ b/miio/miot_device.py
@@ -1,24 +1,26 @@
 import logging
+from enum import Enum
+from typing import Any, Union
 
+import click
+
+from .click_common import EnumType, command
 from .device import Device
 
 _LOGGER = logging.getLogger(__name__)
 
 
+class MiotValueType(Enum):
+    Int = int
+    Float = float
+    Bool = bool
+    Str = str
+
+
 class MiotDevice(Device):
     """Main class representing a MIoT device."""
 
-    def __init__(
-        self,
-        mapping: dict,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-    ) -> None:
-        self.mapping = mapping
-        super().__init__(ip, token, start_id, debug, lazy_discover)
+    mapping = None
 
     def get_properties_for_mapping(self) -> list:
         """Retrieve raw properties based on mapping."""
@@ -30,9 +32,46 @@ class MiotDevice(Device):
             properties, property_getter="get_properties", max_properties=15
         )
 
-    def set_property(self, property_key: str, value):
-        """Sets property value."""
+    @command(
+        click.argument("siid", type=int),
+        click.argument("piid", type=int),
+    )
+    def get_property_by(self, siid: int, piid: int):
+        """Get a single property (siid/piid)."""
+        return self.send(
+            "get_properties", [{"did": f"{siid}-{piid}", "siid": siid, "piid": piid}]
+        )
 
+    @command(
+        click.argument("siid", type=int),
+        click.argument("piid", type=int),
+        click.argument("value"),
+        click.argument(
+            "value_type", type=EnumType(MiotValueType), required=False, default=None
+        ),
+    )
+    def set_property_by(
+        self,
+        siid: int,
+        piid: int,
+        value: Union[int, float, str, bool],
+        value_type: Any = None,
+    ):
+        """Set a single property (siid/piid) to given value.
+
+        value_type can be given to convert the value to wanted type,
+        allowed types are: int, float, bool, str
+        """
+        if value_type is not None:
+            value = value_type.value(value)
+
+        return self.send(
+            "set_properties",
+            [{"did": f"set-{siid}-{piid}", "siid": siid, "piid": piid, "value": value}],
+        )
+
+    def set_property(self, property_key: str, value):
+        """Sets property value using the existing mapping."""
         return self.send(
             "set_properties",
             [{"did": property_key, **self.mapping[property_key], "value": value}],

--- a/miio/miot_device.py
+++ b/miio/miot_device.py
@@ -99,8 +99,8 @@ class MiotDevice(Device):
     ):
         """Set a single property (siid/piid) to given value.
 
-        value_type can be given to convert the value to wanted type,
-        allowed types are: int, float, bool, str
+        value_type can be given to convert the value to wanted type, allowed types are:
+        int, float, bool, str
         """
         if value_type is not None:
             value = value_type.value(value)

--- a/miio/tests/test_miotdevice.py
+++ b/miio/tests/test_miotdevice.py
@@ -1,0 +1,73 @@
+import pytest
+
+from miio import MiotDevice
+from miio.miot_device import MiotValueType
+
+
+@pytest.fixture(scope="module")
+def dev(module_mocker):
+    device = MiotDevice("127.0.0.1", "68ffffffffffffffffffffffffffffff")
+    module_mocker.patch.object(device, "send")
+    return device
+
+
+def test_get_property_by(dev):
+    siid = 1
+    piid = 2
+    _ = dev.get_property_by(siid, piid)
+
+    dev.send.assert_called_with(
+        "get_properties", [{"did": f"{siid}-{piid}", "siid": siid, "piid": piid}]
+    )
+
+
+@pytest.mark.parametrize(
+    "value_type,value",
+    [
+        (None, 1),
+        (MiotValueType.Int, "1"),
+        (MiotValueType.Float, "1.2"),
+        (MiotValueType.Str, "str"),
+        (MiotValueType.Bool, "1"),
+    ],
+)
+def test_set_property_by(dev, value_type, value):
+    siid = 1
+    piid = 1
+    _ = dev.set_property_by(siid, piid, value, value_type)
+
+    if value_type is not None:
+        value = value_type.value(value)
+
+    dev.send.assert_called_with(
+        "set_properties",
+        [{"did": f"set-{siid}-{piid}", "siid": siid, "piid": piid, "value": value}],
+    )
+
+
+def test_call_action_by(dev):
+    siid = 1
+    aiid = 1
+
+    _ = dev.call_action_by(siid, aiid)
+    dev.send.assert_called_with(
+        "action",
+        {
+            "did": f"call-{siid}-{aiid}",
+            "siid": siid,
+            "aiid": aiid,
+            "in": [],
+        },
+    )
+
+    params = {"test_param": 1}
+    _ = dev.call_action_by(siid, aiid, params)
+    dev.send.assert_called_with(
+        "action",
+        {
+            "did": f"call-{siid}-{aiid}",
+            "siid": siid,
+            "aiid": aiid,
+            "in": params,
+        },
+    )

--- a/miio/tests/test_vacuum.py
+++ b/miio/tests/test_vacuum.py
@@ -46,9 +46,11 @@ class DummyVacuum(DummyDevice, Vacuum):
             "app_goto_target": lambda x: self.change_mode("goto"),
             "app_zoned_clean": lambda x: self.change_mode("zoned clean"),
             "app_charge": lambda x: self.change_mode("charge"),
+            "miIO.info": "dummy info",
         }
 
         super().__init__(args, kwargs)
+        self.model = None
 
     def change_mode(self, new_mode):
         if new_mode == "spot":

--- a/miio/yeelight_dual_switch.py
+++ b/miio/yeelight_dual_switch.py
@@ -133,15 +133,7 @@ class YeelightDualControlModule(MiotDevice):
     """Main class representing the Yeelight Dual Control Module (yeelink.switch.sw1)
     which uses MIoT protocol."""
 
-    def __init__(
-        self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-    ) -> None:
-        super().__init__(_MAPPING, ip, token, start_id, debug, lazy_discover)
+    mapping = _MAPPING
 
     @command(
         default_output=format_output(


### PR DESCRIPTION
* `get_property_by(siid, piid)` returns a single property, useful for testing with miiocli
* `set_property_by(siid, piid, value, value_type)` allows setting one, `value_type` is optional and will be used for casting to correct type before passing the value to `send()`.
* `call_action(name, params)` calls an action with the given parameters, anything inside `mapping` that has `aiid` is considered an action.
* `call_action_by(siid, aiid, params)` allows calling arbitrary actions, useful especially for command-line use and testing.

* Also, code cleanup for passing the mapping.
* Now the mapping is a class attribute, avoiding unnecessary __init__ overloading

Testers wanted as I have no test devices!

Related to #901 (no more raw-commands necessary for the simplest test cases).