### PR TITLE
Fix start bug and improve error handling in walkingpad integration

### DIFF
--- a/miio/tests/test_walkingpad.py
+++ b/miio/tests/test_walkingpad.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from unittest import TestCase
 
 import pytest
@@ -120,7 +121,9 @@ class TestWalkingpad(TestCase):
         assert self.state().step_count == self.device.start_state["step"]
         assert self.state().distance == self.device.start_state["dist"]
         assert self.state().sensitivity == self.device.start_state["sensitivity"]
-        assert self.state().walking_time == self.device.start_state["time"]
+        assert self.state().walking_time == timedelta(
+            seconds=self.device.start_state["time"]
+        )
 
     def test_set_mode(self):
         def mode():
@@ -145,6 +148,7 @@ class TestWalkingpad(TestCase):
         def speed():
             return self.device.status().speed
 
+        self.device.on()
         self.device.set_speed(3.055)
         assert speed() == 3.055
 
@@ -157,9 +161,15 @@ class TestWalkingpad(TestCase):
         with pytest.raises(WalkingpadException):
             self.device.set_speed("blah")
 
+        with pytest.raises(WalkingpadException):
+            self.device.off()
+            self.device.set_speed(3.4)
+
     def test_set_start_speed(self):
         def speed():
             return self.device.status().start_speed
+
+        self.device.on()
 
         self.device.set_start_speed(3.055)
         assert speed() == 3.055

--- a/miio/tests/test_walkingpad.py
+++ b/miio/tests/test_walkingpad.py
@@ -183,6 +183,10 @@ class TestWalkingpad(TestCase):
         with pytest.raises(WalkingpadException):
             self.device.set_start_speed("blah")
 
+        with pytest.raises(WalkingpadException):
+            self.device.off()
+            self.device.set_start_speed(3.4)
+
     def test_set_sensitivity(self):
         def sensitivity():
             return self.device.status().sensitivity

--- a/miio/walkingpad.py
+++ b/miio/walkingpad.py
@@ -41,7 +41,7 @@ class WalkingpadStatus(DeviceStatus):
      'sp': 3.0,
      'start_speed': 3.0,
      'step': 180,
-     'walking_time': 121}
+     'time': 121}
     """
 
     def __init__(self, data: Dict[str, Any]) -> None:

--- a/miio/walkingpad.py
+++ b/miio/walkingpad.py
@@ -41,7 +41,7 @@ class WalkingpadStatus(DeviceStatus):
      'sp': 3.0,
      'start_speed': 3.0,
      'step': 180,
-     'time': 121}
+     'walking_time': 121}
     """
 
     def __init__(self, data: Dict[str, Any]) -> None:
@@ -60,7 +60,7 @@ class WalkingpadStatus(DeviceStatus):
     @property
     def walking_time(self) -> timedelta:
         """Current walking duration in seconds."""
-        return int(self.data["time"])
+        return timedelta(seconds=int(self.data["time"]))
 
     @property
     def speed(self) -> float:
@@ -133,7 +133,7 @@ class Walkingpad(Device):
         default_output=format_output(
             "",
             "Mode: {result.mode.name}\n"
-            "Time: {result.walking_time}\n"
+            "Walking time: {result.walking_time}\n"
             "Steps: {result.step_count}\n"
             "Speed: {result.speed}\n"
             "Distance: {result.distance}\n"
@@ -180,7 +180,7 @@ class Walkingpad(Device):
 
         # In case the treadmill is not already turned on, turn it on.
         if not self.status().is_on:
-            self.on(self)
+            self.on()
 
         return self.send("set_state", ["run"])
 
@@ -208,6 +208,10 @@ class Walkingpad(Device):
     def set_speed(self, speed: float):
         """Set speed."""
 
+        # In case the treadmill is not already turned on, throw an exception.
+        if not self.status().is_on:
+            raise WalkingpadException("Cannot set the speed, device is turned off")
+
         if not isinstance(speed, float):
             raise WalkingpadException("Invalid speed: %s" % speed)
 
@@ -222,6 +226,12 @@ class Walkingpad(Device):
     )
     def set_start_speed(self, speed: float):
         """Set start speed."""
+
+        # In case the treadmill is not already turned on, throw an exception.
+        if not self.status().is_on:
+            raise WalkingpadException(
+                "Cannot set the start speed, device is turned off"
+            )
 
         if not isinstance(speed, float):
             raise WalkingpadException("Invalid start speed: %s" % speed)


### PR DESCRIPTION
Hey, a bug fix for the start command, when the device was turned off. Additionally corrected the walking_time return, as it should have been a timedelta and it was returning an int. 

Also added some better error handling for functions to deal with when the device is turned off. 