### PR TITLE
Reformat history data if returned as a dict/Roborock S7 Support (#989)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ To ease the process of setting up a development environment we have prepared `a 
 Supported devices
 -----------------
 
--  Xiaomi Mi Robot Vacuum V1, S5, M1S
+-  Xiaomi Mi Robot Vacuum V1, S5, M1S, S7
 -  Xiaomi Mi Home Air Conditioner Companion
 -  Xiaomi Mi Smart Air Conditioner A (xiaomi.aircondition.mc1, mc2, mc4, mc5)
 -  Xiaomi Mi Air Purifier 2, 3H, 3C, Pro (zhimi.airpurifier.m2, mb3, mb4, v7)

--- a/miio/tests/test_vacuum.py
+++ b/miio/tests/test_vacuum.py
@@ -170,3 +170,50 @@ class TestVacuum(TestCase):
 
         with patch.object(self.device, "send", return_value=0):
             assert self.device.timezone() == "UTC"
+
+    def test_history(self):
+        with patch.object(
+            self.device,
+            "send",
+            return_value=[
+                174145,
+                2410150000,
+                82,
+                [
+                    1488240000,
+                    1488153600,
+                    1488067200,
+                    1487980800,
+                    1487894400,
+                    1487808000,
+                    1487548800,
+                ],
+            ],
+        ):
+            assert self.device.clean_history().total_duration == datetime.timedelta(
+                days=2, seconds=1345
+            )
+
+    def test_history_dict(self):
+        with patch.object(
+            self.device,
+            "send",
+            return_value={
+                "clean_time": 174145,
+                "clean_area": 2410150000,
+                "clean_count": 82,
+                "dust_collection_count": 5,
+                "records": [
+                    1488240000,
+                    1488153600,
+                    1488067200,
+                    1487980800,
+                    1487894400,
+                    1487808000,
+                    1487548800,
+                ],
+            },
+        ):
+            assert self.device.clean_history().total_duration == datetime.timedelta(
+                days=2, seconds=1345
+            )

--- a/miio/vacuumcontainers.py
+++ b/miio/vacuumcontainers.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*#
 from datetime import datetime, time, timedelta
 from enum import IntEnum
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 
 from croniter import croniter
 
@@ -184,14 +184,23 @@ class VacuumStatus(DeviceStatus):
 class CleaningSummary(DeviceStatus):
     """Contains summarized information about available cleaning runs."""
 
-    def __init__(self, data: List[Any]) -> None:
+    def __init__(self, data: Union[List[Any], Dict[str, Any]]) -> None:
         # total duration, total area, amount of cleans
         # [ list, of, ids ]
         # { "result": [ 174145, 2410150000, 82,
         # [ 1488240000, 1488153600, 1488067200, 1487980800,
         #  1487894400, 1487808000, 1487548800 ] ],
         #  "id": 1 }
-        self.data = data
+        # newer models return a dict
+        if type(data) is dict:
+            self.data = [
+                data["clean_time"],
+                data["clean_area"],
+                data["clean_count"],
+                data["records"],
+            ]
+        else:
+            self.data = data
 
     @property
     def total_duration(self) -> timedelta:


### PR DESCRIPTION
This should fix #989 by taking care of the new history format, the Roborock S7 is using. I also added some tests just in case. Couldn't find anything else not working with this vacuum so maybe that was all it takes for it to be supported.

I would've used some pull request template but it seems there isn't any so there is that.