### PR TITLE
Do not use deprecated `depth` property

### DIFF
--- a/miio/airhumidifier.py
+++ b/miio/airhumidifier.py
@@ -199,8 +199,9 @@ class AirHumidifierStatus(DeviceStatus):
 
         If water tank is full, depth is 125.
         """
-        if self.data.get("depth") is not None and self.data["depth"] <= 125:
-            return int(self.data["depth"] / 1.25)
+        depth = self.data.get("depth")
+        if depth is not None and depth <= 125:
+            return int(depth / 1.25)
         return None
 
     @property

--- a/miio/airhumidifier.py
+++ b/miio/airhumidifier.py
@@ -199,8 +199,8 @@ class AirHumidifierStatus(DeviceStatus):
 
         If water tank is full, depth is 125.
         """
-        if self.depth is not None and self.depth <= 125:
-            return int(self.depth / 1.25)
+        if self.data.get("depth") is not None and self.data["depth"] <= 125:
+            return int(self.data["depth"] / 1.25)
         return None
 
     @property


### PR DESCRIPTION
This PR fixes my stupid mistake started here https://github.com/rytilahti/python-miio/pull/1089

We don't want to use deprecated `depth` property to calulate the `water_level` property.