### PR TITLE
Mark device_classes inside devicegroupmeta as private

### DIFF
--- a/miio/cli.py
+++ b/miio/cli.py
@@ -39,7 +39,7 @@ def cli(ctx, debug: int, output: str):
     ctx.obj = GlobalContextObject(debug=debug, output=output_func)
 
 
-for device_class in DeviceGroupMeta.device_classes:
+for device_class in DeviceGroupMeta._device_classes:
     cli.add_command(device_class.get_device_group())
 
 

--- a/miio/click_common.py
+++ b/miio/click_common.py
@@ -119,12 +119,6 @@ class DeviceGroupMeta(type):
 
     _device_classes: Set[Type] = set()
 
-    @property
-    @classmethod
-    def device_classes(cls) -> Set[Type]:
-        """Return the list of registered device classes."""
-        return cls._device_classes
-
     def __new__(mcs, name, bases, namespace):
         commands = {}
 

--- a/miio/click_common.py
+++ b/miio/click_common.py
@@ -117,7 +117,12 @@ class GlobalContextObject:
 
 class DeviceGroupMeta(type):
 
-    device_classes: Set[Type] = set()
+    _device_classes: Set[Type] = set()
+
+    @property
+    def device_classes(self) -> Set[Type]:
+        """Return the list of registered device classes."""
+        return self._device_classes
 
     def __new__(mcs, name, bases, namespace):
         commands = {}
@@ -150,7 +155,7 @@ class DeviceGroupMeta(type):
             namespace["get_device_group"] = classmethod(get_device_group)
 
         cls = super().__new__(mcs, name, bases, namespace)
-        mcs.device_classes.add(cls)
+        mcs._device_classes.add(cls)
         return cls
 
 

--- a/miio/click_common.py
+++ b/miio/click_common.py
@@ -120,9 +120,10 @@ class DeviceGroupMeta(type):
     _device_classes: Set[Type] = set()
 
     @property
-    def device_classes(self) -> Set[Type]:
+    @classmethod
+    def device_classes(cls) -> Set[Type]:
         """Return the list of registered device classes."""
-        return self._device_classes
+        return cls._device_classes
 
     def __new__(mcs, name, bases, namespace):
         commands = {}


### PR DESCRIPTION
This container shouldn't have been exposed directly to the inheriting classes.
The cli will now use the newly introduced property to access the type objects.