### PR TITLE
Add link to the Home Assistant custom component hass-xiaomi-miot

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -168,6 +168,7 @@ Home Assistant (custom)
 -  `Xiaomi Mi Smart Rice Cooker <https://github.com/syssi/xiaomi_cooker>`__
 -  `Xiaomi Raw Sensor <https://github.com/syssi/xiaomi_raw>`__
 -  `Xiaomi MIoT Devices <https://github.com/ha0y/xiaomi_miot_raw>`__
+-  `Xiaomi Miot Auto <https://github.com/al-one/hass-xiaomi-miot>`__
 
 Other projects
 ^^^^^^^^^^^^^^


### PR DESCRIPTION
[hass-xiaomi-miot](https://github.com/al-one/hass-xiaomi-miot) is a custom component that automatically integrates Xiaomi devices into Home Assistant via miot-spec, and now supports most device models.