### PR TITLE
Do not get battery status for mains powered devices

### DIFF
--- a/miio/gateway/devices/subdevice.py
+++ b/miio/gateway/devices/subdevice.py
@@ -41,6 +41,7 @@ class SubDevice:
         if model_info is None:
             model_info = {}
         self._model_info = model_info
+        self._battery_powered = model_info.get("battery", True)
         self._battery = None
         self._voltage = None
         self._fw_ver = dev_info.fw_ver
@@ -208,6 +209,9 @@ class SubDevice:
     @command()
     def get_battery(self):
         """Update the battery level, if available."""
+        if not self._battery_powered:
+            return self._battery
+
         if self._gw.model not in [GATEWAY_MODEL_EU, GATEWAY_MODEL_ZIG3]:
             self._battery = self.send("get_battery").pop()
         else:
@@ -220,6 +224,9 @@ class SubDevice:
     @command()
     def get_voltage(self):
         """Update the battery voltage, if available."""
+        if not self._battery_powered:
+            return self._voltage
+
         if self._gw.model in [GATEWAY_MODEL_EU, GATEWAY_MODEL_ZIG3]:
             self._voltage = self.get_property("voltage").pop() / 1000
         else:

--- a/miio/gateway/devices/subdevice.py
+++ b/miio/gateway/devices/subdevice.py
@@ -207,9 +207,13 @@ class SubDevice:
         return self.send("remove_device")
 
     @command()
-    def get_battery(self):
+    def get_battery(self) -> Optional[int]:
         """Update the battery level, if available."""
         if not self._battery_powered:
+            _LOGGER.debug(
+                "%s is not battery powered, get_battery not supported",
+                self.name,
+            )
             return None
 
         if self._gw.model not in [GATEWAY_MODEL_EU, GATEWAY_MODEL_ZIG3]:
@@ -222,9 +226,13 @@ class SubDevice:
         return self._battery
 
     @command()
-    def get_voltage(self):
+    def get_voltage(self) -> Optional[float]:
         """Update the battery voltage, if available."""
         if not self._battery_powered:
+            _LOGGER.debug(
+                "%s is not battery powered, get_voltage not supported",
+                self.name,
+            )
             return None
 
         if self._gw.model in [GATEWAY_MODEL_EU, GATEWAY_MODEL_ZIG3]:

--- a/miio/gateway/devices/subdevice.py
+++ b/miio/gateway/devices/subdevice.py
@@ -41,7 +41,7 @@ class SubDevice:
         if model_info is None:
             model_info = {}
         self._model_info = model_info
-        self._battery_powered = model_info.get("battery", True)
+        self._battery_powered = model_info.get("battery_powered", True)
         self._battery = None
         self._voltage = None
         self._fw_ver = dev_info.fw_ver

--- a/miio/gateway/devices/subdevices.yaml
+++ b/miio/gateway/devices/subdevices.yaml
@@ -127,6 +127,7 @@
   name: Smart bulb E27
   type: LightBulb
   class: LightBulb
+  battery: false
   properties:
     - property: power_status # 'on' / 'off'
       name: status
@@ -152,6 +153,7 @@
   name: Ikea smart bulb E27 white
   type: LightBulb
   class: LightBulb
+  battery: false
   properties:
     - property: power_status # 'on' / 'off'
       name: status
@@ -177,6 +179,7 @@
   name: Ikea smart bulb E27 white
   type: LightBulb
   class: LightBulb
+  battery: false
   properties:
     - property: power_status # 'on' / 'off'
       name: status
@@ -202,6 +205,7 @@
   name: Ikea smart bulb E12 white
   type: LightBulb
   class: LightBulb
+  battery: false
   properties:
     - property: power_status # 'on' / 'off'
       name: status
@@ -227,6 +231,7 @@
   name: Ikea smart bulb GU10 white
   type: LightBulb
   class: LightBulb
+  battery: false
   properties:
     - property: power_status # 'on' / 'off'
       name: status
@@ -252,6 +257,7 @@
   name: Ikea smart bulb E27 white
   type: LightBulb
   class: LightBulb
+  battery: false
   properties:
     - property: power_status # 'on' / 'off'
       name: status
@@ -277,6 +283,7 @@
   name: Ikea smart bulb GU10 white
   type: LightBulb
   class: LightBulb
+  battery: false
   properties:
     - property: power_status # 'on' / 'off'
       name: status
