### PR TITLE
[miot air purifier] Return None if aqi is 1

### DIFF
--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -84,7 +84,7 @@ class AirPurifierMiotStatus:
     @property
     def aqi(self) -> int:
         """Air quality index."""
-        # zhimi-airpurifier-mb3 returns 1 as AQI value if the measurement was 
+        # zhimi-airpurifier-mb3 returns 1 as AQI value if the measurement was
         # unsuccessful
         if self.data["aqi"] == 1:
             return None

--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -84,6 +84,8 @@ class AirPurifierMiotStatus:
     @property
     def aqi(self) -> int:
         """Air quality index."""
+        # zhimi-airpurifier-mb3 returns 1 as AQI value if the measurement was 
+        # unsuccessful
         if self.data["aqi"] == 1:
             return None
         return self.data["aqi"]

--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -84,6 +84,8 @@ class AirPurifierMiotStatus:
     @property
     def aqi(self) -> int:
         """Air quality index."""
+        if self.data["aqi"] == 1:
+            return None
         return self.data["aqi"]
 
     @property


### PR DESCRIPTION
Probably the air purifier sends a `1` for `aqi` when the measurement failed.
With change from this PR, library returns `None` as `aqi` value in such situation.

Fixes: https://github.com/rytilahti/python-miio/issues/925