### PR TITLE
add fan speed enum 106 as "Auto" for Roborock S6 MaxV

### DIFF
--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -66,6 +66,7 @@ class FanspeedV2(enum.Enum):
     Medium = 103
     Turbo = 104
     Gentle = 105
+    Auto = 106
 
 
 class FanspeedV3(enum.Enum):


### PR DESCRIPTION
If the room customization function for the fan speeds is used, the Roborock S6 MaxV reports a fan speed of 106 back.