@@ -302,6 +309,7 @@
   name: Ikea smart bulb E12 white
   type: LightBulb
   class: LightBulb
+  battery: false
   properties:
     - property: power_status # 'on' / 'off'
       name: status
@@ -474,6 +482,7 @@
   type: Switch
   class: Switch
   setter: toggle_ctrl_neutral
+  battery: false
   properties:
     - property: neutral_0 # 'on' / 'off'
       name: status_ch0
@@ -489,6 +498,7 @@
   type: Switch
   class: Switch
   setter: toggle_ctrl_neutral
+  battery: false
   properties:
     - property: neutral_0 # 'on' / 'off'
       name: status_ch0
@@ -501,6 +511,7 @@
   type: Switch
   class: Switch
   setter: toggle_ctrl_neutral
+  battery: false
   properties:
     - property: neutral_0 # 'on' / 'off'
       name: status_ch0
@@ -516,6 +527,7 @@
   type: Switch
   class: Switch
   setter: toggle_ctrl_neutral
+  battery: false
   properties:
     - property: neutral_0 # 'on' / 'off'
       name: status_ch0
@@ -534,6 +546,7 @@
   type: Switch
   class: Switch
   setter: toggle_ctrl_neutral
+  battery: false
   properties:
     - property: neutral_0 # 'on' / 'off'
       name: status_ch0
@@ -549,6 +562,7 @@
   type: Switch
   class: Switch
   setter: toggle_ctrl_neutral
+  battery: false
   properties:
     - property: neutral_0 # 'on' / 'off'
       name: status_ch0
@@ -567,6 +581,7 @@
   type: Switch
   class: Switch
   setter: toggle_ctrl_neutral
+  battery: false
   properties:
     - property: neutral_0 # 'on' / 'off'
       name: status_ch0
@@ -588,6 +603,7 @@
   type: Switch
   class: Switch
   setter: toggle_ctrl_neutral
+  battery: false
   properties:
     - property: neutral_0 # 'on' / 'off'
       name: status_ch0
@@ -610,6 +626,7 @@
   class: Switch
   getter: get_prop_plug
   setter: toggle_plug
+  battery: false
   properties:
     - property: neutral_0 # 'on' / 'off'
       name: status_ch0
@@ -626,6 +643,7 @@
   class: Switch
   getter: get_prop_plug
   setter: toggle_plug
+  battery: false
   properties:
     - property: neutral_0 # 'on' / 'off'
       name: status_ch0
@@ -641,6 +659,7 @@
   type: Switch
   class: Switch
   setter: toggle_plug
+  battery: false
   properties:
     - property: channel_0 # 'on' / 'off'
       name: status_ch0
@@ -653,6 +672,7 @@
   type: Switch
   class: Switch
   setter: toggle_plug
+  battery: false
   properties:
     - property: channel_0 # 'on' / 'off'
       name: status_ch0
@@ -668,6 +688,7 @@
   type: Switch
   class: Switch
   setter: toggle_ctrl_neutral
+  battery: false
   properties:
     - property: channel_0 # 'on' / 'off'
       name: status_ch0

--- a/miio/gateway/devices/subdevices.yaml
+++ b/miio/gateway/devices/subdevices.yaml
@@ -127,7 +127,7 @@
   name: Smart bulb E27
   type: LightBulb
   class: LightBulb
-  battery: false
+  battery_powered: false
   properties:
     - property: power_status # 'on' / 'off'
       name: status
@@ -153,7 +153,7 @@
   name: Ikea smart bulb E27 white
   type: LightBulb
   class: LightBulb
-  battery: false
+  battery_powered: false
   properties:
     - property: power_status # 'on' / 'off'
       name: status
@@ -179,7 +179,7 @@
   name: Ikea smart bulb E27 white
   type: LightBulb
   class: LightBulb
-  battery: false
+  battery_powered: false
   properties:
     - property: power_status # 'on' / 'off'
       name: status
@@ -205,7 +205,7 @@
   name: Ikea smart bulb E12 white
   type: LightBulb
   class: LightBulb
-  battery: false
+  battery_powered: false
   properties:
     - property: power_status # 'on' / 'off'
       name: status
@@ -231,7 +231,7 @@
   name: Ikea smart bulb GU10 white
   type: LightBulb
   class: LightBulb
