### PR TITLE
Add `water_level` and `water_tank_detached` property for humidifiers, deprecate `depth`

### DIFF
--- a/miio/airhumidifier.py
+++ b/miio/airhumidifier.py
@@ -186,6 +186,9 @@ class AirHumidifierStatus(DeviceStatus):
     @property
     def depth(self) -> Optional[int]:
         """Return raw value of depth."""
+        _LOGGER.warning(
+            "The 'depth' property is deprecated and will be removed in the future. Use 'water_level' and 'water_tank_detached' properties instead."
+        )
         if "depth" in self.data:
             return self.data["depth"]
         return None
@@ -260,10 +263,6 @@ class AirHumidifier(Device):
 
         # TODO: convert to use generic device info in the future
         self.device_info: Optional[DeviceInfo] = None
-
-        _LOGGER.warning(
-            "The 'depth' property is deprecated and will be removed for 3 months (october 2021). Use 'water_level' and 'water_tank_detached' properties instead."
-        )
 
     @command(
         default_output=format_output(

--- a/miio/airhumidifier.py
+++ b/miio/airhumidifier.py
@@ -261,6 +261,8 @@ class AirHumidifier(Device):
         # TODO: convert to use generic device info in the future
         self.device_info: Optional[DeviceInfo] = None
 
+        _LOGGER.warning("The 'depth' property is deprecated and will be removed for 3 months (october 2021). Use 'water_level' property instead.")
+
     @command(
         default_output=format_output(
             "",

--- a/miio/airhumidifier.py
+++ b/miio/airhumidifier.py
@@ -261,7 +261,9 @@ class AirHumidifier(Device):
         # TODO: convert to use generic device info in the future
         self.device_info: Optional[DeviceInfo] = None
 
-        _LOGGER.warning("The 'depth' property is deprecated and will be removed for 3 months (october 2021). Use 'water_level' property instead.")
+        _LOGGER.warning(
+            "The 'depth' property is deprecated and will be removed for 3 months (october 2021). Use 'water_level' property instead."
+        )
 
     @command(
         default_output=format_output(

--- a/miio/airhumidifier.py
+++ b/miio/airhumidifier.py
@@ -262,7 +262,7 @@ class AirHumidifier(Device):
         self.device_info: Optional[DeviceInfo] = None
 
         _LOGGER.warning(
-            "The 'depth' property is deprecated and will be removed for 3 months (october 2021). Use 'water_level' property instead."
+            "The 'depth' property is deprecated and will be removed for 3 months (october 2021). Use 'water_level' and 'water_tank_detached' properties instead."
         )
 
     @command(

--- a/miio/airhumidifier.py
+++ b/miio/airhumidifier.py
@@ -185,15 +185,29 @@ class AirHumidifierStatus(DeviceStatus):
 
     @property
     def depth(self) -> Optional[int]:
-        """The remaining amount of water in percent."""
-
-        # MODEL_HUMIDIFIER_CA1 and MODEL_HUMIDIFIER_CB2
-        # 127 without water tank. 125 = 100% water
-        if self.device_info.model in [MODEL_HUMIDIFIER_CA1, MODEL_HUMIDIFIER_CB2]:
-            return int(int(self.data["depth"]) / 1.25)
-
-        if "depth" in self.data and self.data["depth"] is not None:
+        """Return raw value of depth."""
+        if "depth" in self.data:
             return self.data["depth"]
+        return None
+
+    @property
+    def water_level(self) -> Optional[int]:
+        """Return current water level in percent.
+
+        If water tank is full, depth is 125.
+        """
+        if self.depth is not None and self.depth <= 125:
+            return int(self.depth / 1.25)
+        return None
+
+    @property
+    def water_tank_detached(self) -> Optional[bool]:
+        """True if the water tank is detached.
+
+        If water tank is detached, depth is 127.
+        """
+        if self.data.get("depth") is not None:
+            return self.data["depth"] == 127
         return None
 
     @property
@@ -261,6 +275,8 @@ class AirHumidifier(Device):
             "Trans level: {result.trans_level}\n"
             "Speed: {result.motor_speed}\n"
             "Depth: {result.depth}\n"
+            "Water Level: {result.water_level} %\n"
+            "Water tank detached: {result.water_tank_detached}\n"
             "Dry: {result.dry}\n"
             "Use time: {result.use_time}\n"
             "Hardware version: {result.hardware_version}\n"

--- a/miio/airhumidifier_miot.py
+++ b/miio/airhumidifier_miot.py
@@ -126,10 +126,22 @@ class AirHumidifierMiotStatus(DeviceStatus):
         return self.data["target_humidity"]
 
     @property
-    def water_level(self) -> int:
-        """Return current water level."""
-        # 127 without water tank. 120 = 100% water
-        return int(self.data["water_level"] / 1.20)
+    def water_level(self) -> Optional[int]:
+        """Return current water level in percent.
+
+        If water tank is full, depth is 125.
+        """
+        if self.data["water_level"] <= 125:
+            return int(self.data["water_level"] / 1.25)
+        return None
+
+    @property
+    def water_tank_detached(self) -> bool:
+        """True if the water tank is detached.
+
+        If water tank is detached, water_level is 127.
+        """
+        return self.data["water_level"] == 127
 
     @property
     def dry(self) -> Optional[bool]:
@@ -245,6 +257,7 @@ class AirHumidifierMiot(MiotDevice):
             "Temperature: {result.temperature} °C\n"
             "Temperature: {result.fahrenheit} °F\n"
             "Water Level: {result.water_level} %\n"
+            "Water tank detached: {result.water_tank_detached}\n"
             "Mode: {result.mode}\n"
             "LED brightness: {result.led_brightness}\n"
             "Buzzer: {result.buzzer}\n"

--- a/miio/tests/test_airhumidifier.py
+++ b/miio/tests/test_airhumidifier.py
@@ -344,7 +344,9 @@ class TestAirHumidifierCA1(TestCase):
         assert self.state().motor_speed == self.device.start_state["speed"]
         assert self.state().depth == self.device.start_state["depth"]
         assert self.state().water_level == int(self.device.start_state["depth"] / 1.25)
-        assert self.state().water_tank_detached == (self.device.start_state["depth"] == 127)
+        assert self.state().water_tank_detached == (
+            self.device.start_state["depth"] == 127
+        )
         assert self.state().dry == (self.device.start_state["dry"] == "on")
         assert self.state().use_time == self.device.start_state["use_time"]
         assert self.state().hardware_version == self.device.start_state["hw_version"]

--- a/miio/tests/test_airhumidifier.py
+++ b/miio/tests/test_airhumidifier.py
@@ -343,6 +343,8 @@ class TestAirHumidifierCA1(TestCase):
         assert self.state().trans_level is None
         assert self.state().motor_speed == self.device.start_state["speed"]
         assert self.state().depth == self.device.start_state["depth"]
+        assert self.state().water_level == int(self.device.start_state["depth"] / 1.25)
+        assert self.state().water_tank_detached == (self.device.start_state["depth"] == 127)
         assert self.state().dry == (self.device.start_state["dry"] == "on")
         assert self.state().use_time == self.device.start_state["use_time"]
         assert self.state().hardware_version == self.device.start_state["hw_version"]

--- a/miio/tests/test_airhumidifier_miot.py
+++ b/miio/tests/test_airhumidifier_miot.py
@@ -80,7 +80,8 @@ class TestAirHumidifier(TestCase):
         assert status.error == _INITIAL_STATE["fault"]
         assert status.mode == OperationMode(_INITIAL_STATE["mode"])
         assert status.target_humidity == _INITIAL_STATE["target_humidity"]
-        assert status.water_level == int(_INITIAL_STATE["water_level"] / 1.20)
+        assert status.water_level == int(_INITIAL_STATE["water_level"] / 1.25)
+        assert status.water_tank_detached == (_INITIAL_STATE["water_level"] == 127)
         assert status.dry == _INITIAL_STATE["dry"]
         assert status.use_time == _INITIAL_STATE["use_time"]
         assert status.button_pressed == PressedButton(_INITIAL_STATE["button_pressed"])


### PR DESCRIPTION
This PR:
- adds `water_level` property for AirHumidifier (value is calculated from `depth`)
- adds `water_tank_detached` for AirHumidifier (value is calculated from `depth`)
- fixes `water_level` calculation for AirHumidifierMiot
- adds `water_tank_detached` for AirHumidifierMiot (value is calculated from `water_level`)