### PR TITLE
Add model autodetection

### DIFF
--- a/docs/api/miio.rst
+++ b/docs/api/miio.rst
@@ -43,6 +43,7 @@ Submodules
    miio.cooker
    miio.curtain_youpin
    miio.device
+   miio.deviceinfo
    miio.discovery
    miio.dreamevacuum_miot
    miio.exceptions

--- a/miio/airconditioningcompanion.py
+++ b/miio/airconditioningcompanion.py
@@ -236,12 +236,9 @@ class AirConditioningCompanion(Device):
         lazy_discover: bool = True,
         model: str = MODEL_ACPARTNER_V2,
     ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover)
+        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
 
-        if model in MODELS_SUPPORTED:
-            self.model = model
-        else:
-            self.model = MODEL_ACPARTNER_V2
+        if self.model not in MODELS_SUPPORTED:
             _LOGGER.error(
                 "Device model %s unsupported. Falling back to %s.", model, self.model
             )

--- a/miio/airdehumidifier.py
+++ b/miio/airdehumidifier.py
@@ -167,12 +167,7 @@ class AirDehumidifier(Device):
         lazy_discover: bool = True,
         model: str = MODEL_DEHUMIDIFIER_V1,
     ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover)
-
-        if model in AVAILABLE_PROPERTIES:
-            self.model = model
-        else:
-            self.model = MODEL_DEHUMIDIFIER_V1
+        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
 
         self.device_info: DeviceInfo
 

--- a/miio/airfresh.py
+++ b/miio/airfresh.py
@@ -227,12 +227,7 @@ class AirFresh(Device):
         lazy_discover: bool = True,
         model: str = MODEL_AIRFRESH_VA2,
     ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover)
