### PR TITLE
Add optional length parameter to play_* for chuangmi_ir

### DIFF
--- a/miio/chuangmi_ir.py
+++ b/miio/chuangmi_ir.py
@@ -69,13 +69,19 @@ class ChuangmiIr(Device):
             raise ChuangmiIrException("Invalid storage slot.")
         return self.send("miIO.ir_read", {"key": str(key)})
 
-    def play_raw(self, command: str, frequency: int = 38400):
+    def play_raw(self, command: str, frequency: int = 38400, length: int = -1):
         """Play a captured command.
 
         :param str command: Command to execute
         :param int frequency: Execution frequency
+                :param int length: Length of the command. -1 means not sending the length parameter.
         """
-        return self.send("miIO.ir_play", {"freq": frequency, "code": command})
+        if length < 0:
+            return self.send("miIO.ir_play", {"freq": frequency, "code": command})
+        else:
+            return self.send(
+                "miIO.ir_play", {"freq": frequency, "code": command, "length": length}
+            )
 
     def play_pronto(self, pronto: str, repeats: int = 1):
         """Play a Pronto Hex encoded IR command. Supports only raw Pronto format,

--- a/miio/chuangmi_ir.py
+++ b/miio/chuangmi_ir.py
@@ -74,7 +74,7 @@ class ChuangmiIr(Device):
 
         :param str command: Command to execute
         :param int frequency: Execution frequency
-                :param int length: Length of the command. -1 means not sending the length parameter.
+        :param int length: Length of the command. -1 means not sending the length parameter.
         """
         if length < 0:
             return self.send("miIO.ir_play", {"freq": frequency, "code": command})
@@ -83,14 +83,15 @@ class ChuangmiIr(Device):
                 "miIO.ir_play", {"freq": frequency, "code": command, "length": length}
             )
 
-    def play_pronto(self, pronto: str, repeats: int = 1):
+    def play_pronto(self, pronto: str, repeats: int = 1, length: int = -1):
         """Play a Pronto Hex encoded IR command. Supports only raw Pronto format,
         starting with 0000.
 
         :param str pronto: Pronto Hex string.
         :param int repeats: Number of extra signal repeats.
+        :param int length: Length of the command. -1 means not sending the length parameter.
         """
-        return self.play_raw(*self.pronto_to_raw(pronto, repeats))
+        return self.play_raw(*self.pronto_to_raw(pronto, repeats), length)
 
     @classmethod
     def pronto_to_raw(cls, pronto: str, repeats: int = 1):


### PR DESCRIPTION
The PR added optional "Length" parameter to chuangmi_ir.py play_raw(). for "chuangmi.remote.v2" to send some command properly. In  chuangmi.remote.v2,  "length" is required for the learned command which make HA impossible to send AC command correctly. With this add on, HA libs can be enhanced to send length in play_raw(). 
The issue fixes https://github.com/rytilahti/python-miio/issues/820