### PR TITLE
Add `depth` calculation for zhimi.humidifier.cb1

### DIFF
--- a/miio/airhumidifier.py
+++ b/miio/airhumidifier.py
@@ -187,9 +187,13 @@ class AirHumidifierStatus(DeviceStatus):
     def depth(self) -> Optional[int]:
         """The remaining amount of water in percent."""
 
-        # MODEL_HUMIDIFIER_CA1 and MODEL_HUMIDIFIER_CB2
+        # MODEL_HUMIDIFIER_CA1, MODEL_HUMIDIFIER_CB1 and MODEL_HUMIDIFIER_CB2
         # 127 without water tank. 125 = 100% water
-        if self.device_info.model in [MODEL_HUMIDIFIER_CA1, MODEL_HUMIDIFIER_CB2]:
+        if self.device_info.model in [
+            MODEL_HUMIDIFIER_CA1,
+            MODEL_HUMIDIFIER_CB1,
+            MODEL_HUMIDIFIER_CB2,
+        ]:
             return int(int(self.data["depth"]) / 1.25)
 
         if "depth" in self.data and self.data["depth"] is not None:

--- a/miio/airhumidifier.py
+++ b/miio/airhumidifier.py
@@ -194,7 +194,7 @@ class AirHumidifierStatus(DeviceStatus):
             MODEL_HUMIDIFIER_CB1,
             MODEL_HUMIDIFIER_CB2,
         ]:
-            return int(int(self.data["depth"]) / 1.25)
+            return round(int(self.data["depth"]) / 1.25)
 
         if "depth" in self.data and self.data["depth"] is not None:
             return self.data["depth"]


### PR DESCRIPTION
zhimi.humidifier.cb1 reports `127` whithout water tank and `125` when water tank is full.

This PR also adds rounding value instead of simply converting to `int`.