### PR TITLE
Fix the issue with a wrong properties retrieval for Viomi Vacuum

### DIFF
--- a/miio/viomivacuum.py
+++ b/miio/viomivacuum.py
@@ -486,6 +486,16 @@ class ViomiVacuum(Device):
         self.manual_seqnum = -1
         self._cache: Dict[str, Any] = {"edge_state": None, "rooms": {}, "maps": {}}
 
+    def get_properties(
+        self, properties, *, property_getter="get_prop", max_properties=None
+    ):
+        result = {}
+        for prop in properties:
+            value = self.send(property_getter, [prop])
+            result[prop] = value[0] if len(value) else None
+
+        return list(result.values())
+
     @command(
         default_output=format_output(
             "\n",


### PR DESCRIPTION
Fixes the issue that is described here https://github.com/rytilahti/python-miio/issues/1003. The cause is in the way how the device responds to a query of multiple properties. It just skips None values which makes other logic fails.