### PR TITLE
Fix the logic of staring cleaning a room for Viomi

### DIFF
--- a/miio/viomivacuum.py
+++ b/miio/viomivacuum.py
@@ -630,9 +630,9 @@ class ViomiVacuum(Device):
         room_ids = []
         for room in rooms:
             if room in self._cache["rooms"]:
-                room_ids.append(room)
+                room_ids.append(int(room))
             elif room in reverse_rooms:
-                room_ids.append(reverse_rooms[room])
+                room_ids.append(int(reverse_rooms[room]))
             else:
                 room_keys = ", ".join(self._cache["rooms"].keys())
                 room_ids = ", ".join(self._cache["rooms"].values())
@@ -641,7 +641,7 @@ class ViomiVacuum(Device):
         self._cache["edge_state"] = self.get_properties(["mode"])
         self.send(
             "set_mode_withroom",
-            self._cache["edge_state"] + [1, 0, len(room_ids)] + room_ids,
+            self._cache["edge_state"] + [1, len(room_ids)] + room_ids,
         )
 
     @command()


### PR DESCRIPTION
Found an issue in `miio/viomivacuum.py start_with_room()`

Lines 633 and 635: the `room_ids` is being appended and passed to vacuum as a string, that the vacuum doesn't understand.

Line 642: According to the description in the method `start()` the params `[0, 1, 3, 11, 12, 13]` = start cleaning rooms 11-13, but the line 642 build the line `[0, 1, 0, 3, 11, 12, 13]`, that means that the length of the room ids array is 0. That makes the vacuum to make a full cleaning instead of cleaning a room.