### PR TITLE
Silence unable to decrypt warning for handshake responses

### DIFF
--- a/miio/protocol.py
+++ b/miio/protocol.py
@@ -172,7 +172,8 @@ class EncryptionAdapter(Adapter):
             decrypted = Utils.decrypt(obj, context["_"]["token"])
             decrypted = decrypted.rstrip(b"\x00")
         except Exception:
-            _LOGGER.debug("Unable to decrypt, returning raw bytes: %s", obj)
+            if obj:
+                _LOGGER.debug("Unable to decrypt, returning raw bytes: %s", obj)
             return obj
 
         # list of adaption functions for malformed json payload (quirks)


### PR DESCRIPTION
The decryption error for handshake responses has caused confusion several times in the past, so this PR filters them out from debug logging.

Fixes #1008