### PR TITLE
Add test_properties command to device class

### DIFF
--- a/miio/device.py
+++ b/miio/device.py
@@ -313,6 +313,8 @@ class Device(metaclass=DeviceGroupMeta):
                 value = valid_properties[property] = resp
                 if value is None:
                     fail("None")
+                elif not value:
+                    fail("Empty response")
                 else:
                     ok(f"{value} {type(value)}")
             except Exception as ex:

--- a/miio/device.py
+++ b/miio/device.py
@@ -1,6 +1,7 @@
 import inspect
 import logging
 from enum import Enum
+from pprint import pformat as pf
 from typing import Any, Optional  # noqa: F401
 
 import click
@@ -319,8 +320,6 @@ class Device(metaclass=DeviceGroupMeta):
                     ok(f"{value} {type(value)}")
             except Exception as ex:
                 _LOGGER.warning("Unable to request %s: %s", property, ex)
-
-        from pprint import pformat as pf
 
         click.echo(
             f"Found {len(valid_properties)} valid properties, testing max_properties.."


### PR DESCRIPTION
This allows simple testing of available properties, their values & the number of properties that can be requested at once.
This is done in two steps:
1. Testing all given properties one by one to see which return non-None/non-empty values
2. Testing all valid values using a single request, and removing items one by one on failures to obtain usable obtain the max_properties value

Example output:

```
$ miiocli device --ip <addr> --token <token> test_properties power on off usb_on temperature wifi_led foofoo x
Running command test_properties
Testing properties ('power', 'on', 'off', 'usb_on', 'temperature', 'wifi_led', 'foofoo', 'x') for zimi.powerstrip.v2
Testing power.. on <class 'str'>
Testing on.. None
Testing off.. None
Testing usb_on.. None
Testing temperature.. 46.07 <class 'float'>
Testing wifi_led.. off <class 'str'>
Testing foofoo.. None
Testing x.. None
Found 8 valid properties, testing max_properties..
Testing 8 properties at once.. OK for 8 properties

Please copy the results below to your report
Model: zimi.powerstrip.v2
Total responsives: 8
Total non-empty: 3
All non-empty properties:
{'power': 'on', 'temperature': 46.07, 'wifi_led': 'off'}
Max properties: 8
Done
```

![image](https://user-images.githubusercontent.com/3705853/114280049-ce4d8e00-9a37-11eb-82b7-3694775d8a85.png)

Closes #919