### PR TITLE
Update chuangmi_ir.py to accept 2 arguments (frequency and length)

### DIFF
--- a/miio/chuangmi_ir.py
+++ b/miio/chuangmi_ir.py
@@ -153,7 +153,7 @@ class ChuangmiIr(Device):
         else:
             command_type, command, *command_args = command.split(":")
 
-        arg_types = [int]
+        arg_types = [int, int]
         if len(command_args) > len(arg_types):
             raise ChuangmiIrException("Invalid command arguments count")
 


### PR DESCRIPTION
Changed the arg_types variable to have a length of 2 in order to be able to use something like this (both frequency and length): 
miiocli chuangmiir --ip 192.168.10.14 --token REDACTED play "raw:mc0mU0lkxm00mEsmkznEsmMzmM0AIqazYAPwA1Ag8BjwIfAy8DLwMvAZ8BnwIfAY8BjwA/AD8APwA/AD8APwA/AD8APwqPCo8PzwIfAD8APwSfFX8FHwA/AD8APwA/AD8APwA/AD8APwA/AD8APwA/AD8APwA/AD8APwA/AD8APxgfFw8APwKPAY+bA=:38000:224"