### PR TITLE
Add support for Walkingpad A1 (ksmb.walkingpad.v3)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -133,6 +133,7 @@ Supported devices
 -  Yeelight Dual Control Module (yeelink.switch.sw1)
 -  Scishare coffee maker (scishare.coffee.s1102)
 -  Qingping Air Monitor Lite (cgllc.airm.cgdn1)
+-  Xiaomi Walkingpad A1 (ksmb.walkingpad.v3)
 
 
 *Feel free to create a pull request to add support for new devices as

--- a/docs/api/miio.gateway.rst
+++ b/docs/api/miio.gateway.rst
@@ -1,5 +1,29 @@
-miio.gateway module
-===================
+miio.gateway package
+====================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   miio.gateway.devices
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   miio.gateway.alarm
+   miio.gateway.gateway
+   miio.gateway.gatewaydevice
+   miio.gateway.light
+   miio.gateway.radio
+   miio.gateway.zigbee
+
+Module contents
+---------------
 
 .. automodule:: miio.gateway
    :members:

--- a/docs/api/miio.rst
+++ b/docs/api/miio.rst
@@ -1,12 +1,21 @@
 miio package
 ============
 
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   miio.gateway
+
 Submodules
 ----------
 
 .. toctree::
    :maxdepth: 4
 
+   miio.airconditioner_miot
    miio.airconditioningcompanion
    miio.airconditioningcompanionMCN
    miio.airdehumidifier
@@ -18,8 +27,10 @@ Submodules
    miio.airhumidifier_miot
    miio.airhumidifier_mjjsq
    miio.airpurifier
+   miio.airpurifier_airdog
    miio.airpurifier_miot
    miio.airqualitymonitor
+   miio.airqualitymonitor_miot
    miio.alarmclock
    miio.aqaracamera
    miio.ceil
@@ -30,15 +41,19 @@ Submodules
    miio.cli
    miio.click_common
    miio.cooker
+   miio.curtain_youpin
    miio.device
    miio.discovery
+   miio.dreamevacuum_miot
    miio.exceptions
    miio.extract_tokens
    miio.fan
    miio.fan_common
+   miio.fan_leshow
    miio.fan_miot
-   miio.gateway
    miio.heater
+   miio.heater_miot
+   miio.huizuo
    miio.miioprotocol
    miio.miot_device
    miio.philips_bulb
@@ -50,17 +65,22 @@ Submodules
    miio.powerstrip
    miio.protocol
    miio.pwzn_relay
+   miio.scishare_coffeemaker
    miio.toiletlid
    miio.updater
    miio.utils
    miio.vacuum
    miio.vacuum_cli
+   miio.vacuum_tui
    miio.vacuumcontainers
    miio.viomivacuum
+   miio.walkingpad
    miio.waterpurifier
+   miio.waterpurifier_yunmi
    miio.wifirepeater
    miio.wifispeaker
    miio.yeelight
+   miio.yeelight_dual_switch
 
 Module contents
 ---------------

--- a/miio/__init__.py
+++ b/miio/__init__.py
@@ -62,6 +62,7 @@ from miio.vacuumcontainers import (
     VacuumStatus,
 )
 from miio.viomivacuum import ViomiVacuum
+from miio.walkingpad import Walkingpad
 from miio.waterpurifier import WaterPurifier
 from miio.waterpurifier_yunmi import WaterPurifierYunmi
 from miio.wifirepeater import WifiRepeater

--- a/miio/tests/test_walkingpad.py
+++ b/miio/tests/test_walkingpad.py
@@ -82,7 +82,6 @@ class TestWalkingpad(TestCase):
 
     def test_status(self):
         self.device._reset_state()
-        print(self.state())
 
         # Because we get a set of status values from the walkingpad via 'all' the dummy device doesnt work for testing.
         # TODO Need to figure out how to test this properly.

--- a/miio/tests/test_walkingpad.py
+++ b/miio/tests/test_walkingpad.py
@@ -121,7 +121,7 @@ class TestWalkingpad(TestCase):
         assert self.state().step_count == self.device.start_state["step"]
         assert self.state().distance == self.device.start_state["dist"]
         assert self.state().sensitivity == self.device.start_state["sensitivity"]
-        assert self.state().time == self.device.start_state["time"]
+        assert self.state().walking_time == self.device.start_state["time"]
 
     def test_set_mode(self):
         def mode():

--- a/miio/tests/test_walkingpad.py
+++ b/miio/tests/test_walkingpad.py
@@ -117,11 +117,11 @@ class TestWalkingpad(TestCase):
         assert self.is_on() is True
         assert self.state().power == self.device.start_state["power"]
         assert self.state().mode == self.device.start_state["mode"]
-        assert self.state().speed == str(self.device.start_state["sp"])
-        assert self.state().step_count == str(self.device.start_state["step"])
-        assert self.state().distance == str(self.device.start_state["dist"])
+        assert self.state().speed == self.device.start_state["sp"]
+        assert self.state().step_count == self.device.start_state["step"]
+        assert self.state().distance == self.device.start_state["dist"]
         assert self.state().sensitivity == self.device.start_state["sensitivity"]
-        assert self.state().time == str(self.device.start_state["time"])
+        assert self.state().time == self.device.start_state["time"]
 
     def test_set_mode(self):
         def mode():
@@ -147,7 +147,7 @@ class TestWalkingpad(TestCase):
             return self.device.status().speed
 
         self.device.set_speed(3.055)
-        assert speed() == str(3.055)
+        assert speed() == 3.055
 
         with pytest.raises(WalkingpadException):
             self.device.set_speed(7.6)

--- a/miio/tests/test_walkingpad.py
+++ b/miio/tests/test_walkingpad.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 import pytest
 
 from miio import Walkingpad
-from miio.walkingpad import WalkingpadException, WalkingpadStatus
+from miio.walkingpad import OperationMode, WalkingpadException, WalkingpadStatus
 
 from .dummies import DummyDevice
 
@@ -100,11 +100,11 @@ class TestWalkingpad(TestCase):
         def mode():
             return self.device.status().mode
 
-        self.device.set_mode(1)
-        assert mode() == 1
+        self.device.set_mode(OperationMode.Auto)
+        assert mode() == OperationMode.Auto.value
 
-        self.device.set_mode(0)
-        assert mode() == 0
+        self.device.set_mode(OperationMode.Manual)
+        assert mode() == OperationMode.Manual.value
 
         with pytest.raises(WalkingpadException):
             self.device.set_mode(-1)

--- a/miio/tests/test_walkingpad.py
+++ b/miio/tests/test_walkingpad.py
@@ -38,7 +38,7 @@ class DummyWalkingpad(DummyDevice, Walkingpad):
     def __init__(self, *args, **kwargs):
         self.state = {
             "power": "on",
-            "mode": 1,
+            "mode": OperationMode.Manual,
             "time": 1387,
             "step": 2117,
             "sensitivity": OperationSensitivity.Low,
@@ -47,7 +47,7 @@ class DummyWalkingpad(DummyDevice, Walkingpad):
             "cal": 71710,
             "start_speed": 3.1,
             "all": [
-                "mode:1",
+                "mode:" + str(OperationMode.Manual.value),
                 "time:1387",
                 "sp:3.15",
                 "dist:1150",
@@ -127,10 +127,10 @@ class TestWalkingpad(TestCase):
             return self.device.status().mode
 
         self.device.set_mode(OperationMode.Auto)
-        assert mode() == OperationMode.Auto.value
+        assert mode() == OperationMode.Auto
 
         self.device.set_mode(OperationMode.Manual)
-        assert mode() == OperationMode.Manual.value
+        assert mode() == OperationMode.Manual
 
         with pytest.raises(WalkingpadException):
             self.device.set_mode(-1)
@@ -178,10 +178,10 @@ class TestWalkingpad(TestCase):
             return self.device.status().sensitivity
 
         self.device.set_sensitivity(OperationSensitivity.High)
-        assert sensitivity() == OperationSensitivity.High.value
+        assert sensitivity() == OperationSensitivity.High
 
         self.device.set_sensitivity(OperationSensitivity.Medium)
-        assert sensitivity() == OperationSensitivity.Medium.value
+        assert sensitivity() == OperationSensitivity.Medium
 
         with pytest.raises(WalkingpadException):
             self.device.set_sensitivity(-1)

--- a/miio/tests/test_walkingpad.py
+++ b/miio/tests/test_walkingpad.py
@@ -1,0 +1,117 @@
+from unittest import TestCase
+
+import pytest
+
+from miio import Walkingpad
+from miio.walkingpad import WalkingpadException, WalkingpadStatus
+
+from .dummies import DummyDevice
+
+
+class DummyWalkingpad(DummyDevice, Walkingpad):
+    def __init__(self, *args, **kwargs):
+        self.state = {
+            "power": "on",
+            "mode": 1,
+            "time": 1387,
+            "step": 2117,
+            "dist": 1150,
+            "sp": 3.05,
+            "cal": 71710,
+            "all": [
+                "mode:1",
+                "time:1387",
+                "sp:3.05",
+                "dist:1150",
+                "cal:71710",
+                "step:2117",
+            ],
+        }
+        self.return_values = {
+            "get_prop": self._get_state,
+            "set_power": lambda x: self._set_state("power", x),
+            "set_mode": lambda x: self._set_state("mode", x),
+            "set_speed": lambda x: (
+                self._set_state(
+                    "all",
+                    [
+                        "mode:1",
+                        "time:1387",
+                        "sp:" + str(x),
+                        "dist:1150",
+                        "cal:71710",
+                        "step:2117",
+                    ],
+                ),
+                self._set_state("sp", x),
+            ),
+            "set_step": lambda x: self._set_state("step", x),
+            "set_time": lambda x: self._set_state("time", x),
+            "set_distance": lambda x: self._set_state("dist", x),
+        }
+        super().__init__(args, kwargs)
+
+
+@pytest.fixture(scope="class")
+def walkingpad(request):
+    request.cls.device = DummyWalkingpad()
+    # TODO add ability to test on a real device
+
+
+@pytest.mark.usefixtures("walkingpad")
+class TestWalkingpad(TestCase):
+    def is_on(self):
+        return self.device.status().is_on
+
+    def state(self):
+        return self.device.status()
+
+    def test_on(self):
+        self.device.off()  # ensure off
+        assert self.is_on() is False
+
+        self.device.on()
+        assert self.is_on() is True
+
+    def test_off(self):
+        self.device.on()  # ensure on
+        assert self.is_on() is True
+
+        self.device.off()
+        assert self.is_on() is False
+
+    def test_status(self):
+        self.device._reset_state()
+        print(self.state())
+
+        # Because we get a set of status values from the walkingpad via 'all' the dummy device doesnt work for testing.
+        # TODO Need to figure out how to test this properly.
+
+        assert repr(self.state()) == repr(WalkingpadStatus(self.device.start_state))
+
+        assert self.is_on() is True
+        assert self.state().power == self.device.start_state["power"]
+        assert self.state().mode == self.device.start_state["mode"]
+        # assert self.state().speed == self.device.start_state["speed"]
+        # assert self.state().step == self.device.start_state["step"]
+        # assert self.state().distance == self.device.start_state["dist"]
+        # assert self.state().time == self.device.start_state["time"]
+
+    def test_set_mode(self):
+        def mode():
+            return self.device.status().mode
+
+        self.device.set_mode(1)
+        assert mode() == 1
+
+        self.device.set_mode(0)
+        assert mode() == 0
+
+        with pytest.raises(WalkingpadException):
+            self.device.set_mode(-1)
+
+        with pytest.raises(WalkingpadException):
+            self.device.set_mode(3)
+
+        with pytest.raises(WalkingpadException):
+            self.device.set_mode("blah")

--- a/miio/tests/test_walkingpad.py
+++ b/miio/tests/test_walkingpad.py
@@ -113,7 +113,6 @@ class TestWalkingpad(TestCase):
         self.device._reset_state()
 
         assert repr(self.state()) == repr(WalkingpadStatus(self.device.start_state))
-
         assert self.is_on() is True
         assert self.state().power == self.device.start_state["power"]
         assert self.state().mode == self.device.start_state["mode"]

--- a/miio/tests/test_walkingpad.py
+++ b/miio/tests/test_walkingpad.py
@@ -3,25 +3,53 @@ from unittest import TestCase
 import pytest
 
 from miio import Walkingpad
-from miio.walkingpad import OperationMode, WalkingpadException, WalkingpadStatus
+from miio.walkingpad import (
+    OperationMode,
+    OperationSensitivity,
+    WalkingpadException,
+    WalkingpadStatus,
+)
 
 from .dummies import DummyDevice
 
 
 class DummyWalkingpad(DummyDevice, Walkingpad):
+    def _get_state(self, props):
+        """Return wanted properties."""
+
+        # Overriding here to deal with case of 'all' being requested
+
+        if props[0] == "all":
+            return self.state[props[0]]
+
+        return [self.state[x] for x in props if x in self.state]
+
+    def _set_state(self, var, value):
+        """Set a state of a variable, the value is expected to be an array with length
+        of 1."""
+
+        # Overriding here to deal with case of 'all' being set
+
+        if var == "all":
+            self.state[var] = value
+        else:
+            self.state[var] = value.pop(0)
+
     def __init__(self, *args, **kwargs):
         self.state = {
             "power": "on",
             "mode": 1,
             "time": 1387,
             "step": 2117,
+            "sensitivity": OperationSensitivity.Low,
             "dist": 1150,
-            "sp": 3.05,
+            "sp": 3.15,
             "cal": 71710,
+            "start_speed": 3.1,
             "all": [
                 "mode:1",
                 "time:1387",
-                "sp:3.05",
+                "sp:3.15",
                 "dist:1150",
                 "cal:71710",
                 "step:2117",
@@ -37,7 +65,7 @@ class DummyWalkingpad(DummyDevice, Walkingpad):
                     [
                         "mode:1",
                         "time:1387",
-                        "sp:" + str(x),
+                        "sp:" + str(x[0]),
                         "dist:1150",
                         "cal:71710",
                         "step:2117",
@@ -46,6 +74,8 @@ class DummyWalkingpad(DummyDevice, Walkingpad):
                 self._set_state("sp", x),
             ),
             "set_step": lambda x: self._set_state("step", x),
+            "set_sensitivity": lambda x: self._set_state("sensitivity", x),
+            "set_start_speed": lambda x: self._set_state("start_speed", x),
             "set_time": lambda x: self._set_state("time", x),
             "set_distance": lambda x: self._set_state("dist", x),
         }
@@ -55,7 +85,6 @@ class DummyWalkingpad(DummyDevice, Walkingpad):
 @pytest.fixture(scope="class")
 def walkingpad(request):
     request.cls.device = DummyWalkingpad()
-    # TODO add ability to test on a real device
 
 
 @pytest.mark.usefixtures("walkingpad")
@@ -83,18 +112,16 @@ class TestWalkingpad(TestCase):
     def test_status(self):
         self.device._reset_state()
 
-        # Because we get a set of status values from the walkingpad via 'all' the dummy device doesnt work for testing.
-        # TODO Need to figure out how to test this properly.
-
         assert repr(self.state()) == repr(WalkingpadStatus(self.device.start_state))
 
         assert self.is_on() is True
         assert self.state().power == self.device.start_state["power"]
         assert self.state().mode == self.device.start_state["mode"]
-        # assert self.state().speed == self.device.start_state["speed"]
-        # assert self.state().step == self.device.start_state["step"]
-        # assert self.state().distance == self.device.start_state["dist"]
-        # assert self.state().time == self.device.start_state["time"]
+        assert self.state().speed == str(self.device.start_state["sp"])
+        assert self.state().step_count == str(self.device.start_state["step"])
+        assert self.state().distance == str(self.device.start_state["dist"])
+        assert self.state().sensitivity == self.device.start_state["sensitivity"]
+        assert self.state().time == str(self.device.start_state["time"])
 
     def test_set_mode(self):
         def mode():
@@ -114,3 +141,54 @@ class TestWalkingpad(TestCase):
 
         with pytest.raises(WalkingpadException):
             self.device.set_mode("blah")
+
+    def test_set_speed(self):
+        def speed():
+            return self.device.status().speed
+
+        self.device.set_speed(3.055)
+        assert speed() == str(3.055)
+
+        with pytest.raises(WalkingpadException):
+            self.device.set_speed(7.6)
+
+        with pytest.raises(WalkingpadException):
+            self.device.set_speed(-1)
+
+        with pytest.raises(WalkingpadException):
+            self.device.set_speed("blah")
+
+    def test_set_start_speed(self):
+        def speed():
+            return self.device.status().start_speed
+
+        self.device.set_start_speed(3.055)
+        assert speed() == 3.055
+
+        with pytest.raises(WalkingpadException):
+            self.device.set_start_speed(7.6)
+
+        with pytest.raises(WalkingpadException):
+            self.device.set_start_speed(-1)
+
+        with pytest.raises(WalkingpadException):
+            self.device.set_start_speed("blah")
+
+    def test_set_sensitivity(self):
+        def sensitivity():
+            return self.device.status().sensitivity
+
+        self.device.set_sensitivity(OperationSensitivity.High)
+        assert sensitivity() == OperationSensitivity.High.value
+
+        self.device.set_sensitivity(OperationSensitivity.Medium)
+        assert sensitivity() == OperationSensitivity.Medium.value
+
+        with pytest.raises(WalkingpadException):
+            self.device.set_sensitivity(-1)
+
+        with pytest.raises(WalkingpadException):
+            self.device.set_sensitivity(99)
+
+        with pytest.raises(WalkingpadException):
+            self.device.set_sensitivity("blah")

--- a/miio/walkingpad.py
+++ b/miio/walkingpad.py
@@ -69,7 +69,7 @@ class WalkingpadStatus(DeviceStatus):
 
     @property
     def start_speed(self) -> float:
-        """Current speed."""
+        """Current start speed."""
         return self.data["start_speed"]
 
     @property

--- a/miio/walkingpad.py
+++ b/miio/walkingpad.py
@@ -28,10 +28,22 @@ class OperationSensitivity(enum.Enum):
 
 
 class WalkingpadStatus(DeviceStatus):
-    """Container for status reports from Xiaomi Walkingpad."""
+    """Container for status reports from Xiaomi Walkingpad.
+
+    Input data dictionary to initialise this class:
+
+    {'cal': '0',
+     'dist': '0',
+     'mode': 2,
+     'power': 'off',
+     'sensitivity': 1,
+     'sp': '0.0',
+     'start_speed': 3.0,
+     'step': '0',
+     'time': '0'}
+    """
 
     def __init__(self, data: Dict[str, Any]) -> None:
-
         # NOTE: Only 1 property can be requested at the same time
         self.data = data
 

--- a/miio/walkingpad.py
+++ b/miio/walkingpad.py
@@ -1,0 +1,189 @@
+import logging
+from collections import defaultdict
+from typing import Any, Dict
+
+import click
+
+from .click_common import command, format_output
+from .device import Device, DeviceStatus
+from .exceptions import DeviceException
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class WalkingpadException(DeviceException):
+    pass
+
+
+class WalkingpadStatus(DeviceStatus):
+    """Container for status reports from Xiaomi Walkingpad."""
+
+    # raw_command set_start_speed '["1.0"]' finally made my WalkingPad autostart on speed 1! Hurray!
+    #
+    # raw_command get_prop '["mode"]' returns
+    #
+    # [0] while mode is auto
+    #     [1] while mode is manual
+    #     [2] when in standby
+    # raw_command get_prop '["step"]' returns [2303]
+    # raw_command get_prop '["time"]' returns [1970] (while time is 32:50)
+    # raw_command get_prop '["dist"]' returns [1869]
+    # raw_command get_prop '["cal"]' returns [67340]
+    # raw_command get_prop '["goal"]' returns [0, 60]
+    # raw_command get_prop '["max"]' returns [6.0]
+    # raw_command get_prop '["initial"]' returns [3]
+    # raw_command get_prop '["offline"]' returns [0]
+    # raw_command get_prop '["sensitivity"]' returns [2]
+    # raw_command get_prop '["sp"]' returns [1.0]
+    # raw_command get_prop '["start_speed"]' returns [1.0]
+    # raw_command get_prop '["auto"]' returns [1]
+    # raw_command get_prop '["disp"]' returns [19]
+    # raw_command get_prop '["lock"]' returns [0]
+
+    def __init__(self, data: Dict[str, Any]) -> None:
+
+        # NOTE: Only 1 property can be requested at the same time
+        self.data = data
+
+    @property
+    def power(self) -> str:
+        """Power state."""
+        return self.data["power"]
+
+    @property
+    def is_on(self) -> bool:
+        """True if the device is turned on."""
+        return self.power == "on"
+
+    @property
+    def time(self) -> int:
+        """Current lock status."""
+        return self.data["time"]
+
+    @property
+    def speed(self) -> float:
+        """Current speed."""
+        return self.data["sp"]
+
+    @property
+    def mode(self) -> int:
+        """Current mode."""
+        return self.data["mode"]
+
+    @property
+    def step(self) -> int:
+        """Current steps."""
+        return self.data["step"]
+
+    @property
+    def distance(self) -> int:
+        """Current distance."""
+        return self.data["dist"]
+
+    @property
+    def calories(self) -> int:
+        """Current distance."""
+        return self.data["cal"]
+
+
+class Walkingpad(Device):
+    """Main class representing Xiaomi Walkingpad."""
+
+    # TODO: - Auto On/Off Not Supported
+    #       - Adjust Scenes with Wall Switch Not Supported
+
+    @command(
+        default_output=format_output(
+            "",
+            "Mode: {result.mode}\n"
+            "Time: {result.time}\n"
+            "Steps: {result.step}\n"
+            "Speed: {result.speed}\n"
+            "Distance: {result.distance}\n"
+            "Calories: {result.calories}  ",
+        )
+    )
+    def status(self) -> WalkingpadStatus:
+        """Retrieve properties."""
+
+        properties_received = []
+        values_received = []
+
+        # Walkingpad A1 allows you to retrieve a subset of values with "all"
+        # eg ['mode:1', 'time:1387', 'sp:3.0', 'dist:1150', 'cal:71710', 'step:2117']
+
+        properties = ["all"]
+
+        # Walkingpad A1 only allows 1 property to be read at a time
+
+        values = self.get_properties(properties, max_properties=1)
+
+        # When running the tests, for some reason the list provided is passed within another list, so I take
+        # care of this here.
+
+        if any(isinstance(el, list) for el in values):
+            values = values[0]
+
+        for x in values:
+            prop_split, value = x.split(":")
+            properties_received.append(prop_split)
+            values_received.append(value)
+
+        properties_additional = ["power", "mode"]
+
+        values_additional = self.get_properties(properties_additional, max_properties=1)
+
+        properties_received = properties_received + properties_additional
+        values_received = values_received + values_additional
+        return WalkingpadStatus(
+            defaultdict(lambda: None, zip(properties_received, values_received))
+        )
+
+    @command(default_output=format_output("Powering on"))
+    def on(self):
+        """Power on."""
+        return self.send("set_power", ["on"])
+
+    @command(default_output=format_output("Powering off"))
+    def off(self):
+        """Power off."""
+        return self.send("set_power", ["off"])
+
+    @command(default_output=format_output("Starting the treadmill"))
+    def start(self):
+        """Starting Up."""
+        return self.send("set_state", ["run"])
+
+    @command(default_output=format_output("Stopping the treadmill"))
+    def stop(self):
+        """Starting Up."""
+        return self.send("set_state", ["stop"])
+
+    @command(
+        click.argument("mode", type=int),
+        default_output=format_output("Setting mode to {mode}"),
+    )
+    def set_mode(self, mode: int):
+        """Set mode (auto/manual)."""
+
+        if not isinstance(mode, int):
+            raise WalkingpadException("Invalid mode: %s" % mode)
+
+        elif mode < 0 or mode >= 3:
+            raise WalkingpadException("Invalid mode: %s" % mode)
+        return self.send("set_mode", [mode])
+
+    @command(
+        click.argument("speed", type=float),
+        default_output=format_output("Setting speed to {speed}"),
+    )
+    def set_speed(self, speed: float):
+        """Set speed."""
+
+        if not isinstance(speed, float):
+            raise WalkingpadException("Invalid speed: %s" % speed)
+
+        elif speed < 0 or speed > 6:
+            raise WalkingpadException("Invalid speed: %s" % speed)
+
+        return self.send("set_speed", [speed])

--- a/miio/walkingpad.py
+++ b/miio/walkingpad.py
@@ -179,7 +179,7 @@ class Walkingpad(Device):
 
     @command(default_output=format_output("Starting the treadmill"))
     def start(self):
-        """Starting Up."""
+        """Start the treadmill."""
         if not self.status().is_on:
             raise WalkingpadException(
                 "Can't start the treadmill, it's not turned on - try issuing an 'on' command first"
@@ -189,7 +189,7 @@ class Walkingpad(Device):
 
     @command(default_output=format_output("Stopping the treadmill"))
     def stop(self):
-        """Starting Up."""
+        """Stop the treadmill."""
         return self.send("set_state", ["stop"])
 
     @command(

--- a/miio/walkingpad.py
+++ b/miio/walkingpad.py
@@ -96,15 +96,12 @@ class WalkingpadStatus(DeviceStatus):
 class Walkingpad(Device):
     """Main class representing Xiaomi Walkingpad."""
 
-    # TODO: - Auto On/Off Not Supported
-    #       - Adjust Scenes with Wall Switch Not Supported
-
     @command(
         default_output=format_output(
             "",
             "Mode: {result.mode}\n"
             "Time: {result.time}\n"
-            "Steps: {result.step}\n"
+            "Steps: {result.step_count}\n"
             "Speed: {result.speed}\n"
             "Distance: {result.distance}\n"
             "Calories: {result.calories}  ",
@@ -125,8 +122,8 @@ class Walkingpad(Device):
         # When running the tests, for some reason the list provided is passed within another list, so I take
         # care of this here.
 
-        if any(isinstance(el, list) for el in values):
-            values = values[0]
+        if len(values) <= 1:
+            values = values.pop()
 
         data = {}
         for x in values:

--- a/miio/walkingpad.py
+++ b/miio/walkingpad.py
@@ -1,6 +1,5 @@
 import enum
 import logging
-from collections import defaultdict
 from typing import Any, Dict
 
 import click

--- a/miio/walkingpad.py
+++ b/miio/walkingpad.py
@@ -1,5 +1,6 @@
 import enum
 import logging
+from datetime import timedelta
 from typing import Any, Dict
 
 import click
@@ -57,8 +58,8 @@ class WalkingpadStatus(DeviceStatus):
         return self.power == "on"
 
     @property
-    def time(self) -> int:
-        """Current walking time in seconds."""
+    def walking_time(self) -> timedelta:
+        """Current walking duration in seconds."""
         return int(self.data["time"])
 
     @property


### PR DESCRIPTION
Hey there, I had a go at adding support for the Walkingpad A1. 

What's working:

status, turn on/off, start/stop and set_speed.

What's not working:

Full testing for the status command. The Walkingpad A1 allows retrieval of only 1 property at a time. This means a full status update takes quite a long time to answer. Luckily there is an 'all' property that returns the majority of the status elements. However, this makes testing of the status and speed updates really difficult. (I am sure it's possible but it is outside of my current abilities).

Hope this is good enough to merge... if not be gentle... it's my first ever PR ;) 

Fixes #797