### PR TITLE
vacuum: second try to fix the timezone returning an integer

### DIFF
--- a/miio/tests/test_vacuum.py
+++ b/miio/tests/test_vacuum.py
@@ -166,5 +166,5 @@ class TestVacuum(TestCase):
         with patch.object(self.device, "send", return_value=["Europe/Berlin"]):
             assert self.device.timezone() == "Europe/Berlin"
 
-        with patch.object(self.device, "send", return_value=[0]):
+        with patch.object(self.device, "send", return_value=0):
             assert self.device.timezone() == "UTC"

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -598,7 +598,7 @@ class Vacuum(Device):
     @command()
     def timezone(self):
         """Get the timezone."""
-        res = self.send("get_timezone")[0]
+        res = self.send("get_timezone")
 
         def _fallback_timezone(data):
             fallback = "UTC"
@@ -609,6 +609,8 @@ class Vacuum(Device):
 
         if isinstance(res, int):
             return _fallback_timezone(res)
+
+        res = res[0]
         if isinstance(res, dict):
             # Xiaowa E25 example
             # {'olson': 'Europe/Berlin', 'posix': 'CET-1CEST,M3.5.0,M10.5.0/3'}
@@ -617,7 +619,6 @@ class Vacuum(Device):
 
             return res["olson"]
 
-        # Gen1 vacuum: ['Europe/Berlin']
         return res
 
     def set_timezone(self, new_zone):


### PR DESCRIPTION
The device returns an integer without boxing it inside a list, this should fix #921