### PR TITLE
Fix #32315 for Roborock S7

### DIFF
--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -178,6 +178,7 @@ class Vacuum(Device):
             ROCKROBO_S5,
             ROCKROBO_S6,
             ROCKROBO_S6_MAXV,
+            ROCKROBO_S7,
         ]
 
         if self.model not in SKIP_PAUSE:


### PR DESCRIPTION
This fixes [#918](https://github.com/rytilahti/python-miio/issues/918) for Roborock S7 by skipping `app_pause` as with Roborock S50 and S6 MaxV