### PR TITLE
Fix exception on devices with removed lan_ctrl

### DIFF
--- a/miio/yeelight.py
+++ b/miio/yeelight.py
@@ -70,7 +70,10 @@ class YeelightStatus(DeviceStatus):
     @property
     def developer_mode(self) -> bool:
         """Return whether the developer mode is active."""
-        return bool(int(self.data["lan_ctrl"]))
+        lan_ctrl = self.data["lan_ctrl"]
+        if lan_ctrl:
+            return bool(int(lan_ctrl))
+        return None
 
     @property
     def save_state_on_change(self) -> bool:


### PR DESCRIPTION
Model: yeelink.light.ceiling22
Firmware version: 2.0.6_0030 
lan_ctrl was removed in firmware 2.0.6_0030 for this lamp. That's why we have exception when trying to convert None to int during yeelight status command. 
This pull request fix this.