### PR TITLE
airpurifier_miot: Move favorite_rpm from MB4 to Basic

### DIFF
--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -139,7 +139,7 @@ class BasicAirPurifierMiotStatus(DeviceStatus):
     def motor_speed(self) -> int:
         """Speed of the motor."""
         return self.data["motor_speed"]
-    
+
     @property
     def favorite_rpm(self) -> Optional[int]:
         """Return favorite rpm level."""
@@ -296,7 +296,6 @@ class AirPurifierMB4Status(BasicAirPurifierMiotStatus):
     def led_brightness_level(self) -> int:
         """Return brightness level."""
         return self.data["led_brightness_level"]
-
 
 
 class BasicAirPurifierMiot(MiotDevice):

--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -139,6 +139,11 @@ class BasicAirPurifierMiotStatus(DeviceStatus):
     def motor_speed(self) -> int:
         """Speed of the motor."""
         return self.data["motor_speed"]
+    
+    @property
+    def favorite_rpm(self) -> int:
+        """Return favorite rpm level."""
+        return self.data["favorite_rpm"]
 
 
 class AirPurifierMiotStatus(BasicAirPurifierMiotStatus):
@@ -292,10 +297,6 @@ class AirPurifierMB4Status(BasicAirPurifierMiotStatus):
         """Return brightness level."""
         return self.data["led_brightness_level"]
 
-    @property
-    def favorite_rpm(self) -> int:
-        """Return favorite rpm level."""
-        return self.data["favorite_rpm"]
 
 
 class BasicAirPurifierMiot(MiotDevice):

--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -141,7 +141,7 @@ class BasicAirPurifierMiotStatus(DeviceStatus):
         return self.data["motor_speed"]
     
     @property
-    def favorite_rpm(self) -> int:
+    def favorite_rpm(self) -> Optional[int]:
         """Return favorite rpm level."""
         return self.data.get("favorite_rpm")
 

--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -143,7 +143,7 @@ class BasicAirPurifierMiotStatus(DeviceStatus):
     @property
     def favorite_rpm(self) -> int:
         """Return favorite rpm level."""
-        return self.data["favorite_rpm"]
+        return self.data.get("favorite_rpm")
 
 
 class AirPurifierMiotStatus(BasicAirPurifierMiotStatus):


### PR DESCRIPTION
favorite_rpm is also a 3H parameter so it should be in the basic part

Tested on my local setup, I wasn't able to read this parameter before the modification with the status() function.