### PR TITLE
increase socket buffer size 1024->4096

### DIFF
--- a/miio/miioprotocol.py
+++ b/miio/miioprotocol.py
@@ -190,7 +190,7 @@ class MiIOProtocol:
             raise DeviceException from ex
 
         try:
-            data, addr = s.recvfrom(1024)
+            data, addr = s.recvfrom(4096)
             m = Message.parse(data, token=self.token)
 
             header = m.header.value


### PR DESCRIPTION
When a gateway has 30+ devices connected the message of the device list becomes bigger than 1024 bytes.
That means only part of the message is read, and therefore the checksum will not match and you get an error.
simply increasing the buffer size fixed this issue.
See https://github.com/home-assistant/core/issues/51229