### PR TITLE
Fix set_mode_and_speed mode for airdog airpurifier

### DIFF
--- a/miio/airpurifier_airdog.py
+++ b/miio/airpurifier_airdog.py
@@ -172,7 +172,7 @@ class AirDogX3(Device):
         if speed < 1 or speed > max_speed:
             raise AirDogException("Invalid speed: %s" % speed)
 
-        return self.send("set_wind", [OperationModeMapping[mode.name], speed])
+        return self.send("set_wind", [OperationModeMapping[mode.name].value, speed])
 
     @command(
         click.argument("lock", type=bool),


### PR DESCRIPTION
This is a fix for a small bug.

`set_wind` expects integer, not enum as a first parameter.


Behavior prior to fix:
```
$ miiocli airdogx3 --ip x.x.x.x --token _____ set_mode_and_speed Idle
Setting mode to 'sleep' and speed to 1
Traceback (most recent call last):
  File "/home/user/.local/bin/miiocli", line 8, in <module>
    sys.exit(create_cli())
  File "/home/user/.local/lib/python3.8/site-packages/miio/cli.py", line 45, in create_cli
    return cli(auto_envvar_prefix="MIIO")
  File "/home/user/.local/lib/python3.8/site-packages/miio/click_common.py", line 59, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/user/.local/lib/python3.8/site-packages/miio/click_common.py", line 280, in wrap
    kwargs["result"] = func(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/usr/lib/python3/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/user/.local/lib/python3.8/site-packages/miio/click_common.py", line 245, in command_callback
    return miio_command.call(miio_device, *args, **kwargs)
  File "/home/user/.local/lib/python3.8/site-packages/miio/click_common.py", line 193, in call
    return method(*args, **kwargs)
  File "/home/user/.local/lib/python3.8/site-packages/miio/airpurifier_airdog.py", line 175, in set_mode_and_speed
    return self.send("set_wind", [OperationModeMapping[mode.name], speed])
  File "/home/user/.local/lib/python3.8/site-packages/miio/device.py", line 177, in send
    return self._protocol.send(
  File "/home/user/.local/lib/python3.8/site-packages/miio/miioprotocol.py", line 174, in send
    m = Message.build(msg, token=self.token)
  File "/home/user/.local/lib/python3.8/site-packages/construct/core.py", line 331, in build
    self.build_stream(obj, stream, **contextkw)
  File "/home/user/.local/lib/python3.8/site-packages/construct/core.py", line 343, in build_stream
    self._build(obj, stream, context, "(building)")
  File "/home/user/.local/lib/python3.8/site-packages/construct/core.py", line 2030, in _build
    buildret = sc._build(subobj, stream, context, path)
  File "/home/user/.local/lib/python3.8/site-packages/construct/core.py", line 2468, in _build
    return self.subcon._build(obj, stream, context, path)
  File "/home/user/.local/lib/python3.8/site-packages/construct/core.py", line 4019, in _build
    buildret = self.subcon._build(obj, stream, context, path)
  File "/home/user/.local/lib/python3.8/site-packages/construct/core.py", line 4308, in _build
    buildret = self.subcon._build(value, stream, context, path)
  File "/home/user/.local/lib/python3.8/site-packages/construct/core.py", line 700, in _build
    obj2 = self._encode(obj, context, path)
  File "/home/user/.local/lib/python3.8/site-packages/miio/protocol.py", line 162, in _encode
    json.dumps(obj).encode("utf-8") + b"\x00", context["_"]["token"]
  File "/usr/lib/python3.8/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib/python3.8/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.8/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/lib/python3.8/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type OperationModeMapping is not JSON serializable

```

After the fix:
```
$ miiocli airdogx3 --ip x.x.x.x --token _____ set_mode_and_speed idle
Setting mode to 'sleep' and speed to 1
[]

```