### PR TITLE
Replaced typing by pyyaml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,6 +71,10 @@ stages:
           python.version: '3.8'
           vmImage: 'ubuntu-latest'
 
+        Python 3.9 Ubuntu:
+          python.version: '3.9'
+          vmImage: 'ubuntu-latest'
+
         PyPy Ubuntu:
           python.version: pypy3
           vmImage: 'ubuntu-latest'
@@ -87,6 +91,10 @@ stages:
           python.version: '3.8'
           vmImage: 'windows-latest'
 
+        Python 3.9 Windows:
+          python.version: '3.9'
+          vmImage: 'windows-latest'
+
         Python 3.6 OSX:
           python.version: '3.6'
           vmImage: 'macOS-latest'
@@ -97,6 +105,10 @@ stages:
 
         Python 3.8 OSX:
           python.version: '3.8'
+          vmImage: 'macOS-latest'
+
+        Python 3.9 OSX:
+          python.version: '3.9'
           vmImage: 'macOS-latest'
 
     pool:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py36,py37,py38,lint,typing,docs,pypi-description
+envlist=py36,py37,py38,py39,lint,typing,docs,pypi-description
 skip_missing_interpreters = True
 isolated_build = True
 
@@ -7,6 +7,7 @@ isolated_build = True
 3.6 = py36
 3.7 = py37
 3.8 = py38
+3.9 = py39
 
 [testenv]
 deps=
@@ -14,7 +15,7 @@ deps=
   pytest-cov
   pytest-mock
   voluptuous
-  typing
+  pyyaml
   flake8
   coverage[toml]
   importlib_metadata
@@ -27,6 +28,7 @@ extras=docs
 deps=
   sphinx
   doc8
+  pyyaml
   restructuredtext_lint
   sphinx-autodoc-typehints
   sphinx-click


### PR DESCRIPTION
When using typing with python 3.8 i can not run tox. I am getting the following error:

`AttributeError: type object 'Callable' has no attribute '_abc_registry'`

According to the documenation on https://pypi.org/project/typing/ typing should only by included in projects using python < 3.5. This pull request fixes my build.