-
-        if model in AVAILABLE_PROPERTIES:
-            self.model = model
-        else:
-            self.model = MODEL_AIRFRESH_VA2
+        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
 
     @command(
         default_output=format_output(

--- a/miio/airfresh_t2017.py
+++ b/miio/airfresh_t2017.py
@@ -233,12 +233,7 @@ class AirFreshA1(Device):
         lazy_discover: bool = True,
         model: str = MODEL_AIRFRESH_A1,
     ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover)
-
-        if model in AVAILABLE_PROPERTIES:
-            self.model = model
-        else:
-            self.model = MODEL_AIRFRESH_A1
+        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
 
     @command(
         default_output=format_output(
@@ -380,12 +375,7 @@ class AirFreshT2017(AirFreshA1):
         lazy_discover: bool = True,
         model: str = MODEL_AIRFRESH_T2017,
     ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover)
-
-        if model in AVAILABLE_PROPERTIES:
-            self.model = model
-        else:
-            self.model = MODEL_AIRFRESH_T2017
+        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
 
     @command(
         default_output=format_output(

--- a/miio/airhumidifier.py
+++ b/miio/airhumidifier.py
@@ -236,12 +236,7 @@ class AirHumidifier(Device):
         lazy_discover: bool = True,
         model: str = MODEL_HUMIDIFIER_V1,
     ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover)
-
-        if model in AVAILABLE_PROPERTIES:
-            self.model = model
-        else:
-            self.model = MODEL_HUMIDIFIER_V1
+        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
 
         # TODO: convert to use generic device info in the future
         self.device_info: Optional[DeviceInfo] = None

--- a/miio/airhumidifier_jsq.py
+++ b/miio/airhumidifier_jsq.py
@@ -142,9 +142,9 @@ class AirHumidifierJsq(Device):
         lazy_discover: bool = True,
         model: str = MODEL_HUMIDIFIER_JSQ001,
     ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover)
-
-        self.model = model if model in AVAILABLE_PROPERTIES else MODEL_HUMIDIFIER_JSQ001
+        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
+        if model not in AVAILABLE_PROPERTIES:
+            self._model = MODEL_HUMIDIFIER_JSQ001
 
     @command(
         default_output=format_output(

--- a/miio/airhumidifier_mjjsq.py
+++ b/miio/airhumidifier_mjjsq.py
@@ -131,12 +131,7 @@ class AirHumidifierMjjsq(Device):
         lazy_discover: bool = True,
         model: str = MODEL_HUMIDIFIER_MJJSQ,
     ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover)
-
-        if model in AVAILABLE_PROPERTIES:
-            self.model = model
-        else:
-            self.model = MODEL_HUMIDIFIER_MJJSQ
+        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
 
     @command(
         default_output=format_output(

--- a/miio/airpurifier_airdog.py
+++ b/miio/airpurifier_airdog.py
@@ -109,12 +109,7 @@ class AirDogX3(Device):
         lazy_discover: bool = True,
         model: str = MODEL_AIRDOG_X3,
     ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover)
-
-        if model in AVAILABLE_PROPERTIES:
-            self.model = model
-        else:
-            self.model = MODEL_AIRDOG_X3
+        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
 
     @command(
         default_output=format_output(
@@ -200,12 +195,7 @@ class AirDogX5(AirDogX3):
         lazy_discover: bool = True,
         model: str = MODEL_AIRDOG_X5,
     ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover)
-
-        if model in AVAILABLE_PROPERTIES:
-            self.model = model
-        else:
-            self.model = MODEL_AIRDOG_X5
+        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
 
 
 class AirDogX7SM(AirDogX3):
@@ -218,9 +208,4 @@ class AirDogX7SM(AirDogX3):
         lazy_discover: bool = True,
         model: str = MODEL_AIRDOG_X7SM,
     ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover)
-
-        if model in AVAILABLE_PROPERTIES:
-            self.model = model
-        else:
-            self.model = MODEL_AIRDOG_X7SM
+        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)

--- a/miio/airqualitymonitor.py
+++ b/miio/airqualitymonitor.py
@@ -160,18 +160,12 @@ class AirQualityMonitor(Device):
         lazy_discover: bool = True,
         model: str = MODEL_AIRQUALITYMONITOR_V1,
     ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover)
+        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
 
-        if model in AVAILABLE_PROPERTIES:
-            self.model = model
-        elif model is not None:
-            self.model = MODEL_AIRQUALITYMONITOR_V1
+        if model not in AVAILABLE_PROPERTIES:
             _LOGGER.error(
                 "Device model %s unsupported. Falling back to %s.", model, self.model
             )
-        else:
-            # Force autodetection.
-            self.model = None
 
     @command(
         default_output=format_output(
@@ -191,11 +185,6 @@ class AirQualityMonitor(Device):
     )
     def status(self) -> AirQualityMonitorStatus:
         """Return device status."""
-
-        if self.model is None:
-            info = self.info()
-            self.model = info.model
-
         properties = AVAILABLE_PROPERTIES[self.model]
 
         if self.model == MODEL_AIRQUALITYMONITOR_B1:

--- a/miio/chuangmi_plug.py
+++ b/miio/chuangmi_plug.py
@@ -101,9 +101,9 @@ class ChuangmiPlug(Device):
         super().__init__(ip, token, start_id, debug, lazy_discover)
 
         if model in AVAILABLE_PROPERTIES:
-            self.model = model
+            self._model = model
         else:
-            self.model = MODEL_CHUANGMI_PLUG_M1
+            self._model = MODEL_CHUANGMI_PLUG_M1
 
     @command(
         default_output=format_output(
@@ -182,6 +182,8 @@ class Plug(ChuangmiPlug):
         start_id: int = 0,
         debug: int = 0,
         lazy_discover: bool = True,
+        *,
+        model: str = None
     ) -> None:
         super().__init__(
             ip, token, start_id, debug, lazy_discover, model=MODEL_CHUANGMI_PLUG_M1

--- a/miio/click_common.py
+++ b/miio/click_common.py
@@ -179,8 +179,11 @@ class DeviceGroup(click.MultiCommand):
                         and self._model is None
                         and self._info is None
                     ):
-                        _LOGGER.debug("Unknown model, trying autodetection.")
-                        self.info()
+                        _LOGGER.debug(
+                            "Unknown model, trying autodetection. %s %s"
+                            % (self._model, self._info)
+                        )
+                        self._fetch_info()
                     return func(self, *args, **kwargs)
 
                 # TODO HACK to make the command visible to cli

--- a/miio/device.py
+++ b/miio/device.py
@@ -7,6 +7,7 @@ from typing import Any, Optional  # noqa: F401
 import click
 
 from .click_common import DeviceGroupMeta, LiteralParamType, command, format_output
+from .deviceinfo import DeviceInfo
 from .exceptions import DeviceInfoUnavailableException, PayloadDecodeException
 from .miioprotocol import MiIOProtocol
 
@@ -18,88 +19,6 @@ class UpdateState(Enum):
     Installing = "installing"
     Failed = "failed"
     Idle = "idle"
-
-
-class DeviceInfo:
-    """Container of miIO device information.
-
-    Hardware properties such as device model, MAC address, memory information, and
-    hardware and software information is contained here.
-    """
-
-    def __init__(self, data):
-        """Response of a Xiaomi Smart WiFi Plug.
-
-        {'ap': {'bssid': 'FF:FF:FF:FF:FF:FF', 'rssi': -68, 'ssid': 'network'},
-         'cfg_time': 0,
-         'fw_ver': '1.2.4_16',
-         'hw_ver': 'MW300',
-         'life': 24,
-         'mac': '28:FF:FF:FF:FF:FF',
-         'mmfree': 30312,
-         'model': 'chuangmi.plug.m1',
-         'netif': {'gw': '192.168.xxx.x',
-                   'localIp': '192.168.xxx.x',
-                   'mask': '255.255.255.0'},
-         'ot': 'otu',
-         'ott_stat': [0, 0, 0, 0],
-         'otu_stat': [320, 267, 3, 0, 3, 742],
-         'token': '2b00042f7481c7b056c4b410d28f33cf',
-         'wifi_fw_ver': 'SD878x-14.76.36.p84-702.1.0-WM'}
-        """
-        self.data = data
-
-    def __repr__(self):
-        return "%s v%s (%s) @ %s - token: %s" % (
-            self.data["model"],
-            self.data["fw_ver"],
-            self.data["mac"],
-            self.network_interface["localIp"],
-            self.data["token"],
-        )
-
-    @property
-    def network_interface(self):
-        """Information about network configuration."""
-        return self.data["netif"]
-
-    @property
-    def accesspoint(self):
-        """Information about connected wlan accesspoint."""
-        return self.data["ap"]
-
-    @property
-    def model(self) -> Optional[str]:
-        """Model string if available."""
-        if self.data["model"] is not None:
-            return self.data["model"]
-        return None
-
-    @property
-    def firmware_version(self) -> Optional[str]:
-        """Firmware version if available."""
-        if self.data["fw_ver"] is not None:
-            return self.data["fw_ver"]
-        return None
-
-    @property
-    def hardware_version(self) -> Optional[str]:
-        """Hardware version if available."""
-        if self.data["hw_ver"] is not None:
-            return self.data["hw_ver"]
-        return None
-
-    @property
-    def mac_address(self) -> Optional[str]:
-        """MAC address if available."""
-        if self.data["mac"] is not None:
-            return self.data["mac"]
-        return None
-
-    @property
-    def raw(self):
-        """Raw data as returned by the device."""
-        return self.data
 
 
 class DeviceStatus:
@@ -144,9 +63,13 @@ class Device(metaclass=DeviceGroupMeta):
         debug: int = 0,
         lazy_discover: bool = True,
         timeout: int = None,
+        *,
+        model: str = None,
     ) -> None:
         self.ip = ip
         self.token = token
+        self._model = model
+        self._info = None
         timeout = timeout if timeout is not None else self.timeout
         self._protocol = MiIOProtocol(
             ip, token, start_id, debug, lazy_discover, timeout
@@ -173,6 +96,7 @@ class Device(metaclass=DeviceGroupMeta):
         :param dict parameters: Parameters to send
         :param int retry_count: How many times to retry on error
         :param dict extra_parameters: Extra top-level parameters
+        :param str model: Force model to avoid autodetection
         """
         retry_count = retry_count if retry_count is not None else self.retry_count
         return self._protocol.send(
@@ -202,25 +126,42 @@ class Device(metaclass=DeviceGroupMeta):
             "Model: {result.model}\n"
             "Hardware version: {result.hardware_version}\n"
             "Firmware version: {result.firmware_version}\n",
-        )
+        ),
+        skip_autodetect=True,
     )
-    def info(self) -> DeviceInfo:
-        """Get miIO protocol information from the device.
+    def info(self, *, skip_cache=False) -> DeviceInfo:
+        """Get (and cache) miIO protocol information from the device.
 
         This includes information about connected wlan network, and hardware and
         software versions.
+
+        :param force bool: Skip the cache
         """
+        if self._info is not None and not skip_cache:
+            return self._info
+
         try:
-            return DeviceInfo(self.send("miIO.info"))
+            devinfo = DeviceInfo(self.send("miIO.info"))
+            self._info = devinfo
+            _LOGGER.info("Detected model %s", devinfo.model)
+            return devinfo
         except PayloadDecodeException as ex:
             raise DeviceInfoUnavailableException(
                 "Unable to request miIO.info from the device"
             ) from ex
 
     @property
-    def raw_id(self):
+    def raw_id(self) -> int:
         """Return the last used protocol sequence id."""
         return self._protocol.raw_id
+
+    @property
+    def model(self) -> str:
+        """Return device model."""
+        if self._model is not None:
+            return self._model
+
+        return self.info().model
 
     def update(self, url: str, md5: str):
         """Start an OTA update."""

--- a/miio/device.py
+++ b/miio/device.py
@@ -54,7 +54,7 @@ class Device(metaclass=DeviceGroupMeta):
 
     retry_count = 3
     timeout = 5
-    _supported_models = []
+    _supported_models: List[str] = []
 
     def __init__(
         self,

--- a/miio/device.py
+++ b/miio/device.py
@@ -144,14 +144,16 @@ class Device(metaclass=DeviceGroupMeta):
         return self._fetch_info()
 
     def _fetch_info(self):
+        """Perform miIO.info query on the device and cache the result."""
         try:
             devinfo = DeviceInfo(self.send("miIO.info"))
             self._info = devinfo
-            _LOGGER.info("Detected model %s", devinfo.model)
+            _LOGGER.debug("Detected model %s", devinfo.model)
             if devinfo.model not in self.supported_models:
                 _LOGGER.warning(
-                    "Found an unsupported model %s, if this is working for you, please open an issue at https://github.com/rytilahti/python-miio/",
+                    "Found an unsupported model '%s' for class '%s'. If this is working for you, please open an issue at https://github.com/rytilahti/python-miio/",
                     self.model,
+                    self.__class__.__name__,
                 )
 
             return devinfo

--- a/miio/deviceinfo.py
+++ b/miio/deviceinfo.py
@@ -1,0 +1,89 @@
+from typing import Dict, Optional
+
+
+class DeviceInfo:
+    """Container of miIO device information.
+
+    Hardware properties such as device model, MAC address, memory information, and
+    hardware and software information is contained here.
+    """
+
+    def __init__(self, data):
+        """Response of a Xiaomi Smart WiFi Plug.
+
+        {'ap': {'bssid': 'FF:FF:FF:FF:FF:FF', 'rssi': -68, 'ssid': 'network'},
+         'cfg_time': 0,
+         'fw_ver': '1.2.4_16',
+         'hw_ver': 'MW300',
+         'life': 24,
+         'mac': '28:FF:FF:FF:FF:FF',
+         'mmfree': 30312,
+         'model': 'chuangmi.plug.m1',
+         'netif': {'gw': '192.168.xxx.x',
+                   'localIp': '192.168.xxx.x',
+                   'mask': '255.255.255.0'},
+         'ot': 'otu',
+         'ott_stat': [0, 0, 0, 0],
+         'otu_stat': [320, 267, 3, 0, 3, 742],
+         'token': '2b00042f7481c7b056c4b410d28f33cf',
+         'wifi_fw_ver': 'SD878x-14.76.36.p84-702.1.0-WM'}
+        """
+        self.data = data
+
+    def __repr__(self):
+        return "%s v%s (%s) @ %s - token: %s" % (
+            self.model,
+            self.firmware_version,
+            self.mac_address,
+            self.ip_address,
+            self.token,
+        )
+
+    @property
+    def network_interface(self) -> Dict:
+        """Information about network configuration.
+
+        If unavailable, returns an empty dictionary.
+        """
+        return self.data.get("netif", {})
+
+    @property
+    def accesspoint(self):
+        """Information about connected wlan accesspoint.
+
+        If unavailable, returns an empty dictionary.
+        """
+        return self.data.get("ap", {})
+
+    @property
+    def model(self) -> Optional[str]:
+        """Model string if available."""
+        return self.data.get("model")
+
+    @property
+    def firmware_version(self) -> Optional[str]:
+        """Firmware version if available."""
+        return self.data.get("fw_ver")
+
+    @property
+    def hardware_version(self) -> Optional[str]:
+        """Hardware version if available."""
+        return self.data.get("hw_ver")
+
+    @property
+    def mac_address(self) -> Optional[str]:
+        """MAC address if available."""
+        return self.data.get("mac")
+
+    @property
+    def ip_address(self) -> Optional[str]:
+        return self.network_interface.get("localIp")
+
+    @property
+    def token(self) -> Optional[str]:
+        return self.data.get("token")
+
+    @property
+    def raw(self):
+        """Raw data as returned by the device."""
+        return self.data

--- a/miio/fan.py
+++ b/miio/fan.py
@@ -284,12 +284,7 @@ class Fan(Device):
         lazy_discover: bool = True,
         model: str = MODEL_FAN_V3,
     ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover)
-
-        if model in AVAILABLE_PROPERTIES:
-            self.model = model
-        else:
-            self.model = MODEL_FAN_V3
+        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
 
     @command(
         default_output=format_output(
@@ -532,12 +527,7 @@ class FanP5(Device):
         lazy_discover: bool = True,
         model: str = MODEL_FAN_P5,
     ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover)
-
-        if model in AVAILABLE_PROPERTIES:
-            self.model = model
-        else:
-            self.model = MODEL_FAN_P5
+        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
 
     @command(
         default_output=format_output(

--- a/miio/fan_leshow.py
+++ b/miio/fan_leshow.py
@@ -102,12 +102,7 @@ class FanLeshow(Device):
         lazy_discover: bool = True,
         model: str = MODEL_FAN_LESHOW_SS4,
     ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover)
-
-        if model in AVAILABLE_PROPERTIES:
-            self.model = model
-        else:
-            self.model = MODEL_FAN_LESHOW_SS4
+        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
 
     @command(
         default_output=format_output(

--- a/miio/fan_miot.py
+++ b/miio/fan_miot.py
@@ -244,8 +244,7 @@ class FanMiot(MiotDevice):
         if model not in MIOT_MAPPING:
             raise FanException("Invalid FanMiot model: %s" % model)
 
-        super().__init__(ip, token, start_id, debug, lazy_discover)
-        self.model = model
+        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
 
     @command(
         default_output=format_output(
@@ -408,8 +407,7 @@ class Fan1C(MiotDevice):
         lazy_discover: bool = True,
         model: str = MODEL_FAN_1C,
     ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover)
-        self.model = model
+        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
 
     @command(
         default_output=format_output(

--- a/miio/heater.py
+++ b/miio/heater.py
@@ -136,12 +136,7 @@ class Heater(Device):
         lazy_discover: bool = True,
         model: str = MODEL_HEATER_ZA1,
     ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover)
-
-        if model in SUPPORTED_MODELS:
-            self.model = model
-        else:
-            self.model = MODEL_HEATER_ZA1
+        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
 
     @command(
         default_output=format_output(

--- a/miio/huizuo.py
+++ b/miio/huizuo.py
@@ -231,12 +231,10 @@ class Huizuo(MiotDevice):
         if model in MODELS_WITH_HEATER:
             self.mapping.update(_ADDITIONAL_MAPPING_HEATER)
 
-        super().__init__(ip, token, start_id, debug, lazy_discover)
+        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
 
-        if model in MODELS_SUPPORTED:
-            self.model = model
-        else:
-            self.model = MODEL_HUIZUO_PIS123
+        if model not in MODELS_SUPPORTED:
+            self._model = MODEL_HUIZUO_PIS123
             _LOGGER.error(
                 "Device model %s unsupported. Falling back to %s.", model, self.model
             )

--- a/miio/miot_device.py
+++ b/miio/miot_device.py
@@ -41,10 +41,13 @@ class MiotDevice(Device):
         lazy_discover: bool = True,
         timeout: int = None,
         *,
+        model: str = None,
         mapping: MiotMapping = None,
     ):
         """Overloaded to accept keyword-only `mapping` parameter."""
-        super().__init__(ip, token, start_id, debug, lazy_discover, timeout)
+        super().__init__(
+            ip, token, start_id, debug, lazy_discover, timeout, model=model
+        )
 
         if mapping is None and not hasattr(self, "mapping"):
             raise DeviceException(

--- a/miio/philips_bulb.py
+++ b/miio/philips_bulb.py
@@ -77,12 +77,7 @@ class PhilipsWhiteBulb(Device):
         lazy_discover: bool = True,
         model: str = MODEL_PHILIPS_LIGHT_HBULB,
     ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover)
-
-        if model in AVAILABLE_PROPERTIES:
-            self.model = model
-        else:
-            self.model = MODEL_PHILIPS_LIGHT_HBULB
+        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
 
     @command(
         default_output=format_output(
@@ -148,12 +143,7 @@ class PhilipsBulb(PhilipsWhiteBulb):
         lazy_discover: bool = True,
         model: str = MODEL_PHILIPS_LIGHT_BULB,
     ) -> None:
-        if model in AVAILABLE_PROPERTIES:
-            self.model = model
-        else:
-            self.model = MODEL_PHILIPS_LIGHT_BULB
-
-        super().__init__(ip, token, start_id, debug, lazy_discover, self.model)
+        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
 
     @command(
         click.argument("level", type=int),

--- a/miio/philips_rwread.py
+++ b/miio/philips_rwread.py
@@ -92,12 +92,7 @@ class PhilipsRwread(Device):
         lazy_discover: bool = True,
         model: str = MODEL_PHILIPS_LIGHT_RWREAD,
     ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover)
-
-        if model in AVAILABLE_PROPERTIES:
-            self.model = model
-        else:
-            self.model = MODEL_PHILIPS_LIGHT_RWREAD
+        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
 
     @command(
         default_output=format_output(

--- a/miio/powerstrip.py
+++ b/miio/powerstrip.py
@@ -145,12 +145,7 @@ class PowerStrip(Device):
         lazy_discover: bool = True,
         model: str = MODEL_POWER_STRIP_V1,
     ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover)
-
-        if model in AVAILABLE_PROPERTIES:
-            self.model = model
-        else:
-            self.model = MODEL_POWER_STRIP_V1
+        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
 
     @command(
         default_output=format_output(

--- a/miio/powerstrip.py
+++ b/miio/powerstrip.py
@@ -136,6 +136,8 @@ class PowerStripStatus(DeviceStatus):
 class PowerStrip(Device):
     """Main class representing the smart power strip."""
 
+    _supported_models = [MODEL_POWER_STRIP_V1, MODEL_POWER_STRIP_V2]
+
     def __init__(
         self,
         ip: str = None,

--- a/miio/pwzn_relay.py
+++ b/miio/pwzn_relay.py
@@ -108,12 +108,7 @@ class PwznRelay(Device):
         lazy_discover: bool = True,
         model: str = MODEL_PWZN_RELAY_APPLE,
     ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover)
-
-        if model in AVAILABLE_PROPERTIES:
-            self.model = model
-        else:
-            self.model = MODEL_PWZN_RELAY_APPLE
+        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
 
     @command(default_output=format_output("", "on_count: {result.on_count}\n"))
     def status(self) -> PwznRelayStatus:

--- a/miio/tests/dummies.py
+++ b/miio/tests/dummies.py
@@ -36,6 +36,10 @@ class DummyDevice:
     def __init__(self, *args, **kwargs):
         self.start_state = self.state.copy()
         self._protocol = DummyMiIOProtocol(self)
+        self._model = None
+        self._info = None
+        self.token = "ffffffffffffffffffffffffffffffff"
+        self.ip = "192.0.2.1"
 
     def _reset_state(self):
         """Revert back to the original state."""

--- a/miio/tests/dummies.py
+++ b/miio/tests/dummies.py
@@ -1,6 +1,3 @@
-from miio.deviceinfo import DeviceInfo
-
-
 class DummyMiIOProtocol:
     """DummyProtocol allows you mock MiIOProtocol."""
 
@@ -40,40 +37,15 @@ class DummyDevice:
         self.start_state = self.state.copy()
         self._protocol = DummyMiIOProtocol(self)
         self._info = None
+        # TODO: ugly hack to check for pre-existing _model
+        if getattr(self, "_model", None) is None:
+            self._model = "dummy.model"
         self.token = "ffffffffffffffffffffffffffffffff"
         self.ip = "192.0.2.1"
 
     def _reset_state(self):
         """Revert back to the original state."""
         self.state = self.start_state.copy()
-
-    def info(self):
-        if self._model is None:
-            self._model = "dummy.model"
-
-        # Dummy model information taken from test_airhumidifer_jsq
-        dummy_device_info = DeviceInfo(
-            {
-                "life": 575661,
-                "token": "68ffffffffffffffffffffffffffffff",
-                "mac": "78:11:FF:FF:FF:FF",
-                "fw_ver": "1.3.9",
-                "hw_ver": "ESP8266",
-                "uid": "1111111111",
-                "model": self._model,
-                "mcu_fw_ver": "0001",
-                "wifi_fw_ver": "1.5.0-dev(7efd021)",
-                "ap": {"rssi": -71, "ssid": "ap", "bssid": "FF:FF:FF:FF:FF:FF"},
-                "netif": {
-                    "gw": "192.168.0.1",
-                    "localIp": "192.168.0.25",
-                    "mask": "255.255.255.0",
-                },
-                "mmfree": 228248,
-            }
-        )
-
-        return dummy_device_info
 
     def _set_state(self, var, value):
         """Set a state of a variable, the value is expected to be an array with length

--- a/miio/tests/dummies.py
+++ b/miio/tests/dummies.py
@@ -1,3 +1,6 @@
+from miio.deviceinfo import DeviceInfo
+
+
 class DummyMiIOProtocol:
     """DummyProtocol allows you mock MiIOProtocol."""
 
@@ -36,7 +39,6 @@ class DummyDevice:
     def __init__(self, *args, **kwargs):
         self.start_state = self.state.copy()
         self._protocol = DummyMiIOProtocol(self)
-        self._model = None
         self._info = None
         self.token = "ffffffffffffffffffffffffffffffff"
         self.ip = "192.0.2.1"
@@ -44,6 +46,34 @@ class DummyDevice:
     def _reset_state(self):
         """Revert back to the original state."""
         self.state = self.start_state.copy()
+
+    def info(self):
+        if self._model is None:
+            self._model = "dummy.model"
+
+        # Dummy model information taken from test_airhumidifer_jsq
+        dummy_device_info = DeviceInfo(
+            {
+                "life": 575661,
+                "token": "68ffffffffffffffffffffffffffffff",
+                "mac": "78:11:FF:FF:FF:FF",
+                "fw_ver": "1.3.9",
+                "hw_ver": "ESP8266",
+                "uid": "1111111111",
+                "model": self._model,
+                "mcu_fw_ver": "0001",
+                "wifi_fw_ver": "1.5.0-dev(7efd021)",
+                "ap": {"rssi": -71, "ssid": "ap", "bssid": "FF:FF:FF:FF:FF:FF"},
+                "netif": {
+                    "gw": "192.168.0.1",
+                    "localIp": "192.168.0.25",
+                    "mask": "255.255.255.0",
+                },
+                "mmfree": 228248,
+            }
+        )
+
+        return dummy_device_info
 
     def _set_state(self, var, value):
         """Set a state of a variable, the value is expected to be an array with length

--- a/miio/tests/test_airconditioner_miot.py
+++ b/miio/tests/test_airconditioner_miot.py
@@ -36,6 +36,7 @@ _INITIAL_STATE = {
 
 class DummyAirConditionerMiot(DummyMiotDevice, AirConditionerMiot):
     def __init__(self, *args, **kwargs):
+        self._model = "xiaomi.aircondition.mc1"
         self.state = _INITIAL_STATE
         self.return_values = {
             "get_prop": self._get_state,

--- a/miio/tests/test_airconditioningcompanion.py
+++ b/miio/tests/test_airconditioningcompanion.py
@@ -222,7 +222,7 @@ class DummyAirConditioningCompanionV3(DummyDevice, AirConditioningCompanionV3):
     def __init__(self, *args, **kwargs):
         self.state = ["010507950000257301", "011001160100002573", "807"]
         self.device_prop = {"lumi.0": {"plug_state": ["on"]}}
-        self.model = MODEL_ACPARTNER_V3
+        self._model = MODEL_ACPARTNER_V3
         self.last_ir_played = None
 
         self.return_values = {
@@ -313,7 +313,7 @@ class TestAirConditioningCompanionV3(TestCase):
 class DummyAirConditioningCompanionMcn02(DummyDevice, AirConditioningCompanionMcn02):
     def __init__(self, *args, **kwargs):
         self.state = ["on", "cool", 28, "small_fan", "on", 441.0]
-        self.model = MODEL_ACPARTNER_MCN02
+        self._model = MODEL_ACPARTNER_MCN02
 
         self.return_values = {"get_prop": self._get_state}
         self.start_state = self.state.copy()

--- a/miio/tests/test_airconditioningcompanion.py
+++ b/miio/tests/test_airconditioningcompanion.py
@@ -67,6 +67,7 @@ class DummyAirConditioningCompanion(DummyDevice, AirConditioningCompanion):
     def __init__(self, *args, **kwargs):
         self.state = ["010500978022222102", "01020119A280222221", "2"]
         self.last_ir_played = None
+        self._model = "missing.model.airconditioningcompanion"
 
         self.return_values = {
             "get_model_and_state": self._get_state,

--- a/miio/tests/test_airdehumidifier.py
+++ b/miio/tests/test_airdehumidifier.py
@@ -17,7 +17,7 @@ from .dummies import DummyDevice
 
 class DummyAirDehumidifierV1(DummyDevice, AirDehumidifier):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_DEHUMIDIFIER_V1
+        self._model = MODEL_DEHUMIDIFIER_V1
         self.dummy_device_info = {
             "life": 348202,
             "uid": 1759530000,

--- a/miio/tests/test_airfresh.py
+++ b/miio/tests/test_airfresh.py
@@ -17,7 +17,7 @@ from .dummies import DummyDevice
 
 class DummyAirFresh(DummyDevice, AirFresh):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_AIRFRESH_VA2
+        self._model = MODEL_AIRFRESH_VA2
         self.state = {
             "power": "on",
             "ptc_state": None,
@@ -213,7 +213,7 @@ class TestAirFresh(TestCase):
 
 class DummyAirFreshVA4(DummyDevice, AirFresh):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_AIRFRESH_VA4
+        self._model = MODEL_AIRFRESH_VA4
         self.state = {
             "power": "on",
             "ptc_state": "off",

--- a/miio/tests/test_airfresh_t2017.py
+++ b/miio/tests/test_airfresh_t2017.py
@@ -18,7 +18,7 @@ from .dummies import DummyDevice
 
 class DummyAirFreshA1(DummyDevice, AirFreshA1):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_AIRFRESH_A1
+        self._model = MODEL_AIRFRESH_A1
         self.state = {
             "power": True,
             "mode": "auto",
@@ -185,7 +185,7 @@ class TestAirFreshA1(TestCase):
 
 class DummyAirFreshT2017(DummyDevice, AirFreshT2017):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_AIRFRESH_T2017
+        self._model = MODEL_AIRFRESH_T2017
         self.state = {
             "power": True,
             "mode": "favourite",

--- a/miio/tests/test_airhumidifier.py
+++ b/miio/tests/test_airhumidifier.py
@@ -19,7 +19,7 @@ from .dummies import DummyDevice
 
 class DummyAirHumidifierV1(DummyDevice, AirHumidifier):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_HUMIDIFIER_V1
+        self._model = MODEL_HUMIDIFIER_V1
         self.dummy_device_info = {
             "fw_ver": "1.2.9_5033",
             "token": "68ffffffffffffffffffffffffffffff",
@@ -234,7 +234,7 @@ class TestAirHumidifierV1(TestCase):
 
 class DummyAirHumidifierCA1(DummyDevice, AirHumidifier):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_HUMIDIFIER_CA1
+        self._model = MODEL_HUMIDIFIER_CA1
         self.dummy_device_info = {
             "fw_ver": "1.6.6",
             "token": "68ffffffffffffffffffffffffffffff",
@@ -466,7 +466,7 @@ class TestAirHumidifierCA1(TestCase):
 
 class DummyAirHumidifierCB1(DummyDevice, AirHumidifier):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_HUMIDIFIER_CB1
+        self._model = MODEL_HUMIDIFIER_CB1
         self.dummy_device_info = {
             "fw_ver": "1.2.9_5033",
             "token": "68ffffffffffffffffffffffffffffff",

--- a/miio/tests/test_airhumidifier_jsq.py
+++ b/miio/tests/test_airhumidifier_jsq.py
@@ -17,7 +17,7 @@ from .dummies import DummyDevice
 
 class DummyAirHumidifierJsq(DummyDevice, AirHumidifierJsq):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_HUMIDIFIER_JSQ001
+        self._model = MODEL_HUMIDIFIER_JSQ001
 
         self.dummy_device_info = {
             "life": 575661,

--- a/miio/tests/test_airhumidifier_mjjsq.py
+++ b/miio/tests/test_airhumidifier_mjjsq.py
@@ -15,7 +15,7 @@ from .dummies import DummyDevice
 
 class DummyAirHumidifierMjjsq(DummyDevice, AirHumidifierMjjsq):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_HUMIDIFIER_JSQ1
+        self._model = MODEL_HUMIDIFIER_JSQ1
         self.state = {
             "Humidifier_Gear": 1,
             "Humidity_Value": 44,

--- a/miio/tests/test_airpurifier.py
+++ b/miio/tests/test_airpurifier.py
@@ -17,6 +17,7 @@ from .dummies import DummyDevice
 
 class DummyAirPurifier(DummyDevice, AirPurifier):
     def __init__(self, *args, **kwargs):
+        self._model = "missing.model.airpurifier"
         self.state = {
             "power": "on",
             "aqi": 10,

--- a/miio/tests/test_airpurifier_airdog.py
+++ b/miio/tests/test_airpurifier_airdog.py
@@ -18,7 +18,7 @@ from .dummies import DummyDevice
 
 class DummyAirDogX3(DummyDevice, AirDogX3):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_AIRDOG_X3
+        self._model = MODEL_AIRDOG_X3
         self.state = {
             "power": "on",
             "mode": "manual",
@@ -149,7 +149,7 @@ class TestAirDogX3(TestCase):
 class DummyAirDogX5(DummyAirDogX3, AirDogX5):
     def __init__(self, *args, **kwargs):
         super().__init__(args, kwargs)
-        self.model = MODEL_AIRDOG_X5
+        self._model = MODEL_AIRDOG_X5
         self.state = {
             "power": "on",
             "mode": "manual",
@@ -170,7 +170,7 @@ def airdogx5(request):
 class DummyAirDogX7SM(DummyAirDogX5, AirDogX7SM):
     def __init__(self, *args, **kwargs):
         super().__init__(args, kwargs)
-        self.model = MODEL_AIRDOG_X7SM
+        self._model = MODEL_AIRDOG_X7SM
         self.state["hcho"] = 2
 
 

--- a/miio/tests/test_airqualitymonitor.py
+++ b/miio/tests/test_airqualitymonitor.py
@@ -15,7 +15,7 @@ from .dummies import DummyDevice
 
 class DummyAirQualityMonitorV1(DummyDevice, AirQualityMonitor):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_AIRQUALITYMONITOR_V1
+        self._model = MODEL_AIRQUALITYMONITOR_V1
         self.state = {
             "power": "on",
             "aqi": 34,
@@ -85,7 +85,7 @@ class TestAirQualityMonitorV1(TestCase):
 
 class DummyAirQualityMonitorS1(DummyDevice, AirQualityMonitor):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_AIRQUALITYMONITOR_S1
+        self._model = MODEL_AIRQUALITYMONITOR_S1
         self.state = {
             "battery": 100,
             "co2": 695,
@@ -134,7 +134,7 @@ class TestAirQualityMonitorS1(TestCase):
 
 class DummyAirQualityMonitorB1(DummyDevice, AirQualityMonitor):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_AIRQUALITYMONITOR_B1
+        self._model = MODEL_AIRQUALITYMONITOR_B1
         self.state = {
             "co2e": 1466,
             "humidity": 59.79999923706055,

--- a/miio/tests/test_chuangmi_plug.py
+++ b/miio/tests/test_chuangmi_plug.py
@@ -15,7 +15,7 @@ from .dummies import DummyDevice
 
 class DummyChuangmiPlugV1(DummyDevice, ChuangmiPlug):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_CHUANGMI_PLUG_V1
+        self._model = MODEL_CHUANGMI_PLUG_V1
         self.state = {"on": True, "usb_on": True, "temperature": 32}
         self.return_values = {
             "get_prop": self._get_state,
@@ -86,7 +86,7 @@ class TestChuangmiPlugV1(TestCase):
 
 class DummyChuangmiPlugV3(DummyDevice, ChuangmiPlug):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_CHUANGMI_PLUG_V3
+        self._model = MODEL_CHUANGMI_PLUG_V3
         self.state = {"on": True, "usb_on": True, "temperature": 32, "wifi_led": "off"}
         self.return_values = {
             "get_prop": self._get_state,
@@ -177,7 +177,7 @@ class TestChuangmiPlugV3(TestCase):
 
 class DummyChuangmiPlugM1(DummyDevice, ChuangmiPlug):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_CHUANGMI_PLUG_M1
+        self._model = MODEL_CHUANGMI_PLUG_M1
         self.state = {"power": "on", "temperature": 32}
         self.return_values = {
             "get_prop": self._get_state,

--- a/miio/tests/test_device.py
+++ b/miio/tests/test_device.py
@@ -47,6 +47,7 @@ def test_timeout_retry(mocker):
 
 
 def test_unavailable_device_info_raises(mocker):
+    """Make sure custom exception is raised if the info payload is invalid."""
     send = mocker.patch("miio.Device.send", side_effect=PayloadDecodeException)
     d = Device("127.0.0.1", "68ffffffffffffffffffffffffffffff")
 
@@ -54,3 +55,29 @@ def test_unavailable_device_info_raises(mocker):
         d.info()
 
     assert send.call_count == 1
+
+
+def test_model_autodetection(mocker):
+    """Make sure info() gets called if the model is unknown."""
+    info = mocker.patch("miio.Device.info")
+    _ = mocker.patch("miio.Device.send")
+
+    d = Device("127.0.0.1", "68ffffffffffffffffffffffffffffff")
+
+    d.raw_command("cmd", {})
+
+    info.assert_called()
+
+
+def test_forced_model(mocker):
+    """Make sure info() does not get called automatically if model is given."""
+    info = mocker.patch("miio.Device.info")
+    _ = mocker.patch("miio.Device.send")
+
+    DUMMY_MODEL = "dummy.model"
+
+    d = Device("127.0.0.1", "68ffffffffffffffffffffffffffffff", model=DUMMY_MODEL)
+    d.raw_command("dummy", {})
+
+    assert d.model == DUMMY_MODEL
+    info.assert_not_called()

--- a/miio/tests/test_device.py
+++ b/miio/tests/test_device.py
@@ -77,7 +77,18 @@ def test_forced_model(mocker):
     DUMMY_MODEL = "dummy.model"
 
     d = Device("127.0.0.1", "68ffffffffffffffffffffffffffffff", model=DUMMY_MODEL)
-    d.raw_command("dummy", {})
+    d._fetch_info()
 
     assert d.model == DUMMY_MODEL
     info.assert_not_called()
+
+
+def test_missing_supported(mocker, caplog):
+    """Make sure warning is logged if the device is unsupported for the class."""
+    _ = mocker.patch("miio.Device.send")
+
+    d = Device("127.0.0.1", "68ffffffffffffffffffffffffffffff")
+    d._fetch_info()
+
+    assert "Found an unsupported model" in caplog.text
+    assert "for class 'Device'" in caplog.text

--- a/miio/tests/test_device.py
+++ b/miio/tests/test_device.py
@@ -77,7 +77,7 @@ def test_forced_model(mocker):
     DUMMY_MODEL = "dummy.model"
 
     d = Device("127.0.0.1", "68ffffffffffffffffffffffffffffff", model=DUMMY_MODEL)
-    d._fetch_info()
+    d.raw_command("dummy", {})
 
     assert d.model == DUMMY_MODEL
     info.assert_not_called()

--- a/miio/tests/test_fan.py
+++ b/miio/tests/test_fan.py
@@ -21,7 +21,7 @@ from .dummies import DummyDevice
 
 class DummyFanV2(DummyDevice, Fan):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_FAN_V2
+        self._model = MODEL_FAN_V2
         # This example response is just a guess. Please update!
         self.state = {
             "temp_dec": 232,
@@ -271,7 +271,7 @@ class TestFanV2(TestCase):
 
 class DummyFanV3(DummyDevice, Fan):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_FAN_V3
+        self._model = MODEL_FAN_V3
         self.state = {
             "temp_dec": 232,
             "humidity": 46,
@@ -527,7 +527,7 @@ class TestFanV3(TestCase):
 
 class DummyFanSA1(DummyDevice, Fan):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_FAN_SA1
+        self._model = MODEL_FAN_SA1
         self.state = {
             "angle": 120,
             "speed": 277,
@@ -745,7 +745,7 @@ class TestFanSA1(TestCase):
 
 class DummyFanP5(DummyDevice, FanP5):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_FAN_P5
+        self._model = MODEL_FAN_P5
         self.state = {
             "power": True,
             "mode": "normal",

--- a/miio/tests/test_fan_leshow.py
+++ b/miio/tests/test_fan_leshow.py
@@ -15,7 +15,7 @@ from .dummies import DummyDevice
 
 class DummyFanLeshow(DummyDevice, FanLeshow):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_FAN_LESHOW_SS4
+        self._model = MODEL_FAN_LESHOW_SS4
         self.state = {
             "power": 1,
             "mode": 2,

--- a/miio/tests/test_fan_miot.py
+++ b/miio/tests/test_fan_miot.py
@@ -17,7 +17,7 @@ from .dummies import DummyMiotDevice
 
 class DummyFanMiot(DummyMiotDevice, FanMiot):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_FAN_P9
+        self._model = MODEL_FAN_P9
         self.state = {
             "power": True,
             "mode": 0,
@@ -176,7 +176,7 @@ class TestFanMiot(TestCase):
 class DummyFanMiotP10(DummyFanMiot, FanMiot):
     def __init__(self, *args, **kwargs):
         super().__init__(args, kwargs)
-        self.model = MODEL_FAN_P10
+        self._model = MODEL_FAN_P10
 
 
 @pytest.fixture(scope="class")
@@ -220,7 +220,7 @@ class TestFanMiotP10(TestCase):
 class DummyFanMiotP11(DummyFanMiot, FanMiot):
     def __init__(self, *args, **kwargs):
         super().__init__(args, kwargs)
-        self.model = MODEL_FAN_P11
+        self._model = MODEL_FAN_P11
 
 
 @pytest.fixture(scope="class")
@@ -235,7 +235,7 @@ class TestFanMiotP11(TestFanMiotP10, TestCase):
 
 class DummyFan1C(DummyMiotDevice, Fan1C):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_FAN_1C
+        self._model = MODEL_FAN_1C
         self.state = {
             "power": True,
             "mode": 0,

--- a/miio/tests/test_heater.py
+++ b/miio/tests/test_heater.py
@@ -10,7 +10,7 @@ from .dummies import DummyDevice
 
 class DummyHeater(DummyDevice, Heater):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_HEATER_ZA1
+        self._model = MODEL_HEATER_ZA1
         # This example response is just a guess. Please update!
         self.state = {
             "target_temperature": 24,

--- a/miio/tests/test_huizuo.py
+++ b/miio/tests/test_huizuo.py
@@ -39,28 +39,28 @@ _INITIAL_STATE_HEATER = {
 class DummyHuizuo(DummyMiotDevice, Huizuo):
     def __init__(self, *args, **kwargs):
         self.state = _INITIAL_STATE
-        self.model = MODEL_HUIZUO_PIS123
+        self._model = MODEL_HUIZUO_PIS123
         super().__init__(*args, **kwargs)
 
 
 class DummyHuizuoFan(DummyMiotDevice, HuizuoLampFan):
     def __init__(self, *args, **kwargs):
         self.state = _INITIAL_STATE_FAN
-        self.model = MODEL_HUIZUO_FANWY
+        self._model = MODEL_HUIZUO_FANWY
         super().__init__(*args, **kwargs)
 
 
 class DummyHuizuoFan2(DummyMiotDevice, HuizuoLampFan):
     def __init__(self, *args, **kwargs):
         self.state = _INITIAL_STATE_FAN
-        self.model = MODEL_HUIZUO_FANWY2
+        self._model = MODEL_HUIZUO_FANWY2
         super().__init__(*args, **kwargs)
 
 
 class DummyHuizuoHeater(DummyMiotDevice, HuizuoLampHeater):
     def __init__(self, *args, **kwargs):
         self.state = _INITIAL_STATE_HEATER
-        self.model = MODEL_HUIZUO_WYHEAT
+        self._model = MODEL_HUIZUO_WYHEAT
         super().__init__(*args, **kwargs)
 
 

--- a/miio/tests/test_philips_bulb.py
+++ b/miio/tests/test_philips_bulb.py
@@ -15,7 +15,7 @@ from .dummies import DummyDevice
 
 class DummyPhilipsBulb(DummyDevice, PhilipsBulb):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_PHILIPS_LIGHT_BULB
+        self._model = MODEL_PHILIPS_LIGHT_BULB
         self.state = {"power": "on", "bright": 100, "cct": 10, "snm": 0, "dv": 0}
         self.return_values = {
             "get_prop": self._get_state,
@@ -180,7 +180,7 @@ class TestPhilipsBulb(TestCase):
 
 class DummyPhilipsWhiteBulb(DummyDevice, PhilipsWhiteBulb):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_PHILIPS_LIGHT_HBULB
+        self._model = MODEL_PHILIPS_LIGHT_HBULB
         self.state = {"power": "on", "bri": 100, "dv": 0}
         self.return_values = {
             "get_prop": self._get_state,

--- a/miio/tests/test_philips_rwread.py
+++ b/miio/tests/test_philips_rwread.py
@@ -15,7 +15,7 @@ from .dummies import DummyDevice
 
 class DummyPhilipsRwread(DummyDevice, PhilipsRwread):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_PHILIPS_LIGHT_RWREAD
+        self._model = MODEL_PHILIPS_LIGHT_RWREAD
         self.state = {
             "power": "on",
             "bright": 53,

--- a/miio/tests/test_powerstrip.py
+++ b/miio/tests/test_powerstrip.py
@@ -16,7 +16,7 @@ from .dummies import DummyDevice
 
 class DummyPowerStripV1(DummyDevice, PowerStrip):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_POWER_STRIP_V1
+        self._model = MODEL_POWER_STRIP_V1
         self.state = {
             "power": "on",
             "mode": "normal",
@@ -108,7 +108,7 @@ class TestPowerStripV1(TestCase):
 
 class DummyPowerStripV2(DummyDevice, PowerStrip):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_POWER_STRIP_V2
+        self._model = MODEL_POWER_STRIP_V2
         self.state = {
             "power": "on",
             "mode": "normal",

--- a/miio/tests/test_toiletlid.py
+++ b/miio/tests/test_toiletlid.py
@@ -25,7 +25,7 @@ from .dummies import DummyDevice
 
 class DummyToiletlidV1(DummyDevice, Toiletlid):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_TOILETLID_V1
+        self._model = MODEL_TOILETLID_V1
         self.state = {
             "is_on": False,
             "work_state": 1,

--- a/miio/tests/test_vacuum.py
+++ b/miio/tests/test_vacuum.py
@@ -51,7 +51,7 @@ class DummyVacuum(DummyDevice, Vacuum):
         }
 
         super().__init__(args, kwargs)
-        self.model = None
+
 
     def change_mode(self, new_mode):
         if new_mode == "spot":
@@ -277,9 +277,17 @@ class TestVacuum(TestCase):
 
             assert len(self.device.clean_history().ids) == 0
 
+    def test_info_no_cloud(self):
+        """Test the info functionality for non-cloud connected device."""
+        from miio.exceptions import DeviceInfoUnavailableException
+
+        assert self.device.carpet_cleaning_mode() is None
+        with patch("miio.Device.info", side_effect=DeviceInfoUnavailableException()):
+            assert self.device.info().model == "rockrobo.vacuum.v1"
+            
     def test_carpet_cleaning_mode(self):
         with patch.object(self.device, "send", return_value=[{"carpet_clean_mode": 0}]):
-            assert self.device.carpet_cleaning_mode() == CarpetCleaningMode.Avoid
+            assert self.device.carpet_cleaning_mode() == CarpetCleaningMode.Avoid        
 
         with patch.object(self.device, "send", return_value="unknown_method"):
             assert self.device.carpet_cleaning_mode() is None

--- a/miio/tests/test_vacuum.py
+++ b/miio/tests/test_vacuum.py
@@ -53,7 +53,6 @@ class DummyVacuum(DummyDevice, Vacuum):
 
         super().__init__(args, kwargs)
 
-
     def change_mode(self, new_mode):
         if new_mode == "spot":
             self.state["state"] = DummyVacuum.STATE_SPOT
@@ -285,10 +284,10 @@ class TestVacuum(TestCase):
         assert self.device.carpet_cleaning_mode() is None
         with patch("miio.Device.info", side_effect=DeviceInfoUnavailableException()):
             assert self.device.info().model == "rockrobo.vacuum.v1"
-            
+
     def test_carpet_cleaning_mode(self):
         with patch.object(self.device, "send", return_value=[{"carpet_clean_mode": 0}]):
-            assert self.device.carpet_cleaning_mode() == CarpetCleaningMode.Avoid        
+            assert self.device.carpet_cleaning_mode() == CarpetCleaningMode.Avoid
 
         with patch.object(self.device, "send", return_value="unknown_method"):
             assert self.device.carpet_cleaning_mode() is None

--- a/miio/tests/test_vacuum.py
+++ b/miio/tests/test_vacuum.py
@@ -23,6 +23,7 @@ class DummyVacuum(DummyDevice, Vacuum):
     STATE_MANUAL = 7
 
     def __init__(self, *args, **kwargs):
+        self._model = "missing.model.vacuum"
         self.state = {
             "state": 8,
             "dnd_enabled": 1,

--- a/miio/tests/test_vacuum.py
+++ b/miio/tests/test_vacuum.py
@@ -281,11 +281,12 @@ class TestVacuum(TestCase):
         """Test the info functionality for non-cloud connected device."""
         from miio.exceptions import DeviceInfoUnavailableException
 
-        assert self.device.carpet_cleaning_mode() is None
         with patch("miio.Device.info", side_effect=DeviceInfoUnavailableException()):
             assert self.device.info().model == "rockrobo.vacuum.v1"
 
     def test_carpet_cleaning_mode(self):
+        assert self.device.carpet_cleaning_mode() is None
+
         with patch.object(self.device, "send", return_value=[{"carpet_clean_mode": 0}]):
             assert self.device.carpet_cleaning_mode() == CarpetCleaningMode.Avoid
 

--- a/miio/tests/test_wifirepeater.py
+++ b/miio/tests/test_wifirepeater.py
@@ -9,6 +9,7 @@ from miio.wifirepeater import WifiRepeaterConfiguration, WifiRepeaterStatus
 
 class DummyWifiRepeater(DummyDevice, WifiRepeater):
     def __init__(self, *args, **kwargs):
+        self._model = "xiaomi.repeater.v2"
         self.state = {
             "sta": {"count": 2, "access_policy": 0},
             "mat": [
@@ -75,6 +76,12 @@ class DummyWifiRepeater(DummyDevice, WifiRepeater):
         self.start_config = self.config.copy()
         self.start_device_info = self.device_info.copy()
         super().__init__(args, kwargs)
+
+    def info(self):
+        """This device has custom miIO.info response."""
+        from miio.deviceinfo import DeviceInfo
+
+        return DeviceInfo(self.device_info)
 
     def _reset_state(self):
         """Revert back to the original state."""

--- a/miio/tests/test_yeelight.py
+++ b/miio/tests/test_yeelight.py
@@ -10,6 +10,8 @@ from .dummies import DummyDevice
 
 class DummyLight(DummyDevice, Yeelight):
     def __init__(self, *args, **kwargs):
+        self._model = "missing.model.yeelight"
+
         self.return_values = {
             "get_prop": self._get_state,
             "set_power": lambda x: self._set_state("power", x),
@@ -70,10 +72,13 @@ class DummyCommonBulb(DummyLight):
         super().__init__(*args, **kwargs)
 
 
+
 @pytest.fixture(scope="class")
 def dummycommonbulb(request):
     request.cls.device = DummyCommonBulb()
     # TODO add ability to test on a real device
+
+
 
 
 @pytest.mark.usefixtures("dummycommonbulb")
@@ -304,6 +309,7 @@ class TestYeelightLightColor(TestCase):
         self.device.set_hsv()
 
 
+
 class DummyLightCeilingV1(DummyLight):  # without background light
     def __init__(self, *args, **kwargs):
         self.state = {
@@ -336,10 +342,13 @@ class DummyLightCeilingV1(DummyLight):  # without background light
         super().__init__(*args, **kwargs)
 
 
+
 @pytest.fixture(scope="class")
 def dummylightceilingv1(request):
     request.cls.device = DummyLightCeilingV1()
     # TODO add ability to test on a real device
+
+
 
 
 @pytest.mark.usefixtures("dummylightceilingv1")
@@ -349,6 +358,7 @@ class TestYeelightLightCeilingV1(TestCase):
         status = self.device.status()  # type: YeelightStatus
 
         assert repr(status) == repr(YeelightStatus(self.device.start_state))
+
 
         assert status.name == self.device.start_state["name"]
         assert status.developer_mode is True
@@ -386,6 +396,7 @@ class TestYeelightLightCeilingV1(TestCase):
         # assert status.color_flow_params == "0,0,1000,1,16711680,100,1000,1,65280,100,1000,1,255,100" and status.color_flow_params == status.lights[0].color_flow_params
         assert status.moonlight_mode is True
         assert status.moonlight_mode_brightness == 100
+
 
 
 class DummyLightCeilingV2(DummyLight):  # without background light

--- a/miio/tests/test_yeelight.py
+++ b/miio/tests/test_yeelight.py
@@ -72,13 +72,10 @@ class DummyCommonBulb(DummyLight):
         super().__init__(*args, **kwargs)
 
 
-
 @pytest.fixture(scope="class")
 def dummycommonbulb(request):
     request.cls.device = DummyCommonBulb()
     # TODO add ability to test on a real device
-
-
 
 
 @pytest.mark.usefixtures("dummycommonbulb")
@@ -309,7 +306,6 @@ class TestYeelightLightColor(TestCase):
         self.device.set_hsv()
 
 
-
 class DummyLightCeilingV1(DummyLight):  # without background light
     def __init__(self, *args, **kwargs):
         self.state = {
@@ -342,13 +338,10 @@ class DummyLightCeilingV1(DummyLight):  # without background light
         super().__init__(*args, **kwargs)
 
 
-
 @pytest.fixture(scope="class")
 def dummylightceilingv1(request):
     request.cls.device = DummyLightCeilingV1()
     # TODO add ability to test on a real device
-
-
 
 
 @pytest.mark.usefixtures("dummylightceilingv1")
@@ -358,7 +351,6 @@ class TestYeelightLightCeilingV1(TestCase):
         status = self.device.status()  # type: YeelightStatus
 
         assert repr(status) == repr(YeelightStatus(self.device.start_state))
-
 
         assert status.name == self.device.start_state["name"]
         assert status.developer_mode is True
@@ -396,7 +388,6 @@ class TestYeelightLightCeilingV1(TestCase):
         # assert status.color_flow_params == "0,0,1000,1,16711680,100,1000,1,65280,100,1000,1,255,100" and status.color_flow_params == status.lights[0].color_flow_params
         assert status.moonlight_mode is True
         assert status.moonlight_mode_brightness == 100
-
 
 
 class DummyLightCeilingV2(DummyLight):  # without background light

--- a/miio/toiletlid.py
+++ b/miio/toiletlid.py
@@ -80,12 +80,7 @@ class Toiletlid(Device):
         lazy_discover: bool = True,
         model: str = MODEL_TOILETLID_V1,
     ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover)
-
-        if model in AVAILABLE_PROPERTIES:
-            self.model = model
-        else:
-            self.model = MODEL_TOILETLID_V1
+        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
 
     @command(
         default_output=format_output(

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -7,7 +7,7 @@ import math
 import os
 import pathlib
 import time
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Type, Union
 
 import click
 import pytz
@@ -53,14 +53,18 @@ class Consumable(enum.Enum):
     SensorDirty = "sensor_dirty_time"
 
 
-class FanspeedV1(enum.Enum):
+class FanspeedEnum(enum.Enum):
+    pass
+
+
+class FanspeedV1(FanspeedEnum):
     Silent = 38
     Standard = 60
     Medium = 77
     Turbo = 90
 
 
-class FanspeedV2(enum.Enum):
+class FanspeedV2(FanspeedEnum):
     Silent = 101
     Standard = 102
     Medium = 103
@@ -69,14 +73,14 @@ class FanspeedV2(enum.Enum):
     Auto = 106
 
 
-class FanspeedV3(enum.Enum):
+class FanspeedV3(FanspeedEnum):
     Silent = 38
     Standard = 60
     Medium = 75
     Turbo = 100
 
 
-class FanspeedE2(enum.Enum):
+class FanspeedE2(FanspeedEnum):
     # Original names from the app: Gentle, Silent, Standard, Strong, Max
     Gentle = 41
     Silent = 50
@@ -85,7 +89,7 @@ class FanspeedE2(enum.Enum):
     Turbo = 100
 
 
-class FanspeedS7(enum.Enum):
+class FanspeedS7(FanspeedEnum):
     Silent = 101
     Standard = 102
     Medium = 103
@@ -149,7 +153,6 @@ class Vacuum(Device):
     ):
         super().__init__(ip, token, start_id, debug, model=model)
         self.manual_seqnum = -1
-
 
     @command()
     def start(self):
@@ -220,7 +223,6 @@ class Vacuum(Device):
 
         PAUSE_BEFORE_HOME = [
             ROCKROBO_V1,
-
         ]
 
         if self.model in PAUSE_BEFORE_HOME:
@@ -585,14 +587,13 @@ class Vacuum(Device):
     def fan_speed_presets(self) -> Dict[str, int]:
         """Return dictionary containing supported fan speeds."""
 
-        def _enum_as_dict(speed_enum):
-            return {x.name: x.value for x in list(speed_enum)}
+        def _enum_as_dict(cls):
+            return {x.name: x.value for x in list(cls)}
 
         if self.model is None:
             return _enum_as_dict(FanspeedV1)
 
-        fanspeeds = FanspeedV1
-
+        fanspeeds: Type[FanspeedEnum] = FanspeedV1
 
         if self.model == ROCKROBO_V1:
             _LOGGER.debug("Got robov1, checking for firmware version")
@@ -612,9 +613,7 @@ class Vacuum(Device):
         else:
             fanspeeds = FanspeedV2
 
-
         _LOGGER.debug("Using fanspeeds %s for %s", fanspeeds, self.model)
-
 
         return _enum_as_dict(fanspeeds)
 

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -123,9 +123,20 @@ ROCKROBO_S7 = "roborock.vacuum.a15"
 ROCKROBO_S6_MAXV = "roborock.vacuum.a10"
 ROCKROBO_E2 = "roborock.vacuum.e2"
 
+SUPPORTED_MODELS = [
+    ROCKROBO_V1,
+    ROCKROBO_S5,
+    ROCKROBO_S6,
+    ROCKROBO_S7,
+    ROCKROBO_S6_MAXV,
+    ROCKROBO_E2,
+]
+
 
 class Vacuum(Device):
     """Main class representing the vacuum."""
+
+    _supported_models = SUPPORTED_MODELS
 
     def __init__(
         self,

--- a/miio/yeelight.py
+++ b/miio/yeelight.py
@@ -1,3 +1,4 @@
+
 from enum import IntEnum
 from typing import List, Optional, Tuple
 
@@ -7,6 +8,8 @@ from .click_common import command, format_output
 from .device import Device, DeviceStatus
 from .exceptions import DeviceException
 from .utils import int_to_rgb, rgb_to_int
+
+SUPPORTED_MODELS = ["yeelink.light.color1"]
 
 
 class YeelightException(DeviceException):
@@ -37,6 +40,7 @@ class YeelightMode(IntEnum):
 
 class YeelightSubLight(DeviceStatus):
     def __init__(self, data, type):
+
         self.data = data
         self.type = type
 
@@ -256,7 +260,10 @@ class Yeelight(Device):
     which however requires enabling the developer mode on the bulbs.
     """
 
+    _supported_models = SUPPORTED_MODELS
+
     @command(default_output=format_output("", "{result.cli_format}"))
+
     def status(self) -> YeelightStatus:
         """Retrieve properties."""
         properties = [

--- a/miio/yeelight.py
+++ b/miio/yeelight.py
@@ -1,4 +1,3 @@
-
 from enum import IntEnum
 from typing import List, Optional, Tuple
 
@@ -263,7 +262,6 @@ class Yeelight(Device):
     _supported_models = SUPPORTED_MODELS
 
     @command(default_output=format_output("", "{result.cli_format}"))
-
     def status(self) -> YeelightStatus:
         """Retrieve properties."""
         properties = [


### PR DESCRIPTION
Different device models (even when supported by a single integration) can have different features or even different properties/API.
Previously, some integrations have used a model argument to define the exact device type to be able to adapt to these differences,
but there has been no generalized solution for this issue.

This PR will introduce automatic model detection based on the miIO.info query.
The first invocation of any command-decorated method will do the query to find the model of the device.
The response of this query is cached, so this will only happen once.

* info() has now a new keyword-only argument 'skip_cache' which can be used to bypass the cache
* Device constructor has a new keyword-only argument to specifying the model (which skips the info query)
* This PR converts Vacuum class to use these new facilities for fan speed controls

In the future, there should be no need to use different classes for devices/models that are using only a slightly different feature sets / commands / properties.
This would simplify the usage at least for users of the following classes (based on discovery.py): `Fan`, `FanMiot`, `ChuangmiPlug`, `PowerStrip`, `AirDog*`, `AirHumidifer`, `AirhumidifierJsq`, `AirConditioningCompanion`, `AirFresh`, `AirQualityMonitor`, and `Heater`.

@syssi your feedback would be greatly appreciated, as you have more insight on the classes using `model`! :-) 


TBD:
* [ ] Update docs
* [x] Convert other platforms
* [ ] Make it less hacky
* [ ] Skip info() if there is only a single supported model (potential optimization)