### PR TITLE
Cleanup: add DeviceStatus to simplify status containers

### DIFF
--- a/miio/__init__.py
+++ b/miio/__init__.py
@@ -31,7 +31,7 @@ from miio.chuangmi_ir import ChuangmiIr
 from miio.chuangmi_plug import ChuangmiPlug, Plug, PlugV1, PlugV3
 from miio.cooker import Cooker
 from miio.curtain_youpin import CurtainMiot
-from miio.device import Device
+from miio.device import Device, DeviceStatus
 from miio.dreamevacuum_miot import DreameVacuumMiot
 from miio.exceptions import DeviceError, DeviceException
 from miio.fan import Fan, FanP5, FanSA1, FanV2, FanZA1, FanZA4

--- a/miio/airconditioner_miot.py
+++ b/miio/airconditioner_miot.py
@@ -7,7 +7,7 @@ import click
 
 from .click_common import EnumType, command, format_output
 from .exceptions import DeviceException
-from .miot_device import MiotDevice
+from .miot_device import DeviceStatus, MiotDevice
 
 _LOGGER = logging.getLogger(__name__)
 _MAPPING = {
@@ -52,7 +52,7 @@ class AirConditionerMiotException(DeviceException):
     pass
 
 
-class CleaningStatus:
+class CleaningStatus(DeviceStatus):
     def __init__(self, status: str):
         """Auto clean mode indicator.
 
@@ -92,16 +92,6 @@ class CleaningStatus:
     def cancellable(self) -> bool:
         return bool(self.status[3])
 
-    def __repr__(self) -> str:
-        s = (
-            "<CleaningStage cleaning=%s, "
-            "progress=%s, "
-            "stage=%s, "
-            "cancellable=%s>"
-            % (self.cleaning, self.progress, self.stage, self.cancellable)
-        )
-        return s
-
 
 class OperationMode(enum.Enum):
     Cool = 2
@@ -121,7 +111,7 @@ class FanSpeed(enum.Enum):
     Level7 = 7
 
 
-class TimerStatus:
+class TimerStatus(DeviceStatus):
     def __init__(self, status):
         """Countdown timer indicator.
 
@@ -159,18 +149,8 @@ class TimerStatus:
     def time_left(self) -> timedelta:
         return timedelta(minutes=self.status[3])
 
-    def __repr__(self) -> str:
-        s = (
-            "<TimerStatus enabled=%s, "
-            "countdown=%s, "
-            "power_on=%s, "
-            "time_left=%s>"
-            % (self.enabled, self.countdown, self.power_on, self.time_left)
-        )
-        return s
 
-
-class AirConditionerMiotStatus:
+class AirConditionerMiotStatus(DeviceStatus):
     """Container for status reports from the air conditioner (MIoT)."""
 
     def __init__(self, data: Dict[str, Any]) -> None:
@@ -288,50 +268,6 @@ class AirConditionerMiotStatus:
     def timer(self) -> TimerStatus:
         """Countdown timer indicator."""
         return TimerStatus(self.data["timer"])
-
-    def __repr__(self) -> str:
-        s = (
-            "<AirConditionerMiotStatus power=%s, "
-            "mode=%s, "
-            "target_temperature=%s, "
-            "eco=%s, "
-            "heater=%s, "
-            "dryer=%s, "
-            "sleep_mode=%s, "
-            "fan_speed=%s, "
-            "vertical_swing=%s, "
-            "temperature=%s, "
-            "buzzer=%s, "
-            "led=%s"
-            "electricity=%s"
-            "clean=%s"
-            "total_running_duration=%s"
-            "fan_speed_percent=%s"
-            "timer=%s"
-            % (
-                self.power,
-                self.mode,
-                self.target_temperature,
-                self.eco,
-                self.heater,
-                self.dryer,
-                self.sleep_mode,
-                self.fan_speed,
-                self.vertical_swing,
-                self.temperature,
-                self.buzzer,
-                self.led,
-                self.electricity,
-                self.clean,
-                self.total_running_duration,
-                self.fan_speed_percent,
-                self.timer,
-            )
-        )
-        return s
-
-    def __json__(self):
-        return self.data
 
 
 class AirConditionerMiot(MiotDevice):

--- a/miio/airconditioningcompanion.py
+++ b/miio/airconditioningcompanion.py
@@ -5,7 +5,7 @@ from typing import Optional
 import click
 
 from .click_common import EnumType, command, format_output
-from .device import Device
+from .device import Device, DeviceStatus
 from .exceptions import DeviceException
 
 _LOGGER = logging.getLogger(__name__)
@@ -77,7 +77,7 @@ DEVICE_COMMAND_TEMPLATES = {
 }
 
 
-class AirConditioningCompanionStatus:
+class AirConditioningCompanionStatus(DeviceStatus):
     """Container for status reports of the Xiaomi AC Companion."""
 
     def __init__(self, data):
@@ -222,44 +222,6 @@ class AirConditioningCompanionStatus:
             return OperationMode(mode)
         except TypeError:
             return None
-
-    def __repr__(self) -> str:
-        s = (
-            "<AirConditioningCompanionStatus "
-            "power=%s, "
-            "power_socket=%s, "
-            "load_power=%s, "
-            "air_condition_model=%s, "
-            "model_format=%s, "
-            "device_type=%s, "
-            "air_condition_brand=%s, "
-            "air_condition_remote=%s, "
-            "state_format=%s, "
-            "air_condition_configuration=%s, "
-            "led=%s, "
-            "target_temperature=%s, "
-            "swing_mode=%s, "
-            "fan_speed=%s, "
-            "mode=%s>"
-            % (
-                self.power,
-                self.power_socket,
-                self.load_power,
-                self.air_condition_model.hex(),
-                self.model_format,
-                self.device_type,
-                self.air_condition_brand,
-                self.air_condition_remote,
-                self.state_format,
-                self.air_condition_configuration,
-                self.led,
-                self.target_temperature,
-                self.swing_mode,
-                self.fan_speed,
-                self.mode,
-            )
-        )
-        return s
 
 
 class AirConditioningCompanion(Device):

--- a/miio/airconditioningcompanionMCN.py
+++ b/miio/airconditioningcompanionMCN.py
@@ -4,7 +4,7 @@ import random
 from typing import Any, Optional
 
 from .click_common import command, format_output
-from .device import Device
+from .device import Device, DeviceStatus
 from .exceptions import DeviceException
 
 _LOGGER = logging.getLogger(__name__)
@@ -36,7 +36,7 @@ class SwingMode(enum.Enum):
     Off = "off"
 
 
-class AirConditioningCompanionStatus:
+class AirConditioningCompanionStatus(DeviceStatus):
     """Container for status reports of the Xiaomi AC Companion."""
 
     def __init__(self, data):
@@ -97,26 +97,6 @@ class AirConditioningCompanionStatus:
             return SwingMode(mode)
         except TypeError:
             return None
-
-    def __repr__(self) -> str:
-        s = (
-            "<AirConditioningCompanionStatus "
-            "power=%s, "
-            "load_power=%s, "
-            "target_temperature=%s, "
-            "swing_mode=%s, "
-            "fan_speed=%s, "
-            "mode=%s>"
-            % (
-                self.power,
-                self.load_power,
-                self.target_temperature,
-                self.swing_mode,
-                self.fan_speed,
-                self.mode,
-            )
-        )
-        return s
 
 
 class AirConditioningCompanionMcn02(Device):

--- a/miio/airdehumidifier.py
+++ b/miio/airdehumidifier.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional
 import click
 
 from .click_common import EnumType, command, format_output
-from .device import Device, DeviceInfo
+from .device import Device, DeviceInfo, DeviceStatus
 from .exceptions import DeviceError, DeviceException
 
 _LOGGER = logging.getLogger(__name__)
@@ -51,7 +51,7 @@ class FanSpeed(enum.Enum):
     Strong = 4
 
 
-class AirDehumidifierStatus:
+class AirDehumidifierStatus(DeviceStatus):
     """Container for status reports from the air dehumidifier."""
 
     def __init__(self, data: Dict[str, Any], device_info: DeviceInfo) -> None:
@@ -153,41 +153,6 @@ class AirDehumidifierStatus:
     def alarm(self) -> str:
         """Alarm."""
         return self.data["alarm"]
-
-    def __repr__(self) -> str:
-        s = (
-            "<AirDehumidiferStatus power=%s, "
-            "mode=%s, "
-            "temperature=%s, "
-            "humidity=%s%%, "
-            "buzzer=%s, "
-            "led=%s, "
-            "child_lock=%s, "
-            "target_humidity=%s%%, "
-            "fan_speed=%s, "
-            "tank_full=%s, "
-            "compressor_status=%s, "
-            "defrost_status=%s, "
-            "fan_st=%s, "
-            "alarm=%s, "
-            % (
-                self.power,
-                self.mode,
-                self.temperature,
-                self.humidity,
-                self.buzzer,
-                self.led,
-                self.child_lock,
-                self.target_humidity,
-                self.fan_speed,
-                self.tank_full,
-                self.compressor_status,
-                self.defrost_status,
-                self.fan_st,
-                self.alarm,
-            )
-        )
-        return s
 
 
 class AirDehumidifier(Device):

--- a/miio/airfresh.py
+++ b/miio/airfresh.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional
 import click
 
 from .click_common import EnumType, command, format_output
-from .device import Device
+from .device import Device, DeviceStatus
 from .exceptions import DeviceException
 
 _LOGGER = logging.getLogger(__name__)
@@ -62,7 +62,7 @@ class LedBrightness(enum.Enum):
     Off = 2
 
 
-class AirFreshStatus:
+class AirFreshStatus(DeviceStatus):
     """Container for status reports from the air fresh."""
 
     def __init__(self, data: Dict[str, Any], model: str) -> None:
@@ -213,49 +213,6 @@ class AirFreshStatus:
     @property
     def extra_features(self) -> Optional[int]:
         return self.data["app_extra"]
-
-    def __repr__(self) -> str:
-        s = (
-            "<AirFreshStatus power=%s, "
-            "ptc=%s, "
-            "aqi=%s, "
-            "average_aqi=%s, "
-            "temperature=%s, "
-            "ntc_temperature=%s, "
-            "humidity=%s%%, "
-            "co2=%s, "
-            "mode=%s, "
-            "led=%s, "
-            "led_brightness=%s, "
-            "buzzer=%s, "
-            "child_lock=%s, "
-            "filter_life_remaining=%s, "
-            "filter_hours_used=%s, "
-            "use_time=%s, "
-            "motor_speed=%s, "
-            "extra_features=%s>"
-            % (
-                self.power,
-                self.ptc,
-                self.aqi,
-                self.average_aqi,
-                self.temperature,
-                self.ntc_temperature,
-                self.humidity,
-                self.co2,
-                self.mode,
-                self.led,
-                self.led_brightness,
-                self.buzzer,
-                self.child_lock,
-                self.filter_life_remaining,
-                self.filter_hours_used,
-                self.use_time,
-                self.motor_speed,
-                self.extra_features,
-            )
-        )
-        return s
 
 
 class AirFresh(Device):

--- a/miio/airfresh_t2017.py
+++ b/miio/airfresh_t2017.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional
 import click
 
 from .click_common import EnumType, command, format_output
-from .device import Device
+from .device import Device, DeviceStatus
 from .exceptions import DeviceException
 
 _LOGGER = logging.getLogger(__name__)
@@ -70,7 +70,7 @@ class DisplayOrientation(enum.Enum):
     LandscapeRight = "right"
 
 
-class AirFreshStatus:
+class AirFreshStatus(DeviceStatus):
     """Container for status reports from the air fresh t2017."""
 
     def __init__(self, data: Dict[str, Any]) -> None:
@@ -219,49 +219,6 @@ class AirFreshStatus:
             return DisplayOrientation(self.data["screen_direction"])
         except (KeyError, ValueError):
             return None
-
-    def __repr__(self) -> str:
-        s = (
-            "<AirFreshStatus power=%s, "
-            "mode=%s, "
-            "pm25=%s, "
-            "co2=%s, "
-            "temperature=%s °C, "
-            "favorite_speed=%s, "
-            "control_speed=%s, "
-            "dust_filter_life_remaining=%s, "
-            "dust_filter_life_remaining_days=%s, "
-            "upper_filter_life_remaining=%s, "
-            "upper_filter_life_remaining_days=%s, "
-            "ptc=%s, "
-            "ptc_level=%s, "
-            "ptc_status=%s, "
-            "child_lock=%s, "
-            "buzzer=%s, "
-            "display=%s, "
-            "display_orientation=%s>"
-            % (
-                self.power,
-                self.mode,
-                self.pm25,
-                self.co2,
-                self.temperature,
-                self.favorite_speed,
-                self.control_speed,
-                self.dust_filter_life_remaining,
-                self.dust_filter_life_remaining_days,
-                self.upper_filter_life_remaining,
-                self.upper_filter_life_remaining_days,
-                self.ptc,
-                self.ptc_level,
-                self.ptc_status,
-                self.child_lock,
-                self.buzzer,
-                self.display,
-                self.display_orientation,
-            )
-        )
-        return s
 
 
 class AirFreshA1(Device):

--- a/miio/airhumidifier.py
+++ b/miio/airhumidifier.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional
 import click
 
 from .click_common import EnumType, command, format_output
-from .device import Device, DeviceInfo
+from .device import Device, DeviceInfo, DeviceStatus
 from .exceptions import DeviceError, DeviceException
 
 _LOGGER = logging.getLogger(__name__)
@@ -58,7 +58,7 @@ class LedBrightness(enum.Enum):
     Off = 2
 
 
-class AirHumidifierStatus:
+class AirHumidifierStatus(DeviceStatus):
     """Container for status reports from the air humidifier."""
 
     def __init__(self, data: Dict[str, Any], device_info: DeviceInfo) -> None:
@@ -219,49 +219,6 @@ class AirHumidifierStatus:
         if "button_pressed" in self.data and self.data["button_pressed"] is not None:
             return self.data["button_pressed"]
         return None
-
-    def __repr__(self) -> str:
-        s = (
-            "<AirHumidiferStatus power=%s, "
-            "mode=%s, "
-            "temperature=%s, "
-            "humidity=%s%%, "
-            "led_brightness=%s, "
-            "buzzer=%s, "
-            "child_lock=%s, "
-            "target_humidity=%s%%, "
-            "trans_level=%s, "
-            "motor_speed=%s, "
-            "depth=%s, "
-            "dry=%s, "
-            "use_time=%s, "
-            "hardware_version=%s, "
-            "button_pressed=%s, "
-            "strong_mode_enabled=%s, "
-            "firmware_version_major=%s, "
-            "firmware_version_minor=%s>"
-            % (
-                self.power,
-                self.mode,
-                self.temperature,
-                self.humidity,
-                self.led_brightness,
-                self.buzzer,
-                self.child_lock,
-                self.target_humidity,
-                self.trans_level,
-                self.motor_speed,
-                self.depth,
-                self.dry,
-                self.use_time,
-                self.hardware_version,
-                self.button_pressed,
-                self.strong_mode_enabled,
-                self.firmware_version_major,
-                self.firmware_version_minor,
-            )
-        )
-        return s
 
 
 class AirHumidifier(Device):

--- a/miio/airhumidifier_jsq.py
+++ b/miio/airhumidifier_jsq.py
@@ -6,7 +6,7 @@ import click
 
 from .airhumidifier import AirHumidifierException
 from .click_common import EnumType, command, format_output
-from .device import Device
+from .device import Device, DeviceStatus
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,7 +43,7 @@ class LedBrightness(enum.Enum):
     High = 2
 
 
-class AirHumidifierStatus:
+class AirHumidifierStatus(DeviceStatus):
     """Container for status reports from the air humidifier jsq."""
 
     def __init__(self, data: Dict[str, Any]) -> None:
@@ -128,31 +128,6 @@ class AirHumidifierStatus:
     def lid_opened(self) -> bool:
         """True if the water tank is detached."""
         return self.data["lid_opened"] == 1
-
-    def __repr__(self) -> str:
-        s = (
-            "<AirHumidiferStatus power=%s, "
-            "mode=%s, "
-            "temperature=%s, "
-            "humidity=%s%%, "
-            "led_brightness=%s, "
-            "buzzer=%s, "
-            "child_lock=%s, "
-            "no_water=%s, "
-            "lid_opened=%s>"
-            % (
-                self.power,
-                self.mode,
-                self.temperature,
-                self.humidity,
-                self.led_brightness,
-                self.buzzer,
-                self.child_lock,
-                self.no_water,
-                self.lid_opened,
-            )
-        )
-        return s
 
 
 class AirHumidifierJsq(Device):

--- a/miio/airhumidifier_miot.py
+++ b/miio/airhumidifier_miot.py
@@ -6,7 +6,7 @@ import click
 
 from .click_common import EnumType, command, format_output
 from .exceptions import DeviceException
-from .miot_device import MiotDevice
+from .miot_device import DeviceStatus, MiotDevice
 
 _LOGGER = logging.getLogger(__name__)
 _MAPPING = {
@@ -61,7 +61,7 @@ class PressedButton(enum.Enum):
     Power = 2
 
 
-class AirHumidifierMiotStatus:
+class AirHumidifierMiotStatus(DeviceStatus):
     """Container for status reports from the air humidifier.
 
     Xiaomi Smartmi Evaporation Air Humidifier 2 (zhimi.humidifier.ca4) respone (MIoT format)
@@ -228,50 +228,6 @@ class AirHumidifierMiotStatus:
     def clean_mode(self) -> bool:
         """Return True if clean mode is active."""
         return self.data["clean_mode"]
-
-    def __repr__(self) -> str:
-        s = (
-            "<AirHumidifierMiotStatus"
-            "power=%s, "
-            "error=%s, "
-            "mode=%s, "
-            "target_humidity=%s, "
-            "water_level=%s, "
-            "dry=%s, "
-            "use_time=%s, "
-            "button_pressed=%s, "
-            "motor_speed=%s, "
-            "temperature=%s, "
-            "fahrenheit=%s, "
-            "humidity=%s, "
-            "buzzer=%s, "
-            "led_brightness=%s, "
-            "child_lock=%s, "
-            "actual_speed=%s, "
-            "power_time=%s, "
-            "clean_mode=%s>"
-            % (
-                self.power,
-                self.error,
-                self.mode,
-                self.target_humidity,
-                self.water_level,
-                self.dry,
-                self.use_time,
-                self.button_pressed,
-                self.motor_speed,
-                self.temperature,
-                self.fahrenheit,
-                self.humidity,
-                self.buzzer,
-                self.led_brightness,
-                self.child_lock,
-                self.actual_speed,
-                self.power_time,
-                self.clean_mode,
-            )
-        )
-        return s
 
 
 class AirHumidifierMiot(MiotDevice):

--- a/miio/airhumidifier_mjjsq.py
+++ b/miio/airhumidifier_mjjsq.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional
 import click
 
 from .click_common import EnumType, command, format_output
-from .device import Device
+from .device import Device, DeviceStatus
 from .exceptions import DeviceException
 
 _LOGGER = logging.getLogger(__name__)
@@ -45,7 +45,7 @@ class OperationMode(enum.Enum):
     Humidity = 4
 
 
-class AirHumidifierStatus:
+class AirHumidifierStatus(DeviceStatus):
     """Container for status reports from the air humidifier mjjsq."""
 
     def __init__(self, data: Dict[str, Any]) -> None:
@@ -118,33 +118,6 @@ class AirHumidifierStatus:
             return self.data["wet_and_protect"] == 1
 
         return None
-
-    def __repr__(self) -> str:
-        s = (
-            "<AirHumidiferStatus power=%s, "
-            "mode=%s, "
-            "temperature=%s, "
-            "humidity=%s%%, "
-            "led_brightness=%s, "
-            "buzzer=%s, "
-            "target_humidity=%s%%, "
-            "no_water=%s, "
-            "water_tank_detached=%s,"
-            "wet_protection=%s>"
-            % (
-                self.power,
-                self.mode,
-                self.temperature,
-                self.humidity,
-                self.led,
-                self.buzzer,
-                self.target_humidity,
-                self.no_water,
-                self.water_tank_detached,
-                self.wet_protection,
-            )
-        )
-        return s
 
 
 class AirHumidifierMjjsq(Device):

--- a/miio/airpurifier.py
+++ b/miio/airpurifier.py
@@ -7,7 +7,7 @@ import click
 
 from .airfilter_util import FilterType, FilterTypeUtil
 from .click_common import EnumType, command, format_output
-from .device import Device
+from .device import Device, DeviceStatus
 from .exceptions import DeviceException
 
 _LOGGER = logging.getLogger(__name__)
@@ -42,7 +42,7 @@ class LedBrightness(enum.Enum):
     Off = 2
 
 
-class AirPurifierStatus:
+class AirPurifierStatus(DeviceStatus):
     """Container for status reports from the air purifier."""
 
     _filter_type_cache = {}
@@ -295,73 +295,6 @@ class AirPurifierStatus:
     def button_pressed(self) -> Optional[str]:
         """Last pressed button."""
         return self.data["button_pressed"]
-
-    def __repr__(self) -> str:
-        s = (
-            "<AirPurifierStatus power=%s, "
-            "aqi=%s, "
-            "average_aqi=%s, "
-            "temperature=%s, "
-            "humidity=%s%%, "
-            "mode=%s, "
-            "led=%s, "
-            "led_brightness=%s, "
-            "illuminance=%s, "
-            "buzzer=%s, "
-            "child_lock=%s, "
-            "favorite_level=%s, "
-            "filter_life_remaining=%s, "
-            "filter_hours_used=%s, "
-            "use_time=%s, "
-            "purify_volume=%s, "
-            "motor_speed=%s, "
-            "motor2_speed=%s, "
-            "volume=%s, "
-            "filter_rfid_product_id=%s, "
-            "filter_rfid_tag=%s, "
-            "filter_type=%s, "
-            "learn_mode=%s, "
-            "sleep_mode=%s, "
-            "sleep_time=%s, "
-            "sleep_mode_learn_count=%s, "
-            "extra_features=%s, "
-            "turbo_mode_supported=%s, "
-            "auto_detect=%s, "
-            "button_pressed=%s>"
-            % (
-                self.power,
-                self.aqi,
-                self.average_aqi,
-                self.temperature,
-                self.humidity,
-                self.mode,
-                self.led,
-                self.led_brightness,
-                self.illuminance,
-                self.buzzer,
-                self.child_lock,
-                self.favorite_level,
-                self.filter_life_remaining,
-                self.filter_hours_used,
-                self.use_time,
-                self.purify_volume,
-                self.motor_speed,
-                self.motor2_speed,
-                self.volume,
-                self.filter_rfid_product_id,
-                self.filter_rfid_tag,
-                self.filter_type,
-                self.learn_mode,
-                self.sleep_mode,
-                self.sleep_time,
-                self.sleep_mode_learn_count,
-                self.extra_features,
-                self.turbo_mode_supported,
-                self.auto_detect,
-                self.button_pressed,
-            )
-        )
-        return s
 
 
 class AirPurifier(Device):

--- a/miio/airpurifier_airdog.py
+++ b/miio/airpurifier_airdog.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional
 import click
 
 from .click_common import EnumType, command, format_output
-from .device import Device
+from .device import Device, DeviceStatus
 from .exceptions import DeviceException
 
 _LOGGER = logging.getLogger(__name__)
@@ -40,7 +40,7 @@ class OperationModeMapping(enum.Enum):
     Idle = 2
 
 
-class AirDogStatus:
+class AirDogStatus(DeviceStatus):
     """Container for status reports from the air dog x3."""
 
     def __init__(self, data: Dict[str, Any]) -> None:
@@ -97,27 +97,6 @@ class AirDogStatus:
             return self.data["hcho"]
 
         return None
-
-    def __repr__(self) -> str:
-        s = (
-            "<AirDogStatus power=%s, "
-            "mode=%s, "
-            "speed=%s, "
-            "child_lock=%s, "
-            "clean_filters=%s, "
-            "pm25=%s, "
-            "hcho=%s>"
-            % (
-                self.power,
-                self.mode,
-                self.speed,
-                self.child_lock,
-                self.clean_filters,
-                self.pm25,
-                self.hcho,
-            )
-        )
-        return s
 
 
 class AirDogX3(Device):

--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -7,7 +7,7 @@ import click
 from .airfilter_util import FilterType, FilterTypeUtil
 from .click_common import EnumType, command, format_output
 from .exceptions import DeviceException
-from .miot_device import MiotDevice
+from .miot_device import DeviceStatus, MiotDevice
 
 _LOGGER = logging.getLogger(__name__)
 _MAPPING = {
@@ -85,7 +85,7 @@ class LedBrightness(enum.Enum):
     Off = 2
 
 
-class BasicAirPurifierMiotStatus:
+class BasicAirPurifierMiotStatus(DeviceStatus):
     """Container for status reports from the air purifier."""
 
     def __init__(self, data: Dict[str, Any]) -> None:
@@ -256,55 +256,6 @@ class AirPurifierMiotStatus(BasicAirPurifierMiotStatus):
             self.filter_rfid_tag, self.filter_rfid_product_id
         )
 
-    def __repr__(self) -> str:
-        s = (
-            "<AirPurifierMiotStatus power=%s, "
-            "aqi=%s, "
-            "average_aqi=%s, "
-            "temperature=%s, "
-            "humidity=%s%%, "
-            "fan_level=%s, "
-            "mode=%s, "
-            "led=%s, "
-            "led_brightness=%s, "
-            "buzzer=%s, "
-            "buzzer_volume=%s, "
-            "child_lock=%s, "
-            "favorite_level=%s, "
-            "filter_life_remaining=%s, "
-            "filter_hours_used=%s, "
-            "use_time=%s, "
-            "purify_volume=%s, "
-            "motor_speed=%s, "
-            "filter_rfid_product_id=%s, "
-            "filter_rfid_tag=%s, "
-            "filter_type=%s>"
-            % (
-                self.power,
-                self.aqi,
-                self.average_aqi,
-                self.temperature,
-                self.humidity,
-                self.fan_level,
-                self.mode,
-                self.led,
-                self.led_brightness,
-                self.buzzer,
-                self.buzzer_volume,
-                self.child_lock,
-                self.favorite_level,
-                self.filter_life_remaining,
-                self.filter_hours_used,
-                self.use_time,
-                self.purify_volume,
-                self.motor_speed,
-                self.filter_rfid_product_id,
-                self.filter_rfid_tag,
-                self.filter_type,
-            )
-        )
-        return s
-
 
 class AirPurifierMB4Status(BasicAirPurifierMiotStatus):
     """
@@ -349,33 +300,6 @@ class AirPurifierMB4Status(BasicAirPurifierMiotStatus):
     def favorite_rpm(self) -> int:
         """Return favorite rpm level."""
         return self.data["favorite_rpm"]
-
-    def __repr__(self) -> str:
-        s = (
-            "<AirPurifierMiotStatus power=%s, "
-            "aqi=%s, "
-            "mode=%s, "
-            "led_brightness_level=%s, "
-            "buzzer=%s, "
-            "child_lock=%s, "
-            "filter_life_remaining=%s, "
-            "filter_hours_used=%s, "
-            "motor_speed=%s, "
-            "favorite_rpm=%s>"
-            % (
-                self.power,
-                self.aqi,
-                self.mode,
-                self.led_brightness_level,
-                self.buzzer,
-                self.child_lock,
-                self.filter_life_remaining,
-                self.filter_hours_used,
-                self.motor_speed,
-                self.favorite_rpm,
-            )
-        )
-        return s
 
 
 class BasicAirPurifierMiot(MiotDevice):

--- a/miio/airqualitymonitor.py
+++ b/miio/airqualitymonitor.py
@@ -5,7 +5,7 @@ from typing import Optional
 import click
 
 from .click_common import command, format_output
-from .device import Device
+from .device import Device, DeviceStatus
 from .exceptions import DeviceException
 
 _LOGGER = logging.getLogger(__name__)
@@ -41,7 +41,7 @@ class AirQualityMonitorException(DeviceException):
     pass
 
 
-class AirQualityMonitorStatus:
+class AirQualityMonitorStatus(DeviceStatus):
     """Container of air quality monitor status."""
 
     def __init__(self, data):
@@ -146,35 +146,6 @@ class AirQualityMonitorStatus:
     def tvoc(self) -> Optional[int]:
         """Return tvoc value."""
         return self.data.get("tvoc", None)
-
-    def __repr__(self) -> str:
-        s = (
-            "<AirQualityMonitorStatus power=%s, "
-            "usb_power=%s, "
-            "battery=%s, "
-            "aqi=%s, "
-            "temperature=%s, "
-            "humidity=%s, "
-            "co2=%s, "
-            "co2e=%s, "
-            "pm2.5=%s, "
-            "tvoc=%s, "
-            "display_clock=%s>"
-            % (
-                self.power,
-                self.usb_power,
-                self.battery,
-                self.aqi,
-                self.temperature,
-                self.humidity,
-                self.co2,
-                self.co2e,
-                self.pm25,
-                self.tvoc,
-                self.display_clock,
-            )
-        )
-        return s
 
 
 class AirQualityMonitor(Device):

--- a/miio/airqualitymonitor_miot.py
+++ b/miio/airqualitymonitor_miot.py
@@ -5,7 +5,7 @@ import click
 
 from .click_common import command, format_output
 from .exceptions import DeviceException
-from .miot_device import MiotDevice
+from .miot_device import DeviceStatus, MiotDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -84,7 +84,7 @@ class DisplayTemperatureUnitCGDN1(enum.Enum):
     Fahrenheit = "f"
 
 
-class AirQualityMonitorCGDN1Status:
+class AirQualityMonitorCGDN1Status(DeviceStatus):
     """
     Container of air quality monitor CGDN1 status.
 
@@ -164,35 +164,6 @@ class AirQualityMonitorCGDN1Status:
     def display_temperature_unit(self):
         """Return display temperature unit."""
         return DisplayTemperatureUnitCGDN1(self.data["temperature_unit"])
-
-    def __repr__(self) -> str:
-        s = (
-            "<AirQualityMonitorCGDN1Status humidity=%s, "
-            "pm25=%s, "
-            "pm10=%s, "
-            "temperature=%s, "
-            "co2=%s, "
-            "battery=%s, "
-            "charging_state=%s"
-            "monitoring_frequency=%s"
-            "screen_off=%s"
-            "device_off=%s"
-            "display_temperature_unit=%s>"
-            % (
-                self.humidity,
-                self.pm25,
-                self.pm10,
-                self.temperature,
-                self.co2,
-                self.battery,
-                self.charging_state,
-                self.monitoring_frequency,
-                self.screen_off,
-                self.device_off,
-                self.display_temperature_unit,
-            )
-        )
-        return s
 
 
 class AirQualityMonitorCGDN1(MiotDevice):

--- a/miio/alarmclock.py
+++ b/miio/alarmclock.py
@@ -4,7 +4,7 @@ import time
 import click
 
 from .click_common import EnumType, command
-from .device import Device
+from .device import Device, DeviceStatus
 
 
 class HourlySystem(enum.Enum):
@@ -29,7 +29,7 @@ class Tone(enum.Enum):
     Seventh = "a7.mp3"
 
 
-class Nightmode:
+class Nightmode(DeviceStatus):
     def __init__(self, data):
         self._enabled = bool(data[0])
         self._start = data[1]
@@ -47,24 +47,13 @@ class Nightmode:
     def end(self):
         return self._end
 
-    def __repr__(self):
-        return "<Nightmode enabled:%s %s-%s>" % (self.enabled, self.start, self.end)
 
-
-class RingTone:
+class RingTone(DeviceStatus):
     def __init__(self, data):
         # {'type': 'reminder', 'ringtone': 'a2.mp3', 'smart_clock': 0}]
         self.type = AlarmType(data["type"])
         self.tone = Tone(data["ringtone"])
         self.smart_clock = data["smart_clock"]
-
-    def __repr__(self):
-        return "<%s %s tone: %s smart: %s>" % (
-            self.__class__.__name__,
-            self.type,
-            self.tone,
-            self.smart_clock,
-        )
 
 
 class AlarmClock(Device):

--- a/miio/aqaracamera.py
+++ b/miio/aqaracamera.py
@@ -15,7 +15,7 @@ import attr
 import click
 
 from .click_common import command, format_output
-from .device import Device
+from .device import Device, DeviceStatus
 from .exceptions import DeviceException
 
 _LOGGER = logging.getLogger(__name__)
@@ -63,7 +63,7 @@ class MotionDetectionSensitivity(IntEnum):
     Low = 11000000
 
 
-class CameraStatus:
+class CameraStatus(DeviceStatus):
     """Container for status reports from the Aqara Camera."""
 
     def __init__(self, data: Dict[str, Any]) -> None:
@@ -151,31 +151,6 @@ class CameraStatus:
     def av_password(self) -> str:
         """TODO: What is this? Password for the cloud?"""
         return self.data["avPass"]
-
-    def __repr__(self) -> str:
-        s = (
-            "<CameraStatus is_on=%s, "
-            "type=%s, "
-            "offset=%s, "
-            "ir=%s, "
-            "md=%s, "
-            "md_sensitivity=%s, "
-            "led=%s, "
-            "flip=%s, "
-            "fullstop=%s>"
-            % (
-                self.is_on,
-                self.type,
-                self.offsets,
-                self.ir,
-                self.md,
-                self.md_sensitivity,
-                self.led,
-                self.flipped,
-                self.fullstop,
-            )
-        )
-        return s
 
 
 class AqaraCamera(Device):

--- a/miio/ceil.py
+++ b/miio/ceil.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 import click
 
 from .click_common import command, format_output
-from .device import Device
+from .device import Device, DeviceStatus
 from .exceptions import DeviceException
 
 _LOGGER = logging.getLogger(__name__)
@@ -15,7 +15,7 @@ class CeilException(DeviceException):
     pass
 
 
-class CeilStatus:
+class CeilStatus(DeviceStatus):
     """Container for status reports from Xiaomi Philips LED Ceiling Lamp."""
 
     def __init__(self, data: Dict[str, Any]) -> None:
@@ -65,27 +65,6 @@ class CeilStatus:
     def automatic_color_temperature(self) -> bool:
         """Automatic color temperature state."""
         return self.data["ac"] == 1
-
-    def __repr__(self) -> str:
-        s = (
-            "<CeilStatus power=%s, "
-            "brightness=%s, "
-            "color_temperature=%s, "
-            "scene=%s, "
-            "delay_off_countdown=%s, "
-            "smart_night_light=%s, "
-            "automatic_color_temperature=%s>"
-            % (
-                self.power,
-                self.brightness,
-                self.color_temperature,
-                self.scene,
-                self.delay_off_countdown,
-                self.smart_night_light,
-                self.automatic_color_temperature,
-            )
-        )
-        return s
 
 
 class Ceil(Device):

--- a/miio/chuangmi_camera.py
+++ b/miio/chuangmi_camera.py
@@ -7,7 +7,7 @@ from typing import Any, Dict
 import click
 
 from .click_common import EnumType, command, format_output
-from .device import Device
+from .device import Device, DeviceStatus
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -65,7 +65,7 @@ CONST_HIGH_SENSITIVITY = [MotionDetectionSensitivity.High] * 32
 CONST_LOW_SENSITIVITY = [MotionDetectionSensitivity.Low] * 32
 
 
-class CameraStatus:
+class CameraStatus(DeviceStatus):
     """Container for status reports from the Xiaomi Chuangmi Camera."""
 
     def __init__(self, data: Dict[str, Any]) -> None:
@@ -143,40 +143,6 @@ class CameraStatus:
     def mini_level(self) -> int:
         """Unknown."""
         return self.data["mini_level"]
-
-    def __repr__(self) -> str:
-        s = (
-            "<CameraStatus "
-            "power=%s, "
-            "motion_record=%s, "
-            "light=%s, "
-            "full_color=%s, "
-            "flip=%s, "
-            "improve_program=%s, "
-            "wdr=%s, "
-            "track=%s, "
-            "watermark=%s, "
-            "sdcard_status=%s, "
-            "max_client=%s, "
-            "night_mode=%s, "
-            "mini_level=%s>"
-            % (
-                self.power,
-                self.motion_record,
-                self.light,
-                self.full_color,
-                self.flip,
-                self.improve_program,
-                self.wdr,
-                self.track,
-                self.sdcard_status,
-                self.watermark,
-                self.max_client,
-                self.night_mode,
-                self.mini_level,
-            )
-        )
-        return s
 
 
 class ChuangmiCamera(Device):

--- a/miio/chuangmi_plug.py
+++ b/miio/chuangmi_plug.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional
 import click
 
 from .click_common import command, format_output
-from .device import Device
+from .device import Device, DeviceStatus
 from .utils import deprecated
 
 _LOGGER = logging.getLogger(__name__)
@@ -31,7 +31,7 @@ AVAILABLE_PROPERTIES = {
 }
 
 
-class ChuangmiPlugStatus:
+class ChuangmiPlugStatus(DeviceStatus):
     """Container for status reports from the plug."""
 
     def __init__(self, data: Dict[str, Any]) -> None:
@@ -81,24 +81,6 @@ class ChuangmiPlugStatus:
         if "wifi_led" in self.data and self.data["wifi_led"] is not None:
             return self.data["wifi_led"] == "on"
         return None
-
-    def __repr__(self) -> str:
-        s = (
-            "<ChuangmiPlugStatus "
-            "power=%s, "
-            "usb_power=%s, "
-            "temperature=%s, "
-            "load_power=%s, "
-            "wifi_led=%s>"
-            % (
-                self.power,
-                self.usb_power,
-                self.temperature,
-                self.load_power,
-                self.wifi_led,
-            )
-        )
-        return s
 
 
 class ChuangmiPlug(Device):

--- a/miio/cooker.py
+++ b/miio/cooker.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 import click
 
 from .click_common import command, format_output
-from .device import Device
+from .device import Device, DeviceStatus
 from .exceptions import DeviceException
 
 _LOGGER = logging.getLogger(__name__)
@@ -97,7 +97,7 @@ class OperationMode(enum.Enum):
     Cancel = "Отмена"
 
 
-class TemperatureHistory:
+class TemperatureHistory(DeviceStatus):
     def __init__(self, data: str):
         """Container of temperatures recorded every 10-15 seconds while cooking.
 
@@ -141,12 +141,8 @@ class TemperatureHistory:
     def __str__(self) -> str:
         return str(self.data)
 
-    def __repr__(self) -> str:
-        s = "<TemperatureHistory temperatures=%s>" % str(self.data)
-        return s
 
-
-class CookerCustomizations:
+class CookerCustomizations(DeviceStatus):
     def __init__(self, custom: str):
         """Container of different user customizations.
 
@@ -200,27 +196,8 @@ class CookerCustomizations:
     def __str__(self) -> str:
         return "".join(["{:02x}".format(value) for value in self.custom])
 
-    def __repr__(self) -> str:
-        s = (
-            "<CookerCustomizations jingzhu_appointment=%s, "
-            "kuaizhu_appointment=%s, "
-            "zhuzhou_appointment=%s, "
-            "zhuzhou_cooking=%s, "
-            "favorite_appointment=%s, "
-            "favorite_cooking=%s>"
-            % (
-                self.jingzhu_appointment,
-                self.kuaizhu_appointment,
-                self.zhuzhou_appointment,
-                self.zhuzhou_cooking,
-                self.favorite_appointment,
-                self.favorite_cooking,
-            )
-        )
-        return s
 
-
-class CookingStage:
+class CookingStage(DeviceStatus):
     def __init__(self, stage: str):
         """Container of cooking stages.
 
@@ -279,50 +256,8 @@ class CookingStage:
     def raw(self) -> str:
         return self.stage
 
-    def __str__(self) -> str:
-        s = (
-            "name=%s, "
-            "description=%s, "
-            "state=%s, "
-            "rice_id=%s, "
-            "taste=%s, "
-            "taste_phase=%s, "
-            "raw=%s"
-            % (
-                self.name,
-                self.description,
-                self.state,
-                self.rice_id,
-                self.taste,
-                self.taste_phase,
-                self.raw,
-            )
-        )
-        return s
 
-    def __repr__(self) -> str:
-        s = (
-            "<CookingStage name=%s, "
-            "description=%s, "
-            "state=%s, "
-            "rice_id=%s, "
-            "taste=%s, "
-            "taste_phase=%s, "
-            "raw=%s>"
-            % (
-                self.name,
-                self.description,
-                self.state,
-                self.rice_id,
-                self.taste,
-                self.taste_phase,
-                self.stage,
-            )
-        )
-        return s
-
-
-class InteractionTimeouts:
+class InteractionTimeouts(DeviceStatus):
     def __init__(self, timeouts: str = None):
         """Example timeouts: 05040f, 05060f.
 
@@ -366,17 +301,8 @@ class InteractionTimeouts:
     def __str__(self) -> str:
         return "".join(["{:02x}".format(value) for value in self.timeouts])
 
-    def __repr__(self) -> str:
-        s = (
-            "<InteractionTimeouts led_off=%s, "
-            "lid_open=%s, "
-            "lid_open_warning=%s>"
-            % (self.led_off, self.lid_open, self.lid_open_warning)
-        )
-        return s
 
-
-class CookerSettings:
+class CookerSettings(DeviceStatus):
     def __init__(self, settings: str = None):
         """Example settings: 1407, 0607, 0207.
 
@@ -505,33 +431,8 @@ class CookerSettings:
     def __str__(self) -> str:
         return "".join(["{:02x}".format(value) for value in self.settings])
 
-    def __repr__(self) -> str:
-        s = (
-            "<CookerSettings pressure_supported=%s, "
-            "led_on=%s, "
-            "lid_open_warning=%s, "
-            "lid_open_warning_delayed=%s, "
-            "auto_keep_warm=%s, "
-            "jingzhu_auto_keep_warm=%s, "
-            "kuaizhu_auto_keep_warm=%s, "
-            "zhuzhou_auto_keep_warm=%s, "
-            "favorite_auto_keep_warm=%s>"
-            % (
-                self.pressure_supported,
-                self.led_on,
-                self.lid_open_warning,
-                self.lid_open_warning_delayed,
-                self.auto_keep_warm,
-                self.jingzhu_auto_keep_warm,
-                self.kuaizhu_auto_keep_warm,
-                self.zhuzhou_auto_keep_warm,
-                self.favorite_auto_keep_warm,
-            )
-        )
-        return s
 
-
-class CookerStatus:
+class CookerStatus(DeviceStatus):
     def __init__(self, data):
         """Responses of a chunmi.cooker.normal2 (fw_ver: 1.2.8):
 
@@ -674,41 +575,6 @@ class CookerStatus:
             return CookerCustomizations(custom)
 
         return None
-
-    def __repr__(self) -> str:
-        s = (
-            "<CookerStatus mode=%s "
-            "menu=%s, "
-            "stage=%s, "
-            "temperature=%s, "
-            "start_time=%s"
-            "remaining=%s, "
-            "cooking_delayed=%s, "
-            "cooking_temperature=%s, "
-            "settings=%s, "
-            "interaction_timeouts=%s, "
-            "hardware_version=%s, "
-            "firmware_version=%s, "
-            "favorite=%s, "
-            "custom=%s>"
-            % (
-                self.mode,
-                self.menu,
-                self.stage,
-                self.temperature,
-                self.start_time,
-                self.remaining,
-                self.cooking_delayed,
-                self.duration,
-                self.settings,
-                self.interaction_timeouts,
-                self.hardware_version,
-                self.firmware_version,
-                self.favorite,
-                self.custom,
-            )
-        )
-        return s
 
 
 class Cooker(Device):

--- a/miio/curtain_youpin.py
+++ b/miio/curtain_youpin.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 import click
 
 from .click_common import EnumType, command, format_output
-from .miot_device import MiotDevice
+from .miot_device import DeviceStatus, MiotDevice
 
 _LOGGER = logging.getLogger(__name__)
 _MAPPING = {
@@ -47,7 +47,7 @@ class Polarity(enum.Enum):
     Reverse = 1
 
 
-class CurtainStatus:
+class CurtainStatus(DeviceStatus):
     def __init__(self, data: Dict[str, Any]) -> None:
         """Response from device.
 
@@ -109,30 +109,6 @@ class CurtainStatus:
     def adjust_value(self) -> int:
         """Adjust value."""
         return self.data["adjust_value"]
-
-    def __repr__(self) -> str:
-        s = (
-            "<CurtainStatus"
-            "status=%s,"
-            "polarity=%s,"
-            "is_position_limited=%s,"
-            "night_tip_light=%s,"
-            "run_time=%s,"
-            "current_position=%s,"
-            "target_position=%s,"
-            "adjust_value=%s>"
-            % (
-                self.status,
-                self.polarity,
-                self.is_position_limited,
-                self.night_tip_light,
-                self.run_time,
-                self.current_position,
-                self.target_position,
-                self.adjust_value,
-            )
-        )
-        return s
 
 
 class CurtainMiot(MiotDevice):

--- a/miio/device.py
+++ b/miio/device.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 from enum import Enum
 from typing import Any, Optional  # noqa: F401
@@ -98,6 +99,29 @@ class DeviceInfo:
     def raw(self):
         """Raw data as returned by the device."""
         return self.data
+
+
+class DeviceStatus:
+    """Base class for status containers.
+
+    All status container classes should inherit from this class. The __repr__
+    implementation returns all defined properties and their values.
+    """
+
+    def __repr__(self):
+        props = inspect.getmembers(self.__class__, lambda o: isinstance(o, property))
+
+        s = f"<{self.__class__.__name__}"
+        for prop_tuple in props:
+            name, prop = prop_tuple
+            try:
+                prop_value = prop.fget(self)
+            except Exception as ex:
+                prop_value = ex.__class__.__name__
+
+            s += f" {name}={prop_value}"
+        s += ">"
+        return s
 
 
 class Device(metaclass=DeviceGroupMeta):

--- a/miio/dreamevacuum_miot.py
+++ b/miio/dreamevacuum_miot.py
@@ -4,6 +4,7 @@ import logging
 from enum import Enum
 
 from .click_common import command, format_output
+from .miot_device import DeviceStatus as DeviceStatusContainer
 from .miot_device import MiotDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -75,7 +76,7 @@ class DeviceStatus(Enum):
     Charging = 6
 
 
-class DreameVacuumStatus:
+class DreameVacuumStatus(DeviceStatusContainer):
     def __init__(self, data):
         self.data = data
 
@@ -187,10 +188,7 @@ class DreameVacuumStatus:
 class DreameVacuumMiot(MiotDevice):
     """Interface for Vacuum 1C STYTJ01ZHM (dreame.vacuum.mc1808)"""
 
-    def __init__(
-        self, ip: str, token: str = None, start_id: int = 0, debug: int = 0
-    ) -> None:
-        super().__init__(_MAPPING, ip, token, start_id, debug)
+    mapping = _MAPPING
 
     @command(
         default_output=format_output(

--- a/miio/fan.py
+++ b/miio/fan.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional
 import click
 
 from .click_common import EnumType, command, format_output
-from .device import Device
+from .device import Device, DeviceStatus
 from .fan_common import FanException, LedBrightness, MoveDirection, OperationMode
 
 _LOGGER = logging.getLogger(__name__)
@@ -63,7 +63,7 @@ AVAILABLE_PROPERTIES = {
 }
 
 
-class FanStatus:
+class FanStatus(DeviceStatus):
     """Container for status reports from the Xiaomi Mi Smart Pedestal Fan."""
 
     def __init__(self, data: Dict[str, Any]) -> None:
@@ -205,53 +205,8 @@ class FanStatus:
             return self.data["button_pressed"]
         return None
 
-    def __repr__(self) -> str:
-        s = (
-            "<FanStatus power=%s, "
-            "temperature=%s, "
-            "humidity=%s, "
-            "led=%s, "
-            "led_brightness=%s, "
-            "buzzer=%s, "
-            "child_lock=%s, "
-            "natural_speed=%s, "
-            "direct_speed=%s, "
-            "speed=%s, "
-            "oscillate=%s, "
-            "angle=%s, "
-            "ac_power=%s, "
-            "battery=%s, "
-            "battery_charge=%s, "
-            "battery_state=%s, "
-            "use_time=%s, "
-            "delay_off_countdown=%s, "
-            "button_pressed=%s>"
-            % (
-                self.power,
-                self.temperature,
-                self.humidity,
-                self.led,
-                self.led_brightness,
-                self.buzzer,
-                self.child_lock,
-                self.natural_speed,
-                self.direct_speed,
-                self.speed,
-                self.oscillate,
-                self.angle,
-                self.ac_power,
-                self.battery,
-                self.battery_charge,
-                self.battery_state,
-                self.use_time,
-                self.delay_off_countdown,
-                self.button_pressed,
-            )
-        )
-        return s
 
-
-class FanStatusP5:
+class FanStatusP5(DeviceStatus):
     """Container for status reports from the Xiaomi Mi Smart Pedestal Fan DMaker P5."""
 
     def __init__(self, data: Dict[str, Any]) -> None:
@@ -312,31 +267,6 @@ class FanStatusP5:
     def child_lock(self) -> bool:
         """True if child lock is on."""
         return self.data["child_lock"]
-
-    def __repr__(self) -> str:
-        s = (
-            "<FanStatus power=%s, "
-            "mode=%s, "
-            "speed=%s, "
-            "oscillate=%s, "
-            "angle=%s, "
-            "led=%s, "
-            "buzzer=%s, "
-            "child_lock=%s, "
-            "delay_off_countdown=%s>"
-            % (
-                self.power,
-                self.mode,
-                self.speed,
-                self.oscillate,
-                self.angle,
-                self.led,
-                self.buzzer,
-                self.child_lock,
-                self.delay_off_countdown,
-            )
-        )
-        return s
 
 
 class Fan(Device):

--- a/miio/fan_leshow.py
+++ b/miio/fan_leshow.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 import click
 
 from .click_common import EnumType, command, format_output
-from .device import Device
+from .device import Device, DeviceStatus
 from .exceptions import DeviceException
 
 _LOGGER = logging.getLogger(__name__)
@@ -38,7 +38,7 @@ class OperationMode(enum.Enum):
     Natural = 3
 
 
-class FanLeshowStatus:
+class FanLeshowStatus(DeviceStatus):
     """Container for status reports from the Xiaomi Rosou SS4 Ventilator."""
 
     def __init__(self, data: Dict[str, Any]) -> None:
@@ -88,27 +88,6 @@ class FanLeshowStatus:
     def error_detected(self) -> bool:
         """True if a fault was detected."""
         return self.data["fault"] == 1
-
-    def __repr__(self) -> str:
-        s = (
-            "<FanLeshowStatus power=%s, "
-            "mode=%s, "
-            "speed=%s, "
-            "buzzer=%s, "
-            "oscillate=%s, "
-            "delay_off_countdown=%s, "
-            "error_detected=%s>"
-            % (
-                self.power,
-                self.mode,
-                self.speed,
-                self.buzzer,
-                self.oscillate,
-                self.delay_off_countdown,
-                self.error_detected,
-            )
-        )
-        return s
 
 
 class FanLeshow(Device):

--- a/miio/fan_miot.py
+++ b/miio/fan_miot.py
@@ -5,7 +5,7 @@ import click
 
 from .click_common import EnumType, command, format_output
 from .fan_common import FanException, MoveDirection, OperationMode
-from .miot_device import MiotDevice
+from .miot_device import DeviceStatus, MiotDevice
 
 MODEL_FAN_P9 = "dmaker.fan.p9"
 MODEL_FAN_P10 = "dmaker.fan.p10"
@@ -63,7 +63,7 @@ class OperationModeMiot(enum.Enum):
     Nature = 1
 
 
-class FanStatusMiot:
+class FanStatusMiot(DeviceStatus):
     """Container for status reports for Xiaomi Mi Smart Pedestal Fan DMaker P9/P10."""
 
     def __init__(self, data: Dict[str, Any]) -> None:
@@ -139,31 +139,6 @@ class FanStatusMiot:
     def child_lock(self) -> bool:
         """True if child lock is on."""
         return self.data["child_lock"]
-
-    def __repr__(self) -> str:
-        s = (
-            "<FanStatus power=%s, "
-            "mode=%s, "
-            "speed=%s, "
-            "oscillate=%s, "
-            "angle=%s, "
-            "led=%s, "
-            "buzzer=%s, "
-            "child_lock=%s, "
-            "delay_off_countdown=%s>"
-            % (
-                self.power,
-                self.mode,
-                self.speed,
-                self.oscillate,
-                self.angle,
-                self.led,
-                self.buzzer,
-                self.child_lock,
-                self.delay_off_countdown,
-            )
-        )
-        return s
 
 
 class FanMiot(MiotDevice):

--- a/miio/heater.py
+++ b/miio/heater.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional
 import click
 
 from .click_common import EnumType, command, format_output
-from .device import Device
+from .device import Device, DeviceStatus
 from .exceptions import DeviceException
 
 _LOGGER = logging.getLogger(__name__)
@@ -49,7 +49,7 @@ class Brightness(enum.Enum):
     Off = 2
 
 
-class HeaterStatus:
+class HeaterStatus(DeviceStatus):
     """Container for status reports from the Smartmi Zhimi Heater."""
 
     def __init__(self, data: Dict[str, Any]) -> None:
@@ -122,31 +122,6 @@ class HeaterStatus:
             return self.data["poweroff_level"]
 
         return None
-
-    def __repr__(self) -> str:
-        s = (
-            "<HeaterStatus power=%s, "
-            "target_temperature=%s, "
-            "temperature=%s, "
-            "humidity=%s, "
-            "brightness=%s, "
-            "buzzer=%s, "
-            "child_lock=%s, "
-            "use_time=%s, "
-            "delay_off_countdown=%s>"
-            % (
-                self.power,
-                self.target_temperature,
-                self.temperature,
-                self.humidity,
-                self.brightness,
-                self.buzzer,
-                self.child_lock,
-                self.use_time,
-                self.delay_off_countdown,
-            )
-        )
-        return s
 
 
 class Heater(Device):

--- a/miio/heater_miot.py
+++ b/miio/heater_miot.py
@@ -6,7 +6,7 @@ import click
 
 from .click_common import EnumType, command, format_output
 from .exceptions import DeviceException
-from .miot_device import MiotDevice
+from .miot_device import DeviceStatus, MiotDevice
 
 _LOGGER = logging.getLogger(__name__)
 _MAPPING = {
@@ -41,7 +41,7 @@ class HeaterMiotException(DeviceException):
     pass
 
 
-class HeaterMiotStatus:
+class HeaterMiotStatus(DeviceStatus):
     """Container for status reports from the Xiaomi Smart Space Heater S."""
 
     def __init__(self, data: Dict[str, Any]) -> None:
@@ -99,27 +99,6 @@ class HeaterMiotStatus:
     def led_brightness(self) -> LedBrightness:
         """LED indicator brightness."""
         return LedBrightness(self.data["led_brightness"])
-
-    def __repr__(self) -> str:
-        s = (
-            "<HeaterMiotStatus power=%s, "
-            "target_temperature=%s, "
-            "temperature=%s, "
-            "led_brightness=%s, "
-            "buzzer=%s, "
-            "child_lock=%s, "
-            "delay_off_countdown=%s "
-            % (
-                self.power,
-                self.target_temperature,
-                self.temperature,
-                self.led_brightness,
-                self.buzzer,
-                self.child_lock,
-                self.delay_off_countdown,
-            )
-        )
-        return s
 
 
 class HeaterMiot(MiotDevice):

--- a/miio/huizuo.py
+++ b/miio/huizuo.py
@@ -11,7 +11,7 @@ import click
 
 from .click_common import command, format_output
 from .exceptions import DeviceException
-from .miot_device import MiotDevice
+from .miot_device import DeviceStatus, MiotDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -117,7 +117,7 @@ class HuizuoException(DeviceException):
     pass
 
 
-class HuizuoStatus:
+class HuizuoStatus(DeviceStatus):
     def __init__(self, data: Dict[str, Any]) -> None:
         self.data = data
 
@@ -187,29 +187,6 @@ class HuizuoStatus:
         if "heat_level" in self.data:
             return self.data["heat_level"]
         return None
-
-    def __repr__(self):
-        parameters = []
-        device_properties = [
-            "is_on",
-            "brightness",
-            "color_temp",
-            "is_fan_on",
-            "fan_speed_level",
-            "fan_mode",
-            "is_fan_reverse",
-            "is_heater_on",
-            "heat_level",
-            "heater_fault_code",
-        ]
-
-        for prop in device_properties:
-            val = getattr(self, prop)
-            if val is not None:
-                parameters.append(f"{prop}={val}")
-
-        s = "<Huizuo " + " ".join(parameters) + ">"
-        return s
 
 
 class Huizuo(MiotDevice):

--- a/miio/miot_device.py
+++ b/miio/miot_device.py
@@ -6,6 +6,7 @@ from typing import Any, Union
 import click
 
 from .click_common import EnumType, LiteralParamType, command
+from .device import Device, DeviceStatus  # noqa: F401
 from .exceptions import DeviceException
 
 _LOGGER = logging.getLogger(__name__)

--- a/miio/miot_device.py
+++ b/miio/miot_device.py
@@ -6,7 +6,6 @@ from typing import Any, Union
 import click
 
 from .click_common import EnumType, LiteralParamType, command
-from .device import Device
 from .exceptions import DeviceException
 
 _LOGGER = logging.getLogger(__name__)

--- a/miio/philips_bulb.py
+++ b/miio/philips_bulb.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional
 import click
 
 from .click_common import command, format_output
-from .device import Device
+from .device import Device, DeviceStatus
 from .exceptions import DeviceException
 
 _LOGGER = logging.getLogger(__name__)
@@ -25,7 +25,7 @@ class PhilipsBulbException(DeviceException):
     pass
 
 
-class PhilipsBulbStatus:
+class PhilipsBulbStatus(DeviceStatus):
     """Container for status reports from Xiaomi Philips LED Ceiling Lamp."""
 
     def __init__(self, data: Dict[str, Any]) -> None:
@@ -63,23 +63,6 @@ class PhilipsBulbStatus:
     @property
     def delay_off_countdown(self) -> int:
         return self.data["dv"]
-
-    def __repr__(self) -> str:
-        s = (
-            "<PhilipsBulbStatus power=%s, "
-            "brightness=%s, "
-            "delay_off_countdown=%s, "
-            "color_temperature=%s, "
-            "scene=%s>"
-            % (
-                self.power,
-                self.brightness,
-                self.delay_off_countdown,
-                self.color_temperature,
-                self.scene,
-            )
-        )
-        return s
 
 
 class PhilipsWhiteBulb(Device):

--- a/miio/philips_eyecare.py
+++ b/miio/philips_eyecare.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 import click
 
 from .click_common import command, format_output
-from .device import Device
+from .device import Device, DeviceStatus
 from .exceptions import DeviceException
 
 _LOGGER = logging.getLogger(__name__)
@@ -15,7 +15,7 @@ class PhilipsEyecareException(DeviceException):
     pass
 
 
-class PhilipsEyecareStatus:
+class PhilipsEyecareStatus(DeviceStatus):
     """Container for status reports from Xiaomi Philips Eyecare Smart Lamp 2."""
 
     def __init__(self, data: Dict[str, Any]) -> None:
@@ -73,31 +73,6 @@ class PhilipsEyecareStatus:
     def delay_off_countdown(self) -> int:
         """Countdown until turning off in minutes."""
         return self.data["dvalue"]
-
-    def __repr__(self) -> str:
-        s = (
-            "<PhilipsEyecareStatus power=%s, "
-            "brightness=%s, "
-            "ambient=%s, "
-            "ambient_brightness=%s, "
-            "eyecare=%s, "
-            "scene=%s, "
-            "reminder=%s, "
-            "smart_night_light=%s, "
-            "delay_off_countdown=%s>"
-            % (
-                self.power,
-                self.brightness,
-                self.ambient,
-                self.ambient_brightness,
-                self.eyecare,
-                self.scene,
-                self.reminder,
-                self.smart_night_light,
-                self.delay_off_countdown,
-            )
-        )
-        return s
 
 
 class PhilipsEyecare(Device):

--- a/miio/philips_moonlight.py
+++ b/miio/philips_moonlight.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Tuple
 import click
 
 from .click_common import command, format_output
-from .device import Device
+from .device import Device, DeviceStatus
 from .exceptions import DeviceException
 from .utils import int_to_rgb
 
@@ -16,7 +16,7 @@ class PhilipsMoonlightException(DeviceException):
     pass
 
 
-class PhilipsMoonlightStatus:
+class PhilipsMoonlightStatus(DeviceStatus):
     """Container for status reports from Xiaomi Philips Zhirui Bedside Lamp."""
 
     def __init__(self, data: Dict[str, Any]) -> None:
@@ -85,23 +85,6 @@ class PhilipsMoonlightStatus:
     def wake_up_time(self) -> [int, int, int]:
         # Example: [weekdays?, hour, minute]
         return self.data["wkp"]
-
-    def __repr__(self) -> str:
-        s = (
-            "<PhilipsMoonlightStatus power=%s, "
-            "brightness=%s, "
-            "color_temperature=%s, "
-            "rgb=%s, "
-            "scene=%s>"
-            % (
-                self.power,
-                self.brightness,
-                self.color_temperature,
-                self.rgb,
-                self.scene,
-            )
-        )
-        return s
 
 
 class PhilipsMoonlight(Device):

--- a/miio/philips_rwread.py
+++ b/miio/philips_rwread.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 import click
 
 from .click_common import EnumType, command, format_output
-from .device import Device
+from .device import Device, DeviceStatus
 from .exceptions import DeviceException
 
 _LOGGER = logging.getLogger(__name__)
@@ -28,7 +28,7 @@ class MotionDetectionSensitivity(enum.Enum):
     High = 3
 
 
-class PhilipsRwreadStatus:
+class PhilipsRwreadStatus(DeviceStatus):
     """Container for status reports from Xiaomi Philips RW Read."""
 
     def __init__(self, data: Dict[str, Any]) -> None:
@@ -78,27 +78,6 @@ class PhilipsRwreadStatus:
     def child_lock(self) -> bool:
         """True if child lock is enabled."""
         return self.data["chl"] == 1
-
-    def __repr__(self) -> str:
-        s = (
-            "<PhilipsRwreadStatus power=%s, "
-            "brightness=%s, "
-            "delay_off_countdown=%s, "
-            "scene=%s, "
-            "motion_detection=%s, "
-            "motion_detection_sensitivity=%s, "
-            "child_lock=%s>"
-            % (
-                self.power,
-                self.brightness,
-                self.delay_off_countdown,
-                self.scene,
-                self.motion_detection,
-                self.motion_detection_sensitivity,
-                self.child_lock,
-            )
-        )
-        return s
 
 
 class PhilipsRwread(Device):

--- a/miio/powerstrip.py
+++ b/miio/powerstrip.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional
 import click
 
 from .click_common import EnumType, command, format_output
-from .device import Device
+from .device import Device, DeviceStatus
 from .exceptions import DeviceException
 
 _LOGGER = logging.getLogger(__name__)
@@ -46,7 +46,7 @@ class PowerMode(enum.Enum):
     Normal = "normal"
 
 
-class PowerStripStatus:
+class PowerStripStatus(DeviceStatus):
     """Container for status reports from the power strip."""
 
     def __init__(self, data: Dict[str, Any]) -> None:
@@ -131,33 +131,6 @@ class PowerStripStatus:
         if "power_factor" in self.data and self.data["power_factor"] is not None:
             return self.data["power_factor"]
         return None
-
-    def __repr__(self) -> str:
-        s = (
-            "<PowerStripStatus power=%s, "
-            "temperature=%s, "
-            "voltage=%s, "
-            "current=%s, "
-            "load_power=%s, "
-            "power_factor=%s "
-            "power_price=%s, "
-            "leakage_current=%s, "
-            "mode=%s, "
-            "wifi_led=%s>"
-            % (
-                self.power,
-                self.temperature,
-                self.voltage,
-                self.current,
-                self.load_power,
-                self.power_factor,
-                self.power_price,
-                self.leakage_current,
-                self.mode,
-                self.wifi_led,
-            )
-        )
-        return s
 
 
 class PowerStrip(Device):

--- a/miio/pwzn_relay.py
+++ b/miio/pwzn_relay.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 import click
 
 from .click_common import command, format_output
-from .device import Device
+from .device import Device, DeviceStatus
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -56,7 +56,7 @@ AVAILABLE_PROPERTIES = {
 }
 
 
-class PwznRelayStatus:
+class PwznRelayStatus(DeviceStatus):
     """Container for status reports from the plug."""
 
     def __init__(self, data: Dict[str, Any]) -> None:
@@ -92,15 +92,6 @@ class PwznRelayStatus:
         """Number of on relay."""
         if "on_count" in self.data:
             return self.data["on_count"]
-
-    def __repr__(self) -> str:
-        s = (
-            "<PwznRelayStatus "
-            "relay_status=%s, "
-            "relay_names=%s, "
-            "on_count=%s>" % (self.relay_state, self.relay_names, self.on_count)
-        )
-        return s
 
 
 class PwznRelay(Device):

--- a/miio/tests/test_devicestatus.py
+++ b/miio/tests/test_devicestatus.py
@@ -1,0 +1,66 @@
+from miio import DeviceStatus
+
+
+def test_multiple():
+    class MultipleProperties(DeviceStatus):
+        @property
+        def first(self):
+            return "first"
+
+        @property
+        def second(self):
+            return "second"
+
+    assert (
+        repr(MultipleProperties()) == "<MultipleProperties first=first second=second>"
+    )
+
+
+def test_empty():
+    class EmptyStatus(DeviceStatus):
+        pass
+
+    assert repr(EmptyStatus() == "<EmptyStatus>")
+
+
+def test_exception():
+    class StatusWithException(DeviceStatus):
+        @property
+        def raise_exception(self):
+            raise Exception("test")
+
+    assert (
+        repr(StatusWithException()) == "<StatusWithException raise_exception=Exception>"
+    )
+
+
+def test_inheritance():
+    class Parent(DeviceStatus):
+        @property
+        def from_parent(self):
+            return True
+
+    class Child(Parent):
+        @property
+        def from_child(self):
+            return True
+
+    assert repr(Child()) == "<Child from_child=True from_parent=True>"
+
+
+def test_list():
+    class List(DeviceStatus):
+        @property
+        def return_list(self):
+            return [0, 1, 2]
+
+    assert repr(List()) == "<List return_list=[0, 1, 2]>"
+
+
+def test_none():
+    class NoneStatus(DeviceStatus):
+        @property
+        def return_none(self):
+            return None
+
+    assert repr(NoneStatus()) == "<NoneStatus return_none=None>"

--- a/miio/toiletlid.py
+++ b/miio/toiletlid.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List
 import click
 
 from .click_common import EnumType, command, format_output
-from .device import Device
+from .device import Device, DeviceStatus
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,7 +35,7 @@ class ToiletlidOperatingMode(enum.Enum):
     NozzleClean = 6
 
 
-class ToiletlidStatus:
+class ToiletlidStatus(DeviceStatus):
     def __init__(self, data: Dict[str, Any]) -> None:
         # {"work_state": 1,"filter_use_flux": 100,"filter_use_time": 180, "ambient_light": "Red"}
         self.data = data
@@ -68,24 +68,6 @@ class ToiletlidStatus:
     def ambient_light(self) -> str:
         """Ambient light color."""
         return self.data["ambient_light"]
-
-    def __repr__(self) -> str:
-        return (
-            "<ToiletlidStatus work=%s, "
-            "state=%s, "
-            "work_mode=%s, "
-            "ambient_light=%s, "
-            "filter_use_percentage=%s, "
-            "filter_remaining_time=%s>"
-            % (
-                self.is_on,
-                self.work_state,
-                self.work_mode,
-                self.ambient_light,
-                self.filter_use_percentage,
-                self.filter_remaining_time,
-            )
-        )
 
 
 class Toiletlid(Device):

--- a/miio/viomivacuum.py
+++ b/miio/viomivacuum.py
@@ -52,7 +52,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import click
 
 from .click_common import EnumType, command, format_output
-from .device import Device
+from .device import Device, DeviceStatus
 from .exceptions import DeviceException
 from .utils import pretty_seconds
 from .vacuumcontainers import ConsumableStatus, DNDStatus
@@ -183,17 +183,6 @@ class ViomiConsumableStatus(ConsumableStatus):
         """How long until the mop should be changed."""
         return self.sensor_dirty_total - self.sensor_dirty
 
-    def __repr__(self) -> str:
-        return (
-            "<ConsumableStatus main: %s, side: %s, filter: %s, mop: %s>"
-            % (  # noqa: E501
-                self.main_brush,
-                self.side_brush,
-                self.filter,
-                self.mop,
-            )
-        )
-
 
 class ViomiVacuumSpeed(Enum):
     Silent = 0
@@ -275,7 +264,7 @@ class ViomiEdgeState(Enum):
     Unknown2 = 5
 
 
-class ViomiVacuumStatus:
+class ViomiVacuumStatus(DeviceStatus):
     def __init__(self, data):
         # ["run_state","mode","err_state","battary_life","box_type","mop_type","s_time","s_area",
         # "suction_grade","water_grade","remember_map","has_map","is_mop","has_newmap"]'

--- a/miio/waterpurifier.py
+++ b/miio/waterpurifier.py
@@ -2,12 +2,12 @@ import logging
 from typing import Any, Dict
 
 from .click_common import command, format_output
-from .device import Device
+from .device import Device, DeviceStatus
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class WaterPurifierStatus:
+class WaterPurifierStatus(DeviceStatus):
     """Container for status reports from the water purifier."""
 
     def __init__(self, data: Dict[str, Any]) -> None:
@@ -88,47 +88,6 @@ class WaterPurifierStatus:
     @property
     def valve(self) -> str:
         return self.data["elecval_state"]
-
-    def __repr__(self) -> str:
-        return (
-            "<WaterPurifierStatus "
-            "power=%s, "
-            "mode=%s, "
-            "tds=%s, "
-            "filter_life_remaining=%s, "
-            "filter_state=%s, "
-            "filter2_life_remaining=%s, "
-            "filter2_state=%s, "
-            "life=%s, "
-            "state=%s, "
-            "level=%s, "
-            "volume=%s, "
-            "filter=%s, "
-            "usage=%s, "
-            "temperature=%s, "
-            "uv_filter_life_remaining=%s, "
-            "uv_filter_state=%s, "
-            "valve=%s>"
-            % (
-                self.power,
-                self.mode,
-                self.tds,
-                self.filter_life_remaining,
-                self.filter_state,
-                self.filter2_life_remaining,
-                self.filter2_state,
-                self.life,
-                self.state,
-                self.level,
-                self.volume,
-                self.filter,
-                self.usage,
-                self.temperature,
-                self.uv_filter_life_remaining,
-                self.uv_filter_state,
-                self.valve,
-            )
-        )
 
 
 class WaterPurifier(Device):

--- a/miio/waterpurifier_yunmi.py
+++ b/miio/waterpurifier_yunmi.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from typing import Any, Dict, List
 
 from .click_common import command, format_output
-from .device import Device
+from .device import Device, DeviceStatus
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -73,7 +73,7 @@ ERROR_DESCRIPTION = [
 ]
 
 
-class OperationStatus:
+class OperationStatus(DeviceStatus):
     def __init__(self, operation_status: int):
         """Operation status parser.
 
@@ -96,12 +96,8 @@ class OperationStatus:
     def errors(self) -> List:
         return self.err_list
 
-    def __repr__(self) -> str:
-        s = "<OperationStatus errors=%s>" % (self.errors)
-        return s
 
-
-class WaterPurifierYunmiStatus:
+class WaterPurifierYunmiStatus(DeviceStatus):
     """Container for status reports from the water purifier (Yunmi model)."""
 
     def __init__(self, data: Dict[str, Any]) -> None:
@@ -239,64 +235,6 @@ class WaterPurifierYunmiStatus:
     def tds_warn_thd(self) -> int:
         """TDS warning threshold."""
         return self.data["tds_warn_thd"]
-
-    def __repr__(self) -> str:
-        return (
-            "<WaterPurifierYunmiStatus "
-            "operation_status=%s, "
-            "filter1_life_total=%s, "
-            "filter1_life_used=%s, "
-            "filter1_life_remaining=%s, "
-            "filter1_flow_total=%s, "
-            "filter1_flow_used=%s, "
-            "filter1_flow_remaining=%s, "
-            "filter2_life_total=%s, "
-            "filter2_life_used=%s, "
-            "filter2_life_remaining=%s, "
-            "filter2_flow_total=%s, "
-            "filter2_flow_used=%s, "
-            "filter2_flow_remaining=%s, "
-            "filter3_life_total=%s, "
-            "filter3_life_used=%s, "
-            "filter3_life_remaining=%s, "
-            "filter3_flow_total=%s, "
-            "filter3_flow_used=%s, "
-            "filter3_flow_remaining=%s, "
-            "tds_in=%s, "
-            "tds_out=%s, "
-            "rinse=%s, "
-            "temperature=%s, "
-            "tds_warn_thd=%s>"
-            % (
-                self.operation_status,
-                self.filter1_life_total,
-                self.filter1_life_used,
-                self.filter1_life_remaining,
-                self.filter1_flow_total,
-                self.filter1_flow_used,
-                self.filter1_flow_remaining,
-                self.filter2_life_total,
-                self.filter2_life_used,
-                self.filter2_life_remaining,
-                self.filter2_flow_total,
-                self.filter2_flow_used,
-                self.filter2_flow_remaining,
-                self.filter3_life_total,
-                self.filter3_life_used,
-                self.filter3_life_remaining,
-                self.filter3_flow_total,
-                self.filter3_flow_used,
-                self.filter3_flow_remaining,
-                self.tds_in,
-                self.tds_out,
-                self.rinse,
-                self.temperature,
-                self.tds_warn_thd,
-            )
-        )
-
-    def __json__(self):
-        return self.data
 
 
 class WaterPurifierYunmi(Device):

--- a/miio/wifirepeater.py
+++ b/miio/wifirepeater.py
@@ -3,7 +3,7 @@ import logging
 import click
 
 from .click_common import command, format_output
-from .device import Device
+from .device import Device, DeviceStatus
 from .exceptions import DeviceException
 
 _LOGGER = logging.getLogger(__name__)
@@ -13,7 +13,7 @@ class WifiRepeaterException(DeviceException):
     pass
 
 
-class WifiRepeaterStatus:
+class WifiRepeaterStatus(DeviceStatus):
     def __init__(self, data):
         """
         Response of a xiaomi.repeater.v2:
@@ -47,7 +47,7 @@ class WifiRepeaterStatus:
         return s
 
 
-class WifiRepeaterConfiguration:
+class WifiRepeaterConfiguration(DeviceStatus):
     def __init__(self, data):
         """Response of a xiaomi.repeater.v2:
 
@@ -66,14 +66,6 @@ class WifiRepeaterConfiguration:
     @property
     def ssid_hidden(self) -> bool:
         return self.data["hidden"] == 1
-
-    def __repr__(self) -> str:
-        s = (
-            "<WifiRepeaterConfiguration ssid=%s, "
-            "password=%s, "
-            "ssid_hidden=%s>" % (self.ssid, self.password, self.ssid_hidden)
-        )
-        return s
 
 
 class WifiRepeater(Device):

--- a/miio/wifispeaker.py
+++ b/miio/wifispeaker.py
@@ -5,7 +5,7 @@ import warnings
 import click
 
 from .click_common import command, format_output
-from .device import Device
+from .device import Device, DeviceStatus
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,7 +28,7 @@ class TransportChannel(enum.Enum):
     Qplay = "QPLAY"
 
 
-class WifiSpeakerStatus:
+class WifiSpeakerStatus(DeviceStatus):
     """Container of a speaker state.
 
     This contains information such as the name of the device, and what is currently
@@ -90,33 +90,6 @@ class WifiSpeakerStatus:
     def transport_channel(self) -> TransportChannel:
         """Transport channel, e.g. PLAYLIST."""
         return TransportChannel(self.data["transport_channel"])
-
-    def __repr__(self) -> str:
-        s = (
-            "<WifiSpeakerStatus "
-            "device_name=%s, "
-            "channel=%s, "
-            "state=%s, "
-            "play_mode=%s, "
-            "track_artist=%s, "
-            "track_title=%s, "
-            "track_duration=%s, "
-            "transport_channel=%s, "
-            "hardware_version=%s>"
-            % (
-                self.device_name,
-                self.channel,
-                self.state,
-                self.play_mode,
-                self.track_artist,
-                self.track_title,
-                self.track_duration,
-                self.transport_channel,
-                self.hardware_version,
-            )
-        )
-
-        return s
 
 
 class WifiSpeaker(Device):

--- a/miio/yeelight.py
+++ b/miio/yeelight.py
@@ -5,7 +5,7 @@ from typing import Optional, Tuple
 import click
 
 from .click_common import command, format_output
-from .device import Device
+from .device import Device, DeviceStatus
 from .exceptions import DeviceException
 from .utils import int_to_rgb, rgb_to_int
 
@@ -20,7 +20,7 @@ class YeelightMode(IntEnum):
     HSV = 3
 
 
-class YeelightStatus:
+class YeelightStatus(DeviceStatus):
     def __init__(self, data):
         # ['power', 'bright', 'ct',   'rgb',      'hue', 'sat', 'color_mode', 'name', 'lan_ctrl', 'save_state']
         # ['on',    '100',    '3584', '16711680', '359', '100', '2',          'name', '1',        '1']
@@ -81,24 +81,6 @@ class YeelightStatus:
     def name(self) -> str:
         """Return the internal name of the bulb."""
         return self.data["name"]
-
-    def __repr__(self):
-        s = (
-            "<Yeelight on=%s mode=%s brightness=%s color_temp=%s "
-            "rgb=%s hsv=%s dev=%s save_state=%s name=%s>"
-            % (
-                self.is_on,
-                self.color_mode,
-                self.brightness,
-                self.color_temp,
-                self.rgb,
-                self.hsv,
-                self.developer_mode,
-                self.save_state_on_change,
-                self.name,
-            )
-        )
-        return s
 
 
 class Yeelight(Device):

--- a/miio/yeelight_dual_switch.py
+++ b/miio/yeelight_dual_switch.py
@@ -5,7 +5,7 @@ import click
 
 from .click_common import EnumType, command, format_output
 from .exceptions import DeviceException
-from .miot_device import MiotDevice
+from .miot_device import DeviceStatus, MiotDevice
 
 
 class YeelightDualControlModuleException(DeviceException):
@@ -36,7 +36,7 @@ _MAPPING = {
 }
 
 
-class DualControlModuleStatus:
+class DualControlModuleStatus(DeviceStatus):
     def __init__(self, data: Dict[str, Any]) -> None:
         """
         Response of Yeelight Dual Control Module
@@ -101,32 +101,6 @@ class DualControlModuleStatus:
     def rc_list(self) -> str:
         """List of paired remote controls."""
         return self.data["rc_list"]
-
-    def __repr__(self) -> str:
-        s = (
-            "<YeelightDualControlModuleStatus "
-            "switch_1_state=%s, "
-            "switch_1_default_state=%s, "
-            "switch_1_off_delay=%s, "
-            "switch_2_state=%s, "
-            "switch_2_default_state=%s, "
-            "switch_2_off_delay=%s, "
-            "interlock=%s, "
-            "flex_mode=%s, "
-            "rc_list=%s>"
-            % (
-                self.switch_1_state,
-                self.switch_1_default_state,
-                self.switch_1_off_delay,
-                self.switch_2_state,
-                self.switch_2_default_state,
-                self.switch_2_off_delay,
-                self.interlock,
-                self.flex_mode,
-                self.rc_list,
-            )
-        )
-        return s
 
 
 class YeelightDualControlModule(MiotDevice):


### PR DESCRIPTION
* Implements `__repr__` to return the usual pretty repr with all defined properties
* Special cases can override this behavior if really needed.

Prints out currently also properties returning `None`, opinions?
Another thing is that the order of elements in the response is not guaranteed, but no one should not be parsing these anyway, so I think it's a non-issue.