### PR TITLE
Improve Yeelight support (expose more properties, add support for secondary lights)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,4 +7,5 @@ max-line-length = 88
 select = C,E,F,W,B,SIM,T
 # the line lengths are enforced by black and docformatter
 # therefore we ignore E501 and B950 here
-ignore = E501,B950,W503,E203
+# SIM119 - are irrelevant as we still support python 3.6 series
+ignore = E501,B950,W503,E203,SIM119

--- a/miio/tests/test_yeelight.py
+++ b/miio/tests/test_yeelight.py
@@ -21,6 +21,21 @@ class DummyLight(DummyDevice, Yeelight):
             "name": "test name",
             "lan_ctrl": "1",
             "save_state": "1",
+            "delayoff": "60",
+            "music_on": "1",
+            "flowing": "0",
+            "flow_params": "",
+            "active_mode": "1",
+            "nl_br": "100",
+            "bg_power": "off",
+            "bg_bright": "100",
+            "bg_lmode": "2",
+            "bg_rgb": "16711680",
+            "bg_hue": "359",
+            "bg_sat": "100",
+            "bg_ct": "3584",
+            "bg_flowing": "0",
+            "bg_flow_params": "",
         }
 
         self.return_values = {

--- a/miio/tests/test_yeelight.py
+++ b/miio/tests/test_yeelight.py
@@ -81,11 +81,11 @@ class TestYeelight(TestCase):
         assert repr(status) == repr(YeelightStatus(self.device.start_state))
 
         assert status.name == self.device.start_state["name"]
-        assert status.lights[0].is_on is False
-        assert status.lights[0].brightness == 100
-        assert status.lights[0].color_temp == 3584
-        assert status.lights[0].color_mode == YeelightMode.ColorTemperature
-        assert status.lights[0].rgb is None
+        assert status.is_on is False
+        assert status.brightness == 100
+        assert status.color_temp == 3584
+        assert status.color_mode == YeelightMode.ColorTemperature
+        assert status.rgb is None
         assert status.developer_mode is True
         assert status.save_state_on_change is True
 
@@ -95,21 +95,21 @@ class TestYeelight(TestCase):
 
     def test_on(self):
         self.device.off()  # make sure we are off
-        assert self.device.status().lights[0].is_on is False
+        assert self.device.status().is_on is False
 
         self.device.on()
-        assert self.device.status().lights[0].is_on is True
+        assert self.device.status().is_on is True
 
     def test_off(self):
         self.device.on()  # make sure we are on
-        assert self.device.status().lights[0].is_on is True
+        assert self.device.status().is_on is True
 
         self.device.off()
-        assert self.device.status().lights[0].is_on is False
+        assert self.device.status().is_on is False
 
     def test_set_brightness(self):
         def brightness():
-            return self.device.status().lights[0].brightness
+            return self.device.status().brightness
 
         self.device.set_brightness(50)
         assert brightness() == 50
@@ -125,7 +125,7 @@ class TestYeelight(TestCase):
 
     def test_set_color_temp(self):
         def color_temp():
-            return self.device.status().lights[0].color_temp
+            return self.device.status().color_temp
 
         self.device.set_color_temp(2000)
         assert color_temp() == 2000
@@ -140,7 +140,7 @@ class TestYeelight(TestCase):
 
     def test_set_rgb(self):
         def rgb():
-            return self.device.status().lights[0].rgb
+            return self.device.status().rgb
 
         self.device._reset_state()
         self.device._set_state("color_mode", [1])
@@ -175,7 +175,7 @@ class TestYeelight(TestCase):
     @pytest.mark.skip("hsv is not properly implemented")
     def test_set_hsv(self):
         self.reset_state()
-        hue, sat, val = self.device.status().lights[0].hsv
+        hue, sat, val = self.device.status().hsv
         assert hue == 359
         assert sat == 100
         assert val == 100
@@ -215,7 +215,7 @@ class TestYeelight(TestCase):
 
     def test_toggle(self):
         def is_on():
-            return self.device.status().lights[0].is_on
+            return self.device.status().is_on
 
         orig_state = is_on()
         self.device.toggle()

--- a/miio/tests/test_yeelight.py
+++ b/miio/tests/test_yeelight.py
@@ -81,11 +81,11 @@ class TestYeelight(TestCase):
         assert repr(status) == repr(YeelightStatus(self.device.start_state))
 
         assert status.name == self.device.start_state["name"]
-        assert status.is_on is False
-        assert status.brightness == 100
-        assert status.color_temp == 3584
-        assert status.color_mode == YeelightMode.ColorTemperature
-        assert status.rgb is None
+        assert status.lights[0].is_on is False
+        assert status.lights[0].brightness == 100
+        assert status.lights[0].color_temp == 3584
+        assert status.lights[0].color_mode == YeelightMode.ColorTemperature
+        assert status.lights[0].rgb is None
         assert status.developer_mode is True
         assert status.save_state_on_change is True
 
@@ -95,21 +95,21 @@ class TestYeelight(TestCase):
 
     def test_on(self):
         self.device.off()  # make sure we are off
-        assert self.device.status().is_on is False
+        assert self.device.status().lights[0].is_on is False
 
         self.device.on()
-        assert self.device.status().is_on is True
+        assert self.device.status().lights[0].is_on is True
 
     def test_off(self):
         self.device.on()  # make sure we are on
-        assert self.device.status().is_on is True
+        assert self.device.status().lights[0].is_on is True
 
         self.device.off()
-        assert self.device.status().is_on is False
+        assert self.device.status().lights[0].is_on is False
 
     def test_set_brightness(self):
         def brightness():
-            return self.device.status().brightness
+            return self.device.status().lights[0].brightness
 
         self.device.set_brightness(50)
         assert brightness() == 50
@@ -125,7 +125,7 @@ class TestYeelight(TestCase):
 
     def test_set_color_temp(self):
         def color_temp():
-            return self.device.status().color_temp
+            return self.device.status().lights[0].color_temp
 
         self.device.set_color_temp(2000)
         assert color_temp() == 2000
@@ -140,7 +140,7 @@ class TestYeelight(TestCase):
 
     def test_set_rgb(self):
         def rgb():
-            return self.device.status().rgb
+            return self.device.status().lights[0].rgb
 
         self.device._reset_state()
         self.device._set_state("color_mode", [1])
@@ -175,7 +175,7 @@ class TestYeelight(TestCase):
     @pytest.mark.skip("hsv is not properly implemented")
     def test_set_hsv(self):
         self.reset_state()
-        hue, sat, val = self.device.status().hsv
+        hue, sat, val = self.device.status().lights[0].hsv
         assert hue == 359
         assert sat == 100
         assert val == 100
@@ -215,7 +215,7 @@ class TestYeelight(TestCase):
 
     def test_toggle(self):
         def is_on():
-            return self.device.status().is_on
+            return self.device.status().lights[0].is_on
 
         orig_state = is_on()
         self.device.toggle()

--- a/miio/tests/test_yeelight.py
+++ b/miio/tests/test_yeelight.py
@@ -10,34 +10,6 @@ from .dummies import DummyDevice
 
 class DummyLight(DummyDevice, Yeelight):
     def __init__(self, *args, **kwargs):
-        self.state = {
-            "power": "off",
-            "bright": "100",
-            "ct": "3584",
-            "rgb": "16711680",
-            "hue": "359",
-            "sat": "100",
-            "color_mode": "2",
-            "name": "test name",
-            "lan_ctrl": "1",
-            "save_state": "1",
-            "delayoff": "60",
-            "music_on": "1",
-            "flowing": "0",
-            "flow_params": "",
-            "active_mode": "1",
-            "nl_br": "100",
-            "bg_power": "off",
-            "bg_bright": "100",
-            "bg_lmode": "2",
-            "bg_rgb": "16711680",
-            "bg_hue": "359",
-            "bg_sat": "100",
-            "bg_ct": "3584",
-            "bg_flowing": "0",
-            "bg_flow_params": "",
-        }
-
         self.return_values = {
             "get_prop": self._get_state,
             "set_power": lambda x: self._set_state("power", x),
@@ -66,14 +38,46 @@ class DummyLight(DummyDevice, Yeelight):
             self.state["power"] = "on"
 
 
+class DummyLightСolor(DummyLight):
+    def __init__(self, *args, **kwargs):
+        self.state = {
+            "name": "test name",
+            "lan_ctrl": "1",
+            "save_state": "1",
+            "delayoff": "0",
+            "music_on": "1",
+            "power": "off",
+            "bright": "100",
+            "color_mode": "2",
+            "rgb": "16711680",
+            "hue": "359",
+            "sat": "100",
+            "ct": "3584",
+            "flowing": "0",
+            "flow_params": "0,0,1000,1,16711680,100,1000,1,65280,100,1000,1,255,100",
+            "active_mode": "",
+            "nl_br": "",
+            "bg_power": "",
+            "bg_bright": "",
+            "bg_lmode": "",
+            "bg_rgb": "",
+            "bg_hue": "",
+            "bg_sat": "",
+            "bg_ct": "",
+            "bg_flowing": "",
+            "bg_flow_params": "",
+        }
+        super().__init__(*args, **kwargs)
+
+
 @pytest.fixture(scope="class")
-def dummylight(request):
-    request.cls.device = DummyLight()
+def dummylightcolor(request):
+    request.cls.device = DummyLightСolor()
     # TODO add ability to test on a real device
 
 
-@pytest.mark.usefixtures("dummylight")
-class TestYeelight(TestCase):
+@pytest.mark.usefixtures("dummylightcolor")
+class TestYeelightLightColor(TestCase):
     def test_status(self):
         self.device._reset_state()
         status = self.device.status()  # type: YeelightStatus
@@ -81,17 +85,41 @@ class TestYeelight(TestCase):
         assert repr(status) == repr(YeelightStatus(self.device.start_state))
 
         assert status.name == self.device.start_state["name"]
-        assert status.is_on is False
-        assert status.brightness == 100
-        assert status.color_temp == 3584
-        assert status.color_mode == YeelightMode.ColorTemperature
-        assert status.rgb is None
         assert status.developer_mode is True
         assert status.save_state_on_change is True
-
+        assert status.delay_off == 0
+        assert status.music_mode is True
+        assert len(status.lights) == 1
+        assert status.is_on is False and status.is_on == status.lights[0].is_on
+        assert (
+            status.brightness == 100
+            and status.brightness == status.lights[0].brightness
+        )
+        assert (
+            status.color_mode == YeelightMode.ColorTemperature
+            and status.color_mode == status.lights[0].color_mode
+        )
+        assert (
+            status.color_temp == 3584
+            and status.color_temp == status.lights[0].color_temp
+        )
+        assert status.rgb is None and status.rgb == status.lights[0].rgb
+        assert status.hsv is None and status.hsv == status.lights[0].hsv
         # following are tested in set mode tests
         # assert status.rgb == 16711680
         # assert status.hsv == (359, 100, 100)
+        assert (
+            status.color_flowing is False
+            and status.color_flowing == status.lights[0].color_flowing
+        )
+        assert (
+            status.color_flow_params is None
+            and status.color_flow_params == status.lights[0].color_flow_params
+        )
+        # color_flow_params will be tested after future implementation
+        # assert status.color_flow_params == "0,0,1000,1,16711680,100,1000,1,65280,100,1000,1,255,100" and status.color_flow_params == status.lights[0].color_flow_params
+        assert status.moonlight_mode is None
+        assert status.moonlight_mode_brightness is None
 
     def test_on(self):
         self.device.off()  # make sure we are off
@@ -233,3 +261,360 @@ class TestYeelight(TestCase):
     @pytest.mark.skip("set_scene is not implemented")
     def test_set_scene(self):
         self.fail()
+
+
+class DummyLightCeilingV1(DummyLight):  # without background light
+    def __init__(self, *args, **kwargs):
+        self.state = {
+            "name": "test name",
+            "lan_ctrl": "1",
+            "save_state": "1",
+            "delayoff": "0",
+            "music_on": "",
+            "power": "off",
+            "bright": "100",
+            "color_mode": "2",
+            "rgb": "",
+            "hue": "",
+            "sat": "",
+            "ct": "3584",
+            "flowing": "0",
+            "flow_params": "0,0,2000,3,0,33,2000,3,0,100",
+            "active_mode": "1",
+            "nl_br": "100",
+            "bg_power": "",
+            "bg_bright": "",
+            "bg_lmode": "",
+            "bg_rgb": "",
+            "bg_hue": "",
+            "bg_sat": "",
+            "bg_ct": "",
+            "bg_flowing": "",
+            "bg_flow_params": "",
+        }
+        super().__init__(*args, **kwargs)
+
+
+@pytest.fixture(scope="class")
+def dummylightceilingv1(request):
+    request.cls.device = DummyLightCeilingV1()
+    # TODO add ability to test on a real device
+
+
+@pytest.mark.usefixtures("dummylightceilingv1")
+class TestYeelightLightCeilingV1(TestCase):
+    def test_status(self):
+        self.device._reset_state()
+        status = self.device.status()  # type: YeelightStatus
+
+        assert repr(status) == repr(YeelightStatus(self.device.start_state))
+
+        assert status.name == self.device.start_state["name"]
+        assert status.developer_mode is True
+        assert status.save_state_on_change is True
+        assert status.delay_off == 0
+        assert status.music_mode is None
+        assert len(status.lights) == 1
+        assert status.is_on is False and status.is_on == status.lights[0].is_on
+        assert (
+            status.brightness == 100
+            and status.brightness == status.lights[0].brightness
+        )
+        assert (
+            status.color_mode == YeelightMode.ColorTemperature
+            and status.color_mode == status.lights[0].color_mode
+        )
+        assert (
+            status.color_temp == 3584
+            and status.color_temp == status.lights[0].color_temp
+        )
+        assert status.rgb is None and status.rgb == status.lights[0].rgb
+        assert status.hsv is None and status.hsv == status.lights[0].hsv
+        # following are tested in set mode tests
+        # assert status.rgb == 16711680
+        # assert status.hsv == (359, 100, 100)
+        assert (
+            status.color_flowing is False
+            and status.color_flowing == status.lights[0].color_flowing
+        )
+        assert (
+            status.color_flow_params is None
+            and status.color_flow_params == status.lights[0].color_flow_params
+        )
+        # color_flow_params will be tested after future implementation
+        # assert status.color_flow_params == "0,0,1000,1,16711680,100,1000,1,65280,100,1000,1,255,100" and status.color_flow_params == status.lights[0].color_flow_params
+        assert status.moonlight_mode is True
+        assert status.moonlight_mode_brightness == 100
+
+    def test_on(self):
+        self.device.off()  # make sure we are off
+        assert self.device.status().is_on is False
+
+        self.device.on()
+        assert self.device.status().is_on is True
+
+    def test_off(self):
+        self.device.on()  # make sure we are on
+        assert self.device.status().is_on is True
+
+        self.device.off()
+        assert self.device.status().is_on is False
+
+    def test_set_brightness(self):
+        def brightness():
+            return self.device.status().brightness
+
+        self.device.set_brightness(50)
+        assert brightness() == 50
+        self.device.set_brightness(0)
+        assert brightness() == 0
+        self.device.set_brightness(100)
+
+        with pytest.raises(YeelightException):
+            self.device.set_brightness(-100)
+
+        with pytest.raises(YeelightException):
+            self.device.set_brightness(200)
+
+    def test_set_color_temp(self):
+        def color_temp():
+            return self.device.status().color_temp
+
+        self.device.set_color_temp(2000)
+        assert color_temp() == 2000
+        self.device.set_color_temp(6500)
+        assert color_temp() == 6500
+
+        with pytest.raises(YeelightException):
+            self.device.set_color_temp(1000)
+
+        with pytest.raises(YeelightException):
+            self.device.set_color_temp(7000)
+
+    def test_set_developer_mode(self):
+        def dev_mode():
+            return self.device.status().developer_mode
+
+        orig_mode = dev_mode()
+        self.device.set_developer_mode(not orig_mode)
+        new_mode = dev_mode()
+        assert new_mode is not orig_mode
+        self.device.set_developer_mode(not new_mode)
+        assert new_mode is not dev_mode()
+
+    def test_set_save_state_on_change(self):
+        def save_state():
+            return self.device.status().save_state_on_change
+
+        orig_state = save_state()
+        self.device.set_save_state_on_change(not orig_state)
+        new_state = save_state()
+        assert new_state is not orig_state
+        self.device.set_save_state_on_change(not new_state)
+        new_state = save_state()
+        assert new_state is orig_state
+
+    def test_set_name(self):
+        def name():
+            return self.device.status().name
+
+        assert name() == "test name"
+        self.device.set_name("new test name")
+        assert name() == "new test name"
+
+    def test_toggle(self):
+        def is_on():
+            return self.device.status().is_on
+
+        orig_state = is_on()
+        self.device.toggle()
+        new_state = is_on()
+        assert orig_state != new_state
+
+        self.device.toggle()
+        new_state = is_on()
+        assert new_state == orig_state
+
+
+class DummyLightCeilingV2(DummyLight):  # without background light
+    def __init__(self, *args, **kwargs):
+        self.state = {
+            "name": "test name",
+            "lan_ctrl": "1",
+            "save_state": "1",
+            "delayoff": "0",
+            "music_on": "",
+            "power": "off",
+            "bright": "100",
+            "color_mode": "2",
+            "rgb": "",
+            "hue": "",
+            "sat": "",
+            "ct": "3584",
+            "flowing": "0",
+            "flow_params": "0,0,2000,3,0,33,2000,3,0,100",
+            "active_mode": "1",
+            "nl_br": "100",
+            "bg_power": "off",
+            "bg_bright": "100",
+            "bg_lmode": "2",
+            "bg_rgb": "15531811",
+            "bg_hue": "65",
+            "bg_sat": "86",
+            "bg_ct": "4000",
+            "bg_flowing": "0",
+            "bg_flow_params": "0,0,3000,4,16711680,100,3000,4,65280,100,3000,4,255,100",
+        }
+        super().__init__(*args, **kwargs)
+
+
+@pytest.fixture(scope="class")
+def dummylightceilingv2(request):
+    request.cls.device = DummyLightCeilingV2()
+    # TODO add ability to test on a real device
+
+
+@pytest.mark.usefixtures("dummylightceilingv2")
+class TestYeelightLightCeilingV2(TestCase):
+    def test_status(self):
+        self.device._reset_state()
+        status = self.device.status()  # type: YeelightStatus
+
+        assert repr(status) == repr(YeelightStatus(self.device.start_state))
+
+        assert status.name == self.device.start_state["name"]
+        assert status.developer_mode is True
+        assert status.save_state_on_change is True
+        assert status.delay_off == 0
+        assert status.music_mode is None
+        assert len(status.lights) == 2
+        assert status.is_on is False and status.is_on == status.lights[0].is_on
+        assert (
+            status.brightness == 100
+            and status.brightness == status.lights[0].brightness
+        )
+        assert (
+            status.color_mode == YeelightMode.ColorTemperature
+            and status.color_mode == status.lights[0].color_mode
+        )
+        assert (
+            status.color_temp == 3584
+            and status.color_temp == status.lights[0].color_temp
+        )
+        assert status.rgb is None and status.rgb == status.lights[0].rgb
+        assert status.hsv is None and status.hsv == status.lights[0].hsv
+        # following are tested in set mode tests
+        # assert status.rgb == 16711680
+        # assert status.hsv == (359, 100, 100)
+        assert (
+            status.color_flowing is False
+            and status.color_flowing == status.lights[0].color_flowing
+        )
+        assert (
+            status.color_flow_params is None
+            and status.color_flow_params == status.lights[0].color_flow_params
+        )
+        # color_flow_params will be tested after future implementation
+        # assert status.color_flow_params == "0,0,1000,1,16711680,100,1000,1,65280,100,1000,1,255,100" and status.color_flow_params == status.lights[0].color_flow_params
+        assert status.lights[1].is_on is False
+        assert status.lights[1].brightness == 100
+        assert status.lights[1].color_mode == YeelightMode.ColorTemperature
+        assert status.lights[1].color_temp == 4000
+        assert status.lights[1].rgb is None
+        assert status.lights[1].hsv is None
+        # following are tested in set mode tests
+        # assert status.rgb == 15531811
+        # assert status.hsv == (65, 86, 100)
+        assert status.lights[1].color_flowing is False
+        assert status.lights[1].color_flow_params is None
+        assert status.moonlight_mode is True
+        assert status.moonlight_mode_brightness == 100
+
+    def test_on(self):
+        self.device.off()  # make sure we are off
+        assert self.device.status().is_on is False
+
+        self.device.on()
+        assert self.device.status().is_on is True
+
+    def test_off(self):
+        self.device.on()  # make sure we are on
+        assert self.device.status().is_on is True
+
+        self.device.off()
+        assert self.device.status().is_on is False
+
+    def test_set_brightness(self):
+        def brightness():
+            return self.device.status().brightness
+
+        self.device.set_brightness(50)
+        assert brightness() == 50
+        self.device.set_brightness(0)
+        assert brightness() == 0
+        self.device.set_brightness(100)
+
+        with pytest.raises(YeelightException):
+            self.device.set_brightness(-100)
+
+        with pytest.raises(YeelightException):
+            self.device.set_brightness(200)
+
+    def test_set_color_temp(self):
+        def color_temp():
+            return self.device.status().color_temp
+
+        self.device.set_color_temp(2000)
+        assert color_temp() == 2000
+        self.device.set_color_temp(6500)
+        assert color_temp() == 6500
+
+        with pytest.raises(YeelightException):
+            self.device.set_color_temp(1000)
+
+        with pytest.raises(YeelightException):
+            self.device.set_color_temp(7000)
+
+    def test_set_developer_mode(self):
+        def dev_mode():
+            return self.device.status().developer_mode
+
+        orig_mode = dev_mode()
+        self.device.set_developer_mode(not orig_mode)
+        new_mode = dev_mode()
+        assert new_mode is not orig_mode
+        self.device.set_developer_mode(not new_mode)
+        assert new_mode is not dev_mode()
+
+    def test_set_save_state_on_change(self):
+        def save_state():
+            return self.device.status().save_state_on_change
+
+        orig_state = save_state()
+        self.device.set_save_state_on_change(not orig_state)
+        new_state = save_state()
+        assert new_state is not orig_state
+        self.device.set_save_state_on_change(not new_state)
+        new_state = save_state()
+        assert new_state is orig_state
+
+    def test_set_name(self):
+        def name():
+            return self.device.status().name
+
+        assert name() == "test name"
+        self.device.set_name("new test name")
+        assert name() == "new test name"
+
+    def test_toggle(self):
+        def is_on():
+            return self.device.status().is_on
+
+        orig_state = is_on()
+        self.device.toggle()
+        new_state = is_on()
+        assert orig_state != new_state
+
+        self.device.toggle()
+        new_state = is_on()
+        assert new_state == orig_state

--- a/miio/yeelight.py
+++ b/miio/yeelight.py
@@ -214,19 +214,34 @@ class YeelightStatus(DeviceStatus):
         return sub_lights
 
     @property
-    def cli_format_lights(self) -> str:
+    def cli_format(self) -> str:
         """Return human readable sub lights string."""
-        s = ""
+        s = f"Name: {self.name}\n"
+        s += f"Update default on change: {self.save_state_on_change}\n"
+        s += f"Delay in minute before off: {self.delay_off}\n"
+        if self.music_mode is not None:
+            s += f"Music mode: {self.music_mode}\n"
+        if self.developer_mode is not None:
+            s += f"Developer mode: {self.developer_mode}\n"
         for light in self.lights:
             s += f"{light.type.name} light\n"
             s += f"   Power: {light.is_on}\n"
             s += f"   Brightness: {light.brightness}\n"
             s += f"   Color mode: {light.color_mode}\n"
-            s += f"   RGB: {light.rgb}\n"
-            s += f"   HSV: {light.hsv}\n"
-            s += f"   Temperature: {light.color_temp}\n"
+            if light.color_mode == YeelightMode.RGB:
+                s += f"   RGB: {light.rgb}\n"
+            elif light.color_mode == YeelightMode.HSV:
+                s += f"   HSV: {light.hsv}\n"
+            else:
+                s += f"   Temperature: {light.color_temp}\n"
             s += f"   Color flowing mode: {light.color_flowing}\n"
-            s += f"   Color flowing parameters: {light.color_flow_params}\n"
+            if light.color_flowing:
+                s += f"   Color flowing parameters: {light.color_flow_params}\n"
+        if self.moonlight_mode is not None:
+            s += "Moonlight\n"
+            s += f"   Is in mode: {self.moonlight_mode}\n"
+            s += f"   Moonlight mode brightness: {self.moonlight_mode_brightness}\n"
+        s += "\n"
         return s
 
 
@@ -249,21 +264,7 @@ class Yeelight(Device):
         )
         super().__init__(*args, **kwargs)
 
-    @command(
-        default_output=format_output(
-            "",
-            "Name: {result.name}\n"
-            "Developer mode: {result.developer_mode}\n"
-            "Update default on change: {result.save_state_on_change}\n"
-            "Delay in minute before off: {result.delay_off}\n"
-            "Music mode: {result.music_mode}\n"
-            "{result.cli_format_lights}"
-            "Moonlight\n"
-            "   Is in mode: {result.moonlight_mode}\n"
-            "   Moonlight mode brightness: {result.moonlight_mode_brightness}\n"
-            "\n",
-        )
-    )
+    @command(default_output=format_output("", "{result.cli_format}"))
     def status(self) -> YeelightStatus:
         """Retrieve properties."""
         properties = [

--- a/miio/yeelight.py
+++ b/miio/yeelight.py
@@ -127,6 +127,46 @@ class YeelightStatus(DeviceStatus):
         self.data = data
 
     @property
+    def is_on(self) -> bool:
+        """Return whether the light is on or off."""
+        return self.lights[0].is_on
+
+    @property
+    def brightness(self) -> int:
+        """Return current brightness."""
+        return self.lights[0].brightness
+
+    @property
+    def rgb(self) -> Optional[Tuple[int, int, int]]:
+        """Return color in RGB if RGB mode is active."""
+        return self.lights[0].rgb
+
+    @property
+    def color_mode(self) -> YeelightMode:
+        """Return current color mode."""
+        return self.lights[0].color_mode
+
+    @property
+    def hsv(self) -> Optional[Tuple[int, int, int]]:
+        """Return current color in HSV if HSV mode is active."""
+        return self.lights[0].hsv
+
+    @property
+    def color_temp(self) -> Optional[int]:
+        """Return current color temperature, if applicable."""
+        return self.lights[0].color_temp
+
+    @property
+    def color_flowing(self) -> bool:
+        """Return whether the color flowing is active."""
+        return self.lights[0].color_flowing
+
+    @property
+    def color_flow_params(self) -> Optional[str]:
+        """Return color flowing params."""
+        return self.lights[0].color_flow_params
+
+    @property
     def developer_mode(self) -> Optional[bool]:
         """Return whether the developer mode is active."""
         lan_ctrl = self.data["lan_ctrl"]

--- a/miio/yeelight.py
+++ b/miio/yeelight.py
@@ -41,6 +41,19 @@ class YeelightSubLight:
         self.data = data
         self.type = type
 
+    def __repr__(self):
+        s = "\n"
+        s += f"   Sub Light - {self.type.name} \n"
+        s += f"      Power: {self.is_on}\n"
+        s += f"      Brightness: {self.brightness}\n"
+        s += f"      Color mode: {self.color_mode}\n"
+        s += f"      RGB: {self.rgb}\n"
+        s += f"      HSV: {self.hsv}\n"
+        s += f"      Temperature: {self.color_temp}\n"
+        s += f"      Color flowing mode: {self.color_flowing}\n"
+        s += f"      Color flowing parameters: {self.color_flow_params}\n"
+        return s
+
     def get_prop_name(self, prop) -> str:
         if prop == "color_mode":
             return SUBLIGHT_COLOR_MODE_PROP[self.type]
@@ -201,28 +214,10 @@ class Yeelight(Device):
             "Update default on change: {result.save_state_on_change}\n"
             "Delay in minute before off: {result.delay_off}\n"
             "Music mode: {result.music_mode}\n"
-            "Light\n"
-            "   Power: {result.lights[0].is_on}\n"
-            "   Brightness: {result.lights[0].brightness}\n"
-            "   Color mode: {result.lights[0].color_mode}\n"
-            "   RGB: {result.lights[0].rgb}\n"
-            "   HSV: {result.lights[0].hsv}\n"
-            "   Temperature: {result.lights[0].color_temp}\n"
-            "   Color flowing mode: {result.lights[0].color_flowing}\n"
-            "   Color flowing parameters: {result.lights[0].color_flow_params}\n"
+            "Lights: \n{result.lights}\n"
             "Moonlight\n"
             "   Is in mode: {result.moonlight_mode}\n"
             "   Moonlight mode brightness: {result.moonlight_mode_brightness}\n"
-            # Have no any idea how it must be
-            # "Background light\n"
-            # "   Power: {result.lights[1].is_on}\n"
-            # "   Brightness: {result.lights[1].brightness}\n"
-            # "   Color mode: {result.lights[1].color_mode}\n"
-            # "   RGB: {result.lights[1].rgb}\n"
-            # "   HSV: {result.lights[1].hsv}\n"
-            # "   Temperature: {result.lights[1].color_temp}\n"
-            # "   Color flowing mode: {result.lights[1].color_flowing}\n"
-            # "   Color flowing parameters: {result.lights[1].color_flow_params}\n"
             "\n",
         )
     )