-  battery: false
+  battery_powered: false
   properties:
     - property: power_status # 'on' / 'off'
       name: status
@@ -257,7 +257,7 @@
   name: Ikea smart bulb E27 white
   type: LightBulb
   class: LightBulb
-  battery: false
+  battery_powered: false
   properties:
     - property: power_status # 'on' / 'off'
       name: status
@@ -283,7 +283,7 @@
   name: Ikea smart bulb GU10 white
   type: LightBulb
   class: LightBulb
-  battery: false
+  battery_powered: false
   properties:
     - property: power_status # 'on' / 'off'
       name: status
@@ -309,7 +309,7 @@
   name: Ikea smart bulb E12 white
   type: LightBulb
   class: LightBulb
-  battery: false
+  battery_powered: false
   properties:
     - property: power_status # 'on' / 'off'
       name: status
@@ -482,7 +482,7 @@
   type: Switch
   class: Switch
   setter: toggle_ctrl_neutral
-  battery: false
+  battery_powered: false
   properties:
     - property: neutral_0 # 'on' / 'off'
       name: status_ch0
@@ -498,7 +498,7 @@
   type: Switch
   class: Switch
   setter: toggle_ctrl_neutral
-  battery: false
+  battery_powered: false
   properties:
     - property: neutral_0 # 'on' / 'off'
       name: status_ch0
@@ -511,7 +511,7 @@
   type: Switch
   class: Switch
   setter: toggle_ctrl_neutral
-  battery: false
+  battery_powered: false
   properties:
     - property: neutral_0 # 'on' / 'off'
       name: status_ch0
@@ -527,7 +527,7 @@
   type: Switch
   class: Switch
   setter: toggle_ctrl_neutral
-  battery: false
+  battery_powered: false
   properties:
     - property: neutral_0 # 'on' / 'off'
       name: status_ch0
@@ -546,7 +546,7 @@
   type: Switch
   class: Switch
   setter: toggle_ctrl_neutral
-  battery: false
+  battery_powered: false
   properties:
     - property: neutral_0 # 'on' / 'off'
       name: status_ch0
@@ -562,7 +562,7 @@
   type: Switch
   class: Switch
   setter: toggle_ctrl_neutral
-  battery: false
+  battery_powered: false
   properties:
     - property: neutral_0 # 'on' / 'off'
       name: status_ch0
@@ -581,7 +581,7 @@
   type: Switch
   class: Switch
   setter: toggle_ctrl_neutral
-  battery: false
+  battery_powered: false
   properties:
     - property: neutral_0 # 'on' / 'off'
       name: status_ch0
@@ -603,7 +603,7 @@
   type: Switch
   class: Switch
   setter: toggle_ctrl_neutral
-  battery: false
+  battery_powered: false
   properties:
     - property: neutral_0 # 'on' / 'off'
       name: status_ch0
@@ -626,7 +626,7 @@
   class: Switch
   getter: get_prop_plug
   setter: toggle_plug
-  battery: false
+  battery_powered: false
   properties:
     - property: neutral_0 # 'on' / 'off'
       name: status_ch0
@@ -643,7 +643,7 @@
   class: Switch
   getter: get_prop_plug
   setter: toggle_plug
-  battery: false
+  battery_powered: false
   properties:
     - property: neutral_0 # 'on' / 'off'
       name: status_ch0
@@ -659,7 +659,7 @@
   type: Switch
   class: Switch
   setter: toggle_plug
-  battery: false
+  battery_powered: false
   properties:
     - property: channel_0 # 'on' / 'off'
       name: status_ch0
@@ -672,7 +672,7 @@
   type: Switch
   class: Switch
   setter: toggle_plug
-  battery: false
+  battery_powered: false
   properties:
     - property: channel_0 # 'on' / 'off'
       name: status_ch0
@@ -688,7 +688,7 @@
   type: Switch
   class: Switch
   setter: toggle_ctrl_neutral
-  battery: false
+  battery_powered: false
   properties:
     - property: channel_0 # 'on' / 'off'
       name: status_ch0


### PR DESCRIPTION
This schould fix the errors as reported here: https://github.com/rytilahti/python-miio/discussions/1121#discussioncomment-1267774
If the battery status is requested from a mains powered device like the `lumi.plug.mmeu01` it gives an error like:
`miio.exceptions.DeviceError: {'code': -4003, 'message': 'prop or action not exist'}`