### PR TITLE
Add additional mode of Air Purifier Super 2

### DIFF
--- a/miio/airpurifier.py
+++ b/miio/airpurifier.py
@@ -28,6 +28,8 @@ class OperationMode(enum.Enum):
     Medium = "medium"
     High = "high"
     Strong = "strong"
+    # Additional supported modes of the Air Purifier Super 2
+    Low = "low"
 
 
 class SleepMode(enum.Enum):


### PR DESCRIPTION
I got an error message when I try to add my Xiaomi Air Purifier Super 2(model: zhimi.airpurifier.sa2) into HA using this [custom component](https://github.com/syssi/xiaomi_airpurifier).

```
xiaomi_miio_airpurifier: Error on device update!
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 407, in _async_add_entity
    await entity.async_device_update(warning=False)
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 516, in async_device_update
    await task
  File "/config/custom_components/xiaomi_miio_airpurifier/fan.py", line 1400, in async_update
    {
  File "/config/custom_components/xiaomi_miio_airpurifier/fan.py", line 1401, in <dictcomp>
    key: self._extract_value_from_attribute(state, value)
  File "/config/custom_components/xiaomi_miio_airpurifier/fan.py", line 1250, in _extract_value_from_attribute
    value = getattr(state, attribute)
  File "/usr/local/lib/python3.8/site-packages/miio/airpurifier.py", line 154, in mode
    return OperationMode(self.data["mode"])
  File "/usr/local/lib/python3.8/enum.py", line 339, in __call__
    return cls.__new__(cls, value)
  File "/usr/local/lib/python3.8/enum.py", line 662, in __new__
    raise ve_exc
ValueError: 'low' is not a valid OperationMode
```

With this message, I found that the OperationMode`low` is not defined in python-miio. I added it into miio package file `airpurifier.py` directly on my HA server and it works. So I open this PR to make this work. 