### PR TITLE
Prepare 0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,103 @@
 # Change Log
 
+## [0.5.5](https://github.com/rytilahti/python-miio/tree/0.5.5) (2021-03-13)
+
+This release adds support for several new devices, and contains improvements and fixes on several existing integrations.
+Instead of summarizing all changes here, this library seeks to move completely automated changelogs based on the pull request tags to facilitate faster release cycles.
+Until that happens, the full list of changes is listed below as usual.
+
+[Full Changelog](https://github.com/rytilahti/python-miio/compare/0.5.4...0.5.5)
+
+**Implemented enhancements:**
+
+- Connecting from external network [\#931](https://github.com/rytilahti/python-miio/issues/931)
+- Filter out value 1 from the property AQI [\#925](https://github.com/rytilahti/python-miio/issues/925)
+- Any plans on supporting Air Detector Lite PM2.5? [\#879](https://github.com/rytilahti/python-miio/issues/879)
+- Get possible device commands/arguments via API [\#846](https://github.com/rytilahti/python-miio/issues/846)
+- Add support for xiaomi scishare coffee machine [\#833](https://github.com/rytilahti/python-miio/issues/833)
+- Make netifaces optional dependency [\#970](https://github.com/rytilahti/python-miio/pull/970) ([rytilahti](https://github.com/rytilahti))
+- Unify subdevice types [\#947](https://github.com/rytilahti/python-miio/pull/947) ([starkillerOG](https://github.com/starkillerOG))
+- Cleanup: add DeviceStatus to simplify status containers [\#941](https://github.com/rytilahti/python-miio/pull/941) ([rytilahti](https://github.com/rytilahti))
+- add method to load subdevices from dict \(EU gateway support\) [\#936](https://github.com/rytilahti/python-miio/pull/936) ([starkillerOG](https://github.com/starkillerOG))
+- Refactor & improve support for gateway devices [\#924](https://github.com/rytilahti/python-miio/pull/924) ([starkillerOG](https://github.com/starkillerOG))
+- Add docformatter to pre-commit hooks [\#914](https://github.com/rytilahti/python-miio/pull/914) ([rytilahti](https://github.com/rytilahti))
+- Improve MiotDevice API \(get\_property\_by, set\_property\_by, call\_action, call\_action\_by\) [\#905](https://github.com/rytilahti/python-miio/pull/905) ([rytilahti](https://github.com/rytilahti))
+- Stopgap fix for miottemplate [\#902](https://github.com/rytilahti/python-miio/pull/902) ([rytilahti](https://github.com/rytilahti))
+- Support resume\_or\_start for vacuum's segment cleaning [\#894](https://github.com/rytilahti/python-miio/pull/894) ([Sian-Lee-SA](https://github.com/Sian-Lee-SA))
+- Add missing annotations for ViomiVacuum [\#872](https://github.com/rytilahti/python-miio/pull/872) ([dominikkarall](https://github.com/dominikkarall))
+- Add generic \_\_repr\_\_ for Device class [\#869](https://github.com/rytilahti/python-miio/pull/869) ([rytilahti](https://github.com/rytilahti))
+- Set timeout as parameter [\#866](https://github.com/rytilahti/python-miio/pull/866) ([titilambert](https://github.com/titilambert))
+- Improve Viomi support \(status reporting, maps\) [\#808](https://github.com/rytilahti/python-miio/pull/808) ([titilambert](https://github.com/titilambert))
+
+**Fixed bugs:**
+
+- Make netifaces optional dependency [\#964](https://github.com/rytilahti/python-miio/issues/964)
+- Some errors in miio/airdehumidifier.py [\#960](https://github.com/rytilahti/python-miio/issues/960)
+- Roborock S5 Max not discovered [\#944](https://github.com/rytilahti/python-miio/issues/944)
+- Vacuum timezone returns 'int' object is not subscriptable [\#921](https://github.com/rytilahti/python-miio/issues/921)
+- discover\_devices doesnt work with xiaomi gateway v3 [\#916](https://github.com/rytilahti/python-miio/issues/916)
+- Can control but not get info from the vacuum [\#912](https://github.com/rytilahti/python-miio/issues/912)
+- airhumidifier\_miot.py - mapping attribute error [\#911](https://github.com/rytilahti/python-miio/issues/911)
+- Xiaomi Humidifier CA4 fail to read status. \(zhimi.humidifier.ca4\) [\#908](https://github.com/rytilahti/python-miio/issues/908)
+- miottemplate.py print specs.json fails [\#906](https://github.com/rytilahti/python-miio/issues/906)
+- Miiocli and Airdog appliance [\#892](https://github.com/rytilahti/python-miio/issues/892)
+- ServiceInfo has no attribute 'address' in miio/discovery [\#891](https://github.com/rytilahti/python-miio/issues/891)
+- Devtools exception miottemplate.py generate [\#885](https://github.com/rytilahti/python-miio/issues/885)
+- Issue with Xiaomi Miio gateway Integrations ZNDMWG03LM [\#864](https://github.com/rytilahti/python-miio/issues/864)
+- Xiaomi Mi Robot Vacuum V1 - Fan Speed Issue [\#860](https://github.com/rytilahti/python-miio/issues/860)
+- Xiaomi Smartmi Evaporation Air Humidifier 2 \(zhimi.humidifier.ca4\) [\#859](https://github.com/rytilahti/python-miio/issues/859)
+- Report more specific exception when airdehumidifer is off [\#963](https://github.com/rytilahti/python-miio/pull/963) ([rytilahti](https://github.com/rytilahti))
+- vacuum: second try to fix the timezone returning an integer [\#949](https://github.com/rytilahti/python-miio/pull/949) ([rytilahti](https://github.com/rytilahti))
+- Fix the logic of staring cleaning a room for Viomi [\#946](https://github.com/rytilahti/python-miio/pull/946) ([AlexAlexPin](https://github.com/AlexAlexPin))
+- vacuum: skip pausing on s50 and s6 maxv before return home call [\#933](https://github.com/rytilahti/python-miio/pull/933) ([rytilahti](https://github.com/rytilahti))
+- Fix airpurifier\_airdog x5 and x7sm to derive from the x3 base class [\#903](https://github.com/rytilahti/python-miio/pull/903) ([rytilahti](https://github.com/rytilahti))
+- Fix discovery for python-zeroconf 0.28+ [\#898](https://github.com/rytilahti/python-miio/pull/898) ([rytilahti](https://github.com/rytilahti))
+- Vacuum: add fan speed preset for gen1 firmwares 3.5.8+ [\#893](https://github.com/rytilahti/python-miio/pull/893) ([mat4444](https://github.com/mat4444))
+
+**Closed issues:**
+
+- miiocli command not found [\#956](https://github.com/rytilahti/python-miio/issues/956)
+- \[Roborock S6 MaxV\] Need a delay between pause and charge commands to return to dock [\#918](https://github.com/rytilahti/python-miio/issues/918)
+- Support for Xiaomi Air purifier 3C [\#888](https://github.com/rytilahti/python-miio/issues/888)
+- zhimi.heater.mc2 not fully supported [\#880](https://github.com/rytilahti/python-miio/issues/880)
+- Support for leshow.fan.ss4 \(xiaomi Rosou SS4 Ventilator\) [\#806](https://github.com/rytilahti/python-miio/issues/806)
+- Constant spam of: Unable to discover a device at address \[IP\] and Got exception while fetching the state: Unable to discover the device \[IP\] [\#407](https://github.com/rytilahti/python-miio/issues/407)
+- Add documentation for miiocli [\#400](https://github.com/rytilahti/python-miio/issues/400)
+
+**Merged pull requests:**
+
+- Fix another typo in the docs [\#968](https://github.com/rytilahti/python-miio/pull/968) ([muellermartin](https://github.com/muellermartin))
+- Fix link to API documentation [\#967](https://github.com/rytilahti/python-miio/pull/967) ([muellermartin](https://github.com/muellermartin))
+- Add section for getting tokens from rooted devices [\#966](https://github.com/rytilahti/python-miio/pull/966) ([muellermartin](https://github.com/muellermartin))
+- Improve airpurifier doc strings by adding raw responses [\#961](https://github.com/rytilahti/python-miio/pull/961) ([arturdobo](https://github.com/arturdobo))
+- Add troubleshooting for Roborock app [\#954](https://github.com/rytilahti/python-miio/pull/954) ([lyghtnox](https://github.com/lyghtnox))
+- Initial support for Vacuum 1C STYTJ01ZHM \(dreame.vacuum.mc1808\) [\#952](https://github.com/rytilahti/python-miio/pull/952) ([legacycode](https://github.com/legacycode))
+- Replaced typing by pyyaml [\#945](https://github.com/rytilahti/python-miio/pull/945) ([legacycode](https://github.com/legacycode))
+- janitoring: add bandit to pre-commit checks [\#940](https://github.com/rytilahti/python-miio/pull/940) ([rytilahti](https://github.com/rytilahti))
+- vacuum: fallback to UTC when encountering unknown timezone response [\#932](https://github.com/rytilahti/python-miio/pull/932) ([rytilahti](https://github.com/rytilahti))
+- \[miot air purifier\] Return None if aqi is 1 [\#930](https://github.com/rytilahti/python-miio/pull/930) ([bieniu](https://github.com/bieniu))
+- added support for zhimi.humidifier.cb2 [\#917](https://github.com/rytilahti/python-miio/pull/917) ([sannoob](https://github.com/sannoob))
+- Include some more flake8 checks [\#915](https://github.com/rytilahti/python-miio/pull/915) ([rytilahti](https://github.com/rytilahti))
+- Improve miottemplate.py print to support python 3.7.3 \(Closes: \#906\) [\#910](https://github.com/rytilahti/python-miio/pull/910) ([syssi](https://github.com/syssi))
+- Fix \_\_repr\_\_ of AirHumidifierMiotStatus \(Closes: \#908\) [\#909](https://github.com/rytilahti/python-miio/pull/909) ([syssi](https://github.com/syssi))
+- Add clean mode \(new feature\) to the zhimi.humidifier.ca4 [\#907](https://github.com/rytilahti/python-miio/pull/907) ([syssi](https://github.com/syssi))
+- Allow downloading miot spec files by model for miottemplate [\#904](https://github.com/rytilahti/python-miio/pull/904) ([rytilahti](https://github.com/rytilahti))
+- Add Qingping Air Monitor Lite support \(cgllc.airm.cgdn1\) [\#900](https://github.com/rytilahti/python-miio/pull/900) ([arturdobo](https://github.com/arturdobo))
+- Add support for Xiaomi Air purifier 3C  [\#899](https://github.com/rytilahti/python-miio/pull/899) ([arturdobo](https://github.com/arturdobo))
+- Add support for zhimi.heater.mc2 [\#895](https://github.com/rytilahti/python-miio/pull/895) ([bafonins](https://github.com/bafonins))
+- Add support for Yeelight Dual Control Module \(yeelink.switch.sw1\) [\#887](https://github.com/rytilahti/python-miio/pull/887) ([IhorSyerkov](https://github.com/IhorSyerkov))
+- Retry and timeout can be change by setting a class attribute [\#884](https://github.com/rytilahti/python-miio/pull/884) ([titilambert](https://github.com/titilambert))
+- Add support for all Huizuo Lamps \(w/ fans, heaters, and scenes\) [\#881](https://github.com/rytilahti/python-miio/pull/881) ([darckly](https://github.com/darckly))
+- Add deerma.humidifier.jsq support [\#878](https://github.com/rytilahti/python-miio/pull/878) ([syssi](https://github.com/syssi))
+- Export MiotDevice for miio module [\#876](https://github.com/rytilahti/python-miio/pull/876) ([syssi](https://github.com/syssi))
+- Add missing "info" to device information query [\#873](https://github.com/rytilahti/python-miio/pull/873) ([rytilahti](https://github.com/rytilahti))
+- Add Rosou SS4 Ventilator \(leshow.fan.ss4\) support [\#871](https://github.com/rytilahti/python-miio/pull/871) ([syssi](https://github.com/syssi))
+- Initial support for HUIZUO PISCES For Bedroom [\#868](https://github.com/rytilahti/python-miio/pull/868) ([darckly](https://github.com/darckly))
+- Add airdog.airpurifier.{x3,x5,x7sm} support [\#865](https://github.com/rytilahti/python-miio/pull/865) ([syssi](https://github.com/syssi))
+- Add dmaker.airfresh.a1 support [\#862](https://github.com/rytilahti/python-miio/pull/862) ([syssi](https://github.com/syssi))
+- Add support for Scishare coffee maker \(scishare.coffee.s1102\) [\#858](https://github.com/rytilahti/python-miio/pull/858) ([rytilahti](https://github.com/rytilahti))
+
+
 ## [0.5.4](https://github.com/rytilahti/python-miio/tree/0.5.4) (2020-11-15)
 
 New devices:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "python-miio"
-version = "0.5.4"
+version = "0.5.5"
 description = "Python library for interfacing with Xiaomi smart appliances"
 authors = ["Teemu R <tpr@iki.fi>"]
 repository = "https://github.com/rytilahti/python-miio"


### PR DESCRIPTION
## [0.5.5](https://github.com/rytilahti/python-miio/tree/0.5.5) (2021-03-13)

This release adds support for several new devices, and contains improvements and fixes on several existing integrations.
Instead of summarizing all changes here, this library seeks to move completely automated changelogs based on the pull request tags to facilitate faster release cycles.
Until that happens, the full list of changes is listed below as usual.

[Full Changelog](https://github.com/rytilahti/python-miio/compare/0.5.4...0.5.5)

**Implemented enhancements:**

- Connecting from external network [\#931](https://github.com/rytilahti/python-miio/issues/931)
- Filter out value 1 from the property AQI [\#925](https://github.com/rytilahti/python-miio/issues/925)
- Any plans on supporting Air Detector Lite PM2.5? [\#879](https://github.com/rytilahti/python-miio/issues/879)
- Get possible device commands/arguments via API [\#846](https://github.com/rytilahti/python-miio/issues/846)
- Add support for xiaomi scishare coffee machine [\#833](https://github.com/rytilahti/python-miio/issues/833)
- Make netifaces optional dependency [\#970](https://github.com/rytilahti/python-miio/pull/970) ([rytilahti](https://github.com/rytilahti))
- Unify subdevice types [\#947](https://github.com/rytilahti/python-miio/pull/947) ([starkillerOG](https://github.com/starkillerOG))
- Cleanup: add DeviceStatus to simplify status containers [\#941](https://github.com/rytilahti/python-miio/pull/941) ([rytilahti](https://github.com/rytilahti))
- add method to load subdevices from dict \(EU gateway support\) [\#936](https://github.com/rytilahti/python-miio/pull/936) ([starkillerOG](https://github.com/starkillerOG))
- Refactor & improve support for gateway devices [\#924](https://github.com/rytilahti/python-miio/pull/924) ([starkillerOG](https://github.com/starkillerOG))
- Add docformatter to pre-commit hooks [\#914](https://github.com/rytilahti/python-miio/pull/914) ([rytilahti](https://github.com/rytilahti))
- Improve MiotDevice API \(get\_property\_by, set\_property\_by, call\_action, call\_action\_by\) [\#905](https://github.com/rytilahti/python-miio/pull/905) ([rytilahti](https://github.com/rytilahti))
- Stopgap fix for miottemplate [\#902](https://github.com/rytilahti/python-miio/pull/902) ([rytilahti](https://github.com/rytilahti))
- Support resume\_or\_start for vacuum's segment cleaning [\#894](https://github.com/rytilahti/python-miio/pull/894) ([Sian-Lee-SA](https://github.com/Sian-Lee-SA))
- Add missing annotations for ViomiVacuum [\#872](https://github.com/rytilahti/python-miio/pull/872) ([dominikkarall](https://github.com/dominikkarall))
- Add generic \_\_repr\_\_ for Device class [\#869](https://github.com/rytilahti/python-miio/pull/869) ([rytilahti](https://github.com/rytilahti))
- Set timeout as parameter [\#866](https://github.com/rytilahti/python-miio/pull/866) ([titilambert](https://github.com/titilambert))
- Improve Viomi support \(status reporting, maps\) [\#808](https://github.com/rytilahti/python-miio/pull/808) ([titilambert](https://github.com/titilambert))

**Fixed bugs:**

- Make netifaces optional dependency [\#964](https://github.com/rytilahti/python-miio/issues/964)
- Some errors in miio/airdehumidifier.py [\#960](https://github.com/rytilahti/python-miio/issues/960)
- Roborock S5 Max not discovered [\#944](https://github.com/rytilahti/python-miio/issues/944)
- Vacuum timezone returns 'int' object is not subscriptable [\#921](https://github.com/rytilahti/python-miio/issues/921)
- discover\_devices doesnt work with xiaomi gateway v3 [\#916](https://github.com/rytilahti/python-miio/issues/916)
- Can control but not get info from the vacuum [\#912](https://github.com/rytilahti/python-miio/issues/912)
- airhumidifier\_miot.py - mapping attribute error [\#911](https://github.com/rytilahti/python-miio/issues/911)
- Xiaomi Humidifier CA4 fail to read status. \(zhimi.humidifier.ca4\) [\#908](https://github.com/rytilahti/python-miio/issues/908)
- miottemplate.py print specs.json fails [\#906](https://github.com/rytilahti/python-miio/issues/906)
- Miiocli and Airdog appliance [\#892](https://github.com/rytilahti/python-miio/issues/892)
- ServiceInfo has no attribute 'address' in miio/discovery [\#891](https://github.com/rytilahti/python-miio/issues/891)
- Devtools exception miottemplate.py generate [\#885](https://github.com/rytilahti/python-miio/issues/885)
- Issue with Xiaomi Miio gateway Integrations ZNDMWG03LM [\#864](https://github.com/rytilahti/python-miio/issues/864)
- Xiaomi Mi Robot Vacuum V1 - Fan Speed Issue [\#860](https://github.com/rytilahti/python-miio/issues/860)
- Xiaomi Smartmi Evaporation Air Humidifier 2 \(zhimi.humidifier.ca4\) [\#859](https://github.com/rytilahti/python-miio/issues/859)
- Report more specific exception when airdehumidifer is off [\#963](https://github.com/rytilahti/python-miio/pull/963) ([rytilahti](https://github.com/rytilahti))
- vacuum: second try to fix the timezone returning an integer [\#949](https://github.com/rytilahti/python-miio/pull/949) ([rytilahti](https://github.com/rytilahti))
- Fix the logic of staring cleaning a room for Viomi [\#946](https://github.com/rytilahti/python-miio/pull/946) ([AlexAlexPin](https://github.com/AlexAlexPin))
- vacuum: skip pausing on s50 and s6 maxv before return home call [\#933](https://github.com/rytilahti/python-miio/pull/933) ([rytilahti](https://github.com/rytilahti))
- Fix airpurifier\_airdog x5 and x7sm to derive from the x3 base class [\#903](https://github.com/rytilahti/python-miio/pull/903) ([rytilahti](https://github.com/rytilahti))
- Fix discovery for python-zeroconf 0.28+ [\#898](https://github.com/rytilahti/python-miio/pull/898) ([rytilahti](https://github.com/rytilahti))
- Vacuum: add fan speed preset for gen1 firmwares 3.5.8+ [\#893](https://github.com/rytilahti/python-miio/pull/893) ([mat4444](https://github.com/mat4444))

**Closed issues:**

- miiocli command not found [\#956](https://github.com/rytilahti/python-miio/issues/956)
- \[Roborock S6 MaxV\] Need a delay between pause and charge commands to return to dock [\#918](https://github.com/rytilahti/python-miio/issues/918)
- Support for Xiaomi Air purifier 3C [\#888](https://github.com/rytilahti/python-miio/issues/888)
- zhimi.heater.mc2 not fully supported [\#880](https://github.com/rytilahti/python-miio/issues/880)
- Support for leshow.fan.ss4 \(xiaomi Rosou SS4 Ventilator\) [\#806](https://github.com/rytilahti/python-miio/issues/806)
- Constant spam of: Unable to discover a device at address \[IP\] and Got exception while fetching the state: Unable to discover the device \[IP\] [\#407](https://github.com/rytilahti/python-miio/issues/407)
- Add documentation for miiocli [\#400](https://github.com/rytilahti/python-miio/issues/400)

**Merged pull requests:**

- Fix another typo in the docs [\#968](https://github.com/rytilahti/python-miio/pull/968) ([muellermartin](https://github.com/muellermartin))
- Fix link to API documentation [\#967](https://github.com/rytilahti/python-miio/pull/967) ([muellermartin](https://github.com/muellermartin))
- Add section for getting tokens from rooted devices [\#966](https://github.com/rytilahti/python-miio/pull/966) ([muellermartin](https://github.com/muellermartin))
- Improve airpurifier doc strings by adding raw responses [\#961](https://github.com/rytilahti/python-miio/pull/961) ([arturdobo](https://github.com/arturdobo))
- Add troubleshooting for Roborock app [\#954](https://github.com/rytilahti/python-miio/pull/954) ([lyghtnox](https://github.com/lyghtnox))
- Initial support for Vacuum 1C STYTJ01ZHM \(dreame.vacuum.mc1808\) [\#952](https://github.com/rytilahti/python-miio/pull/952) ([legacycode](https://github.com/legacycode))
- Replaced typing by pyyaml [\#945](https://github.com/rytilahti/python-miio/pull/945) ([legacycode](https://github.com/legacycode))
- janitoring: add bandit to pre-commit checks [\#940](https://github.com/rytilahti/python-miio/pull/940) ([rytilahti](https://github.com/rytilahti))
- vacuum: fallback to UTC when encountering unknown timezone response [\#932](https://github.com/rytilahti/python-miio/pull/932) ([rytilahti](https://github.com/rytilahti))
- \[miot air purifier\] Return None if aqi is 1 [\#930](https://github.com/rytilahti/python-miio/pull/930) ([bieniu](https://github.com/bieniu))
- added support for zhimi.humidifier.cb2 [\#917](https://github.com/rytilahti/python-miio/pull/917) ([sannoob](https://github.com/sannoob))
- Include some more flake8 checks [\#915](https://github.com/rytilahti/python-miio/pull/915) ([rytilahti](https://github.com/rytilahti))
- Improve miottemplate.py print to support python 3.7.3 \(Closes: \#906\) [\#910](https://github.com/rytilahti/python-miio/pull/910) ([syssi](https://github.com/syssi))
- Fix \_\_repr\_\_ of AirHumidifierMiotStatus \(Closes: \#908\) [\#909](https://github.com/rytilahti/python-miio/pull/909) ([syssi](https://github.com/syssi))
- Add clean mode \(new feature\) to the zhimi.humidifier.ca4 [\#907](https://github.com/rytilahti/python-miio/pull/907) ([syssi](https://github.com/syssi))
- Allow downloading miot spec files by model for miottemplate [\#904](https://github.com/rytilahti/python-miio/pull/904) ([rytilahti](https://github.com/rytilahti))
- Add Qingping Air Monitor Lite support \(cgllc.airm.cgdn1\) [\#900](https://github.com/rytilahti/python-miio/pull/900) ([arturdobo](https://github.com/arturdobo))
- Add support for Xiaomi Air purifier 3C  [\#899](https://github.com/rytilahti/python-miio/pull/899) ([arturdobo](https://github.com/arturdobo))
- Add support for zhimi.heater.mc2 [\#895](https://github.com/rytilahti/python-miio/pull/895) ([bafonins](https://github.com/bafonins))
- Add support for Yeelight Dual Control Module \(yeelink.switch.sw1\) [\#887](https://github.com/rytilahti/python-miio/pull/887) ([IhorSyerkov](https://github.com/IhorSyerkov))
- Retry and timeout can be change by setting a class attribute [\#884](https://github.com/rytilahti/python-miio/pull/884) ([titilambert](https://github.com/titilambert))
- Add support for all Huizuo Lamps \(w/ fans, heaters, and scenes\) [\#881](https://github.com/rytilahti/python-miio/pull/881) ([darckly](https://github.com/darckly))
- Add deerma.humidifier.jsq support [\#878](https://github.com/rytilahti/python-miio/pull/878) ([syssi](https://github.com/syssi))
- Export MiotDevice for miio module [\#876](https://github.com/rytilahti/python-miio/pull/876) ([syssi](https://github.com/syssi))
- Add missing "info" to device information query [\#873](https://github.com/rytilahti/python-miio/pull/873) ([rytilahti](https://github.com/rytilahti))
- Add Rosou SS4 Ventilator \(leshow.fan.ss4\) support [\#871](https://github.com/rytilahti/python-miio/pull/871) ([syssi](https://github.com/syssi))
- Initial support for HUIZUO PISCES For Bedroom [\#868](https://github.com/rytilahti/python-miio/pull/868) ([darckly](https://github.com/darckly))
- Add airdog.airpurifier.{x3,x5,x7sm} support [\#865](https://github.com/rytilahti/python-miio/pull/865) ([syssi](https://github.com/syssi))
- Add dmaker.airfresh.a1 support [\#862](https://github.com/rytilahti/python-miio/pull/862) ([syssi](https://github.com/syssi))
- Add support for Scishare coffee maker \(scishare.coffee.s1102\) [\#858](https://github.com/rytilahti/python-miio/pull/858) ([rytilahti](https://github.com/rytilahti))