### PR TITLE
Fix another typo in the docs

### DIFF
--- a/docs/discovery.rst
+++ b/docs/discovery.rst
@@ -267,7 +267,7 @@ Tokens from rooted device
 
 If a device is rooted via `dustcloud <https://github.com/dgiese/dustcloud>`_ (e.g. for running the cloud-free control webinterface `Valetudo <https://valetudo.cloud/>`_), the token can be extracted by connecting to the device via SSH and reading the file: :code:`printf $(cat /mnt/data/miio/device.token) | xxd -p`
 
-See also `"How can I get the token from the robots FileSystem?" in the FAQ for Veltudo <https://valetudo.cloud/pages/faq.html#how-can-i-get-the-token-from-the-robots-filesystem>`_.
+See also `"How can I get the token from the robots FileSystem?" in the FAQ for Valetudo <https://valetudo.cloud/pages/faq.html#how-can-i-get-the-token-from-the-robots-filesystem>`_.
 
 Environment variables for command-line tools
 ============================================


### PR DESCRIPTION
Valetudo is misspelled in the docs. This PR hopefully fixes the last remaining typo introduced in PR #966.