### PR TITLE
Improve test_properties output

### DIFF
--- a/miio/device.py
+++ b/miio/device.py
@@ -309,9 +309,18 @@ class Device(metaclass=DeviceGroupMeta):
             try:
                 click.echo(f"Testing {property:{max_property_len+2}} ", nl=False)
                 value = self.get_properties([property])
-                # Handle responses with one-element lists
-                if isinstance(value, list) and len(value) == 1:
-                    value = value.pop()
+                # Handle list responses
+                if isinstance(value, list):
+                    # unwrap single-element lists
+                    if len(value) == 1:
+                        value = value.pop()
+                    # report on unexpected multi-element lists
+                    elif len(value) > 1:
+                        _LOGGER.error("Got an array as response: %s", value)
+                    # otherwise we received an empty list, which we consider here as None
+                    else:
+                        value = None
+
                 if value is None:
                     fail("None")
                 else:
@@ -341,7 +350,7 @@ class Device(metaclass=DeviceGroupMeta):
                 else:
                     removed_property = props_to_test.pop()
                     fail(
-                        f"Got different amount of properties ({len(props_to_test)}) than requested ({len(resp)}, removing {removed_property}"
+                        f"Got different amount of properties ({len(props_to_test)}) than requested ({len(resp)}), removing {removed_property}"
                     )
 
             except Exception as ex:

--- a/miio/device.py
+++ b/miio/device.py
@@ -315,10 +315,8 @@ class Device(metaclass=DeviceGroupMeta):
                 value = valid_properties[property] = resp
                 if value is None:
                     fail("None")
-                elif isinstance(value, str) and value == "":
-                    fail("Empty response")
                 else:
-                    ok(f"{value} {type(value)}")
+                    ok(f"{repr(value)} {type(value)}")
             except Exception as ex:
                 _LOGGER.warning("Unable to request %s: %s", property, ex)
 

--- a/miio/device.py
+++ b/miio/device.py
@@ -304,9 +304,10 @@ class Device(metaclass=DeviceGroupMeta):
 
         click.echo(f"Testing properties {properties} for {model}")
         valid_properties = {}
+        max_property_len = max([len(p) for p in properties])
         for property in properties:
             try:
-                click.echo(f"Testing {property}.. ", nl=False)
+                click.echo(f"Testing {property:{max_property_len+2}} ", nl=False)
                 resp = self.get_properties([property])
                 # Handle responses with one-element lists
                 if isinstance(resp, list) and len(resp) == 1:

--- a/miio/device.py
+++ b/miio/device.py
@@ -314,7 +314,7 @@ class Device(metaclass=DeviceGroupMeta):
                 value = valid_properties[property] = resp
                 if value is None:
                     fail("None")
-                elif not value:
+                elif isinstance(value, str) and value == "":
                     fail("Empty response")
                 else:
                     ok(f"{value} {type(value)}")
@@ -338,13 +338,16 @@ class Device(metaclass=DeviceGroupMeta):
                     ok(f"OK for {max_properties} properties")
                     break
                 else:
-                    fail("Got different amount of properties than requested")
+                    removed_property = props_to_test.pop()
+                    fail(
+                        f"Got different amount of properties ({len(props_to_test)}) than requested ({len(resp)}, removing {removed_property}"
+                    )
 
-                props_to_test.pop()
             except Exception as ex:
-                _LOGGER.warning("Unable to request properties: %s", ex)
+                removed_property = props_to_test.pop()
+                msg = f"Unable to request properties: {ex} - removing {removed_property} for next try"
+                _LOGGER.warning(msg)
                 fail(ex)
-                props_to_test.pop()
 
         non_empty_properties = {
             k: v for k, v in valid_properties.items() if v is not None

--- a/miio/device.py
+++ b/miio/device.py
@@ -330,9 +330,11 @@ class Device(metaclass=DeviceGroupMeta):
         while len(props_to_test) > 1:
             try:
                 click.echo(
-                    f"Testing {len(props_to_test)} properties at once.. ", nl=False
+                    f"Testing {len(props_to_test)} properties at once ({' '.join(props_to_test)}): ",
+                    nl=False,
                 )
                 resp = self.get_properties(props_to_test)
+
                 if len(resp) == len(props_to_test):
                     max_properties = len(props_to_test)
                     ok(f"OK for {max_properties} properties")

--- a/miio/device.py
+++ b/miio/device.py
@@ -308,14 +308,14 @@ class Device(metaclass=DeviceGroupMeta):
         for property in properties:
             try:
                 click.echo(f"Testing {property:{max_property_len+2}} ", nl=False)
-                resp = self.get_properties([property])
+                value = self.get_properties([property])
                 # Handle responses with one-element lists
-                if isinstance(resp, list) and len(resp) == 1:
-                    resp = resp.pop()
-                value = valid_properties[property] = resp
+                if isinstance(value, list) and len(value) == 1:
+                    value = value.pop()
                 if value is None:
                     fail("None")
                 else:
+                    valid_properties[property] = value
                     ok(f"{repr(value)} {type(value)}")
             except Exception as ex:
                 _LOGGER.warning("Unable to request %s: %s", property, ex)


### PR DESCRIPTION
* When the number of expected vs. returned differs, report the difference
* Report which properties are actively tested
* Report which property gets removed for the next round
* Only `''` is reported as empty response

Related to discussion in #1003