### PR TITLE
Re-add mapping parameter to MiotDevice ctor

### DIFF
--- a/miio/miot_device.py
+++ b/miio/miot_device.py
@@ -1,7 +1,7 @@
 import logging
 from enum import Enum
 from functools import partial
-from typing import Any, Union
+from typing import Any, Dict, Union
 
 import click
 
@@ -29,6 +29,23 @@ class MiotDevice(Device):
     """Main class representing a MIoT device."""
 
     mapping = None
+
+    def __init__(
+        self,
+        ip: str = None,
+        token: str = None,
+        start_id: int = 0,
+        debug: int = 0,
+        lazy_discover: bool = True,
+        timeout: int = None,
+        *,
+        mapping: Dict = None,
+    ):
+        """Overloaded to accept keyword-only `mapping` parameter."""
+        if mapping is not None:
+            self.mapping = mapping
+
+        super().__init__(ip, token, start_id, debug, lazy_discover, timeout)
 
     def get_properties_for_mapping(self, *, max_properties=15) -> list:
         """Retrieve raw properties based on mapping."""

--- a/miio/tests/test_miotdevice.py
+++ b/miio/tests/test_miotdevice.py
@@ -11,6 +11,18 @@ def dev(module_mocker):
     return device
 
 
+def test_ctor_mapping():
+    """Make sure the constructor accepts the mapping parameter."""
+    dev = MiotDevice("127.0.0.1", "68ffffffffffffffffffffffffffffff")
+    assert dev.mapping is None
+
+    test_mapping = {}
+    dev2 = MiotDevice(
+        "127.0.0.1", "68ffffffffffffffffffffffffffffff", mapping=test_mapping
+    )
+    assert dev2.mapping == test_mapping
+
+
 def test_get_property_by(dev):
     siid = 1
     piid = 2


### PR DESCRIPTION
Note that the method signature is different from previous versions to accommodate the compatibility with the Device ctor.

Previous versions had a signature where the mapping was the first argument, now it is only allowed as a keyword-only argument:
```
dev = MiotDevice("127.0.0.1", "token")
```
and
```
dev = MiotDevice("127.0.0.1", "token", mapping={})
```
are the the allowed ways to initialize a plain `MiotDevice` instance.

The implementations should not override the constructor to use this method to pass the mapping, but instead define `mapping` as a class variable.

Fixes #982