### PR TITLE
Roborock S7: Parse history details returned as dict

### DIFF
--- a/miio/tests/test_vacuum.py
+++ b/miio/tests/test_vacuum.py
@@ -196,6 +196,8 @@ class TestVacuum(TestCase):
 
             assert self.device.clean_history().dust_collection_count is None
 
+            assert self.device.clean_history().ids[0] == 1488240000
+
     def test_history_dict(self):
         with patch.object(
             self.device,
@@ -221,6 +223,8 @@ class TestVacuum(TestCase):
             )
 
             assert self.device.clean_history().dust_collection_count == 5
+
+            assert self.device.clean_history().ids[0] == 1488240000
 
     def test_history_details(self):
         with patch.object(
@@ -269,3 +273,5 @@ class TestVacuum(TestCase):
             assert self.device.clean_history().total_duration == datetime.timedelta(
                 days=2, seconds=1345
             )
+
+            assert len(self.device.clean_history().ids) == 0

--- a/miio/tests/test_vacuum.py
+++ b/miio/tests/test_vacuum.py
@@ -221,3 +221,51 @@ class TestVacuum(TestCase):
             )
 
             assert self.device.clean_history().dust_collection_count == 5
+
+    def test_history_details(self):
+        with patch.object(
+            self.device,
+            "send",
+            return_value=[[1488347071, 1488347123, 16, 0, 0, 0]],
+        ):
+            assert self.device.clean_details(
+                123123, return_list=False
+            ).duration == datetime.timedelta(seconds=16)
+
+    def test_history_details_dict(self):
+        with patch.object(
+            self.device,
+            "send",
+            return_value=[
+                {
+                    "begin": 1616757243,
+                    "end": 1616758193,
+                    "duration": 950,
+                    "area": 10852500,
+                    "error": 0,
+                    "complete": 1,
+                    "start_type": 2,
+                    "clean_type": 1,
+                    "finish_reason": 52,
+                    "dust_collection_status": 0,
+                }
+            ],
+        ):
+            assert self.device.clean_details(
+                123123, return_list=False
+            ).duration == datetime.timedelta(seconds=950)
+
+    def test_history_empty(self):
+        with patch.object(
+            self.device,
+            "send",
+            return_value={
+                "clean_time": 174145,
+                "clean_area": 2410150000,
+                "clean_count": 82,
+                "dust_collection_count": 5,
+            },
+        ):
+            assert self.device.clean_history().total_duration == datetime.timedelta(
+                days=2, seconds=1345
+            )

--- a/miio/vacuumcontainers.py
+++ b/miio/vacuumcontainers.py
@@ -197,8 +197,9 @@ class CleaningSummary(DeviceStatus):
                 "clean_time": data[0],
                 "clean_area": data[1],
                 "clean_count": data[2],
-                "records": data[3],
             }
+            if len(data) > 3:
+                self.data["records"] = data[3]
         else:
             self.data = data
 
@@ -220,7 +221,10 @@ class CleaningSummary(DeviceStatus):
     @property
     def ids(self) -> List[int]:
         """A list of available cleaning IDs, see also :class:`CleaningDetails`."""
-        return list(self.data["records"])
+        if "records" in self.data:
+            return list(self.data["records"])
+        else:
+            return []
 
     @property
     def dust_collection_count(self) -> Optional[int]:
@@ -234,40 +238,51 @@ class CleaningSummary(DeviceStatus):
 class CleaningDetails(DeviceStatus):
     """Contains details about a specific cleaning run."""
 
-    def __init__(self, data: List[Any]) -> None:
+    def __init__(self, data: Union[List[Any], Dict[str, Any]]) -> None:
         # start, end, duration, area, unk, complete
         # { "result": [ [ 1488347071, 1488347123, 16, 0, 0, 0 ] ], "id": 1 }
-        self.data = data
+        # newer models return a dict
+        if type(data) is list:
+            self.data = {
+                "begin": data[0],
+                "end": data[1],
+                "duration": data[2],
+                "area": data[3],
+                "error": data[4],
+                "complete": data[5],
+            }
+        else:
+            self.data = data
 
     @property
     def start(self) -> datetime:
         """When cleaning was started."""
-        return pretty_time(self.data[0])
+        return pretty_time(self.data["begin"])
 
     @property
     def end(self) -> datetime:
         """When cleaning was finished."""
-        return pretty_time(self.data[1])
+        return pretty_time(self.data["end"])
 
     @property
     def duration(self) -> timedelta:
         """Total duration of the cleaning run."""
-        return pretty_seconds(self.data[2])
+        return pretty_seconds(self.data["duration"])
 
     @property
     def area(self) -> float:
         """Total cleaned area."""
-        return pretty_area(self.data[3])
+        return pretty_area(self.data["area"])
 
     @property
     def error_code(self) -> int:
         """Error code."""
-        return int(self.data[4])
+        return int(self.data["error"])
 
     @property
     def error(self) -> str:
         """Error state of this cleaning run."""
-        return error_codes[self.data[4]]
+        return error_codes[self.data["error"]]
 
     @property
     def complete(self) -> bool:
@@ -275,7 +290,7 @@ class CleaningDetails(DeviceStatus):
 
         see also :func:`error`.
         """
-        return bool(self.data[5] == 1)
+        return bool(self.data["complete"] == 1)
 
 
 class ConsumableStatus(DeviceStatus):

--- a/miio/vacuumcontainers.py
+++ b/miio/vacuumcontainers.py
@@ -203,6 +203,9 @@ class CleaningSummary(DeviceStatus):
         else:
             self.data = data
 
+        if "records" not in self.data:
+            self.data["records"] = []
+
     @property
     def total_duration(self) -> timedelta:
         """Total cleaning duration."""
@@ -221,10 +224,7 @@ class CleaningSummary(DeviceStatus):
     @property
     def ids(self) -> List[int]:
         """A list of available cleaning IDs, see also :class:`CleaningDetails`."""
-        if "records" in self.data:
-            return list(self.data["records"])
-        else:
-            return []
+        return list(self.data["records"])
 
     @property
     def dust_collection_count(self) -> Optional[int]:


### PR DESCRIPTION
I noticed, that history details as of FW 4.1.2_0928 for this vacuum also come formatted as a dict (similar behavior see #990).

This PR also tries to fix #1004 (robot has an empty cleaning record)