### PR TITLE
Allow subnet to be specified for broadcast

### DIFF
--- a/miio/miioprotocol.py
+++ b/miio/miioprotocol.py
@@ -62,7 +62,7 @@ class MiIOProtocol:
         :raises DeviceException: if the device could not be discovered after retries.
         """
         try:
-            m = MiIOProtocol.discover(self.ip)
+            m = MiIOProtocol.discover(self.ip, is_broadcast=False)
         except DeviceException as ex:
             if retry_count > 0:
                 return self.send_handshake(retry_count=retry_count - 1)
@@ -90,7 +90,7 @@ class MiIOProtocol:
         return m
 
     @staticmethod
-    def discover(addr: str = None, timeout: int = 5) -> Any:
+    def discover(addr: str = None, is_broadcast: bool = True, timeout: int = 5) -> Any:
         """Scan for devices in the network. This method is used to discover supported
         devices by sending a handshake message to the broadcast address on port 54321.
         If the target IP address is given, the handshake will be send as an unicast
@@ -98,10 +98,10 @@ class MiIOProtocol:
 
         :param str addr: Target IP address
         """
-        is_broadcast = addr is None
         seen_addrs = []  # type: List[str]
         if is_broadcast:
-            addr = "<broadcast>"
+            if not addr:
+                addr = "<broadcast>"
             is_broadcast = True
             _LOGGER.info("Sending discovery to %s with timeout of %ss..", addr, timeout)
         # magic, length 32

--- a/miio/vacuum_cli.py
+++ b/miio/vacuum_cli.py
@@ -97,10 +97,11 @@ def cleanup(vac: miio.Vacuum, *args, **kwargs):
 
 @cli.command()
 @click.option("--handshake", type=bool, default=False)
-def discover(handshake):
+@click.option("--subnet", type=str, default="<broadcast>")
+def discover(handshake, subnet):
     """Search for robots in the network."""
     if handshake:
-        MiIOProtocol.discover()
+        MiIOProtocol.discover(subnet, is_broadcast=True)
     else:
         miio.Discovery.discover_mdns()
 


### PR DESCRIPTION
This is to address issue #584 - discover doesn't work on Windows unless you specify the correct interface's subnet.