### PR TITLE
deprecate old helper scripts in favor of miiocli

### DIFF
--- a/miio/ceil_cli.py
+++ b/miio/ceil_cli.py
@@ -46,6 +46,10 @@ def cli(ctx, ip: str, token: str, debug: int):
     else:
         logging.basicConfig(level=logging.INFO)
 
+    _LOGGER.warning(
+        "This script is deprecated and will be removed soon, use `miiocli ceil` instead"
+    )
+
     # if we are scanning, we do not try to connect.
     if ctx.invoked_subcommand == "discover":
         return

--- a/miio/philips_eyecare_cli.py
+++ b/miio/philips_eyecare_cli.py
@@ -46,6 +46,10 @@ def cli(ctx, ip: str, token: str, debug: int):
     else:
         logging.basicConfig(level=logging.INFO)
 
+    _LOGGER.warning(
+        "This script is deprecated and will be removed soon, use `miiocli philipseyecare` instead"
+    )
+
     # if we are scanning, we do not try to connect.
     if ctx.invoked_subcommand == "discover":
         return

--- a/miio/plug_cli.py
+++ b/miio/plug_cli.py
@@ -26,6 +26,10 @@ def cli(ctx, ip: str, token: str, debug: int):
     else:
         logging.basicConfig(level=logging.INFO)
 
+    _LOGGER.warning(
+        "This script is deprecated and will be removed soon, use `miiocli chuangmiplug` instead"
+    )
+
     # if we are scanning, we do not try to connect.
     if ctx.invoked_subcommand == "discover":
         return


### PR DESCRIPTION
These scripts were done prior the existence of miiocli and are not needed anymore. This PR adds a warning for the next release and these will get dropped completely for 0.6.0.