--- a/miio/yeelight.py
+++ b/miio/yeelight.py
@@ -227,7 +227,7 @@ class YeelightStatus(DeviceStatus):
             s += f"{light.type.name} light\n"
             s += f"   Power: {light.is_on}\n"
             s += f"   Brightness: {light.brightness}\n"
-            s += f"   Color mode: {light.color_mode}\n"
+            s += f"   Color mode: {light.color_mode.name}\n"
             if light.color_mode == YeelightMode.RGB:
                 s += f"   RGB: {light.rgb}\n"
             elif light.color_mode == YeelightMode.HSV:

--- a/miio/yeelight.py
+++ b/miio/yeelight.py
@@ -36,23 +36,10 @@ class YeelightMode(IntEnum):
     HSV = 3
 
 
-class YeelightSubLight:
+class YeelightSubLight(DeviceStatus):
     def __init__(self, data, type):
         self.data = data
         self.type = type
-
-    def __repr__(self):
-        s = "\n"
-        s += f"   Sub Light - {self.type.name} \n"
-        s += f"      Power: {self.is_on}\n"
-        s += f"      Brightness: {self.brightness}\n"
-        s += f"      Color mode: {self.color_mode}\n"
-        s += f"      RGB: {self.rgb}\n"
-        s += f"      HSV: {self.hsv}\n"
-        s += f"      Temperature: {self.color_temp}\n"
-        s += f"      Color flowing mode: {self.color_flowing}\n"
-        s += f"      Color flowing parameters: {self.color_flow_params}\n"
-        return s
 
     def get_prop_name(self, prop) -> str:
         if prop == "color_mode":
@@ -226,6 +213,22 @@ class YeelightStatus(DeviceStatus):
             )
         return sub_lights
 
+    @property
+    def cli_format_lights(self) -> str:
+        """Return human readable sub lights string."""
+        s = ""
+        for light in self.lights:
+            s += f"{light.type.name} light\n"
+            s += f"   Power: {light.is_on}\n"
+            s += f"   Brightness: {light.brightness}\n"
+            s += f"   Color mode: {light.color_mode}\n"
+            s += f"   RGB: {light.rgb}\n"
+            s += f"   HSV: {light.hsv}\n"
+            s += f"   Temperature: {light.color_temp}\n"
+            s += f"   Color flowing mode: {light.color_flowing}\n"
+            s += f"   Color flowing parameters: {light.color_flow_params}\n"
+        return s
+
 
 class Yeelight(Device):
     """A rudimentary support for Yeelight bulbs.
@@ -254,7 +257,7 @@ class Yeelight(Device):
             "Update default on change: {result.save_state_on_change}\n"
             "Delay in minute before off: {result.delay_off}\n"
             "Music mode: {result.music_mode}\n"
-            "Lights: \n{result.lights}\n"
+            "{result.cli_format_lights}"
             "Moonlight\n"
             "   Is in mode: {result.moonlight_mode}\n"
             "   Moonlight mode brightness: {result.moonlight_mode_brightness}\n"

--- a/miio/yeelight.py
+++ b/miio/yeelight.py
@@ -100,7 +100,7 @@ class YeelightStatus(DeviceStatus):
     @property
     def delay_off(self) -> int:
         """Return delay in minute before bulb is off."""
-        return self.data["delayoff"]
+        return int(self.data["delayoff"])
 
     @property
     def music_mode(self) -> Optional[bool]:

--- a/miio/yeelight.py
+++ b/miio/yeelight.py
@@ -22,8 +22,14 @@ class YeelightMode(IntEnum):
 
 class YeelightStatus(DeviceStatus):
     def __init__(self, data):
-        # ['name', 'lan_ctrl', 'save_state', 'delayoff', 'music_on', 'power', 'bright', 'color_mode', 'rgb',      'hue', 'sat', 'ct',   'flowing', 'flow_params', 'active_mode', 'nl_br', 'bg_power', 'bg_bright', 'bg_lmode', 'bg_rgb',   'bg_hue', 'bg_sat', 'bg_ct', 'bg_flowing', 'bg_flow_params']
-        # ['name', '1',        '1',          '60',       '1',        'on',    '100',    '2',          '16711680', '359', '100', '3584', '1',       '[0, 24, 0]',  '1',           '100',   'on',       '100',       '2',        '16711680', '359',    '100',    '3584',  '1',          '[0, 24, 0]']
+        # yeelink.light.ceiling4, yeelink.light.ceiling20
+        # {'name': '', 'lan_ctrl': '1', 'save_state': '1', 'delayoff': '0', 'music_on': '',  'power': 'off', 'bright': '1',   'color_mode': '2', 'rgb': '',        'hue': '',    'sat': '',   'ct': '4115', 'flowing': '0', 'flow_params': '0,0,2000,3,0,33,2000,3,0,100',                                                                                                          'active_mode': '1', 'nl_br': '1', 'bg_power': 'off', 'bg_bright': '100', 'bg_lmode': '1', 'bg_rgb': '15531811', 'bg_hue': '65',  'bg_sat': '86', 'bg_ct': '4000', 'bg_flowing': '0', 'bg_flow_params': '0,0,3000,4,16711680,100,3000,4,65280,100,3000,4,255,100'}
+        # yeelink.light.ceiling1
+        # {'name': '', 'lan_ctrl': '1', 'save_state': '1', 'delayoff': '0', 'music_on': '',  'power': 'off', 'bright': '100', 'color_mode': '2', 'rgb': '',        'hue': '',    'sat': '',   'ct': '5200', 'flowing': '0', 'flow_params': '',                                                                                                                                      'active_mode': '0', 'nl_br': '0', 'bg_power': '',    'bg_bright': '',    'bg_lmode': '',  'bg_rgb': '', 'bg_hue': '', 'bg_sat': '', 'bg_ct': '', 'bg_flowing': '', 'bg_flow_params': ''}
+        # yeelink.light.ceiling22 - like yeelink.light.ceiling1 but without "lan_ctrl"
+        # {'name': '', 'lan_ctrl': '',  'save_state': '1', 'delayoff': '0', 'music_on': '',  'power': 'off', 'bright': '84',  'color_mode': '2', 'rgb': '',        'hue': '',    'sat': '',   'ct': '4000', 'flowing': '0', 'flow_params': '0,0,800,2,2700,50,800,2,2700,30,1200,2,2700,80,800,2,2700,60,1200,2,2700,90,2400,2,2700,50,1200,2,2700,80,800,2,2700,60,400,2,2700,70', 'active_mode': '0', 'nl_br': '0', 'bg_power': '',    'bg_bright': '',    'bg_lmode': '',  'bg_rgb': '', 'bg_hue': '', 'bg_sat': '', 'bg_ct': '', 'bg_flowing': '', 'bg_flow_params': ''}
+        # yeelink.light.color3, yeelink.light.color4, yeelink.light.color5, yeelink.light.strip2
+        # {'name': '', 'lan_ctrl': '1', 'save_state': '1', 'delayoff': '0', 'music_on': '0', 'power': 'off', 'bright': '100', 'color_mode': '1', 'rgb': '2353663', 'hue': '186', 'sat': '86', 'ct': '6500', 'flowing': '0', 'flow_params': '0,0,1000,1,16711680,100,1000,1,65280,100,1000,1,255,100',                                                                               'active_mode': '',  'nl_br': '',  'bg_power': '',    'bg_bright': '',    'bg_lmode': '',  'bg_rgb': '', 'bg_hue': '', 'bg_sat': '', 'bg_ct': '', 'bg_flowing': '', 'bg_flow_params': ''}
         self.data = data
 
     @property


### PR DESCRIPTION
In this pull request I want to add more property to Yeelight (I looked to python-yeelight and operation specification). Base reason of this because Yeelight closing lan controle for theirs lamps that`s why I want to add all functionality from python-yeelight to this repository. This is first PR from many :)

@rytilahti due to this pull request I want to ask some question:
1) First off all Yeelight has very different lamp. Is it ok that we use one Device class to describe them all?
2) Second I use "status" command to get all type of the properties. Maybe better add additional command like "bg_status" for Background light. What is better for Home Assistant integration?

I would be grateful for any criticism