### PR TITLE
Make cli work again for offline gen1 vacs, fix tests

### DIFF
--- a/miio/click_common.py
+++ b/miio/click_common.py
@@ -183,7 +183,7 @@ class DeviceGroup(click.MultiCommand):
                             "Unknown model, trying autodetection. %s %s"
                             % (self._model, self._info)
                         )
-                        self.info()
+                        self._fetch_info()
                     return func(self, *args, **kwargs)
 
                 # TODO HACK to make the command visible to cli

--- a/miio/click_common.py
+++ b/miio/click_common.py
@@ -183,7 +183,7 @@ class DeviceGroup(click.MultiCommand):
                             "Unknown model, trying autodetection. %s %s"
                             % (self._model, self._info)
                         )
-                        self._fetch_info()
+                        self.info()
                     return func(self, *args, **kwargs)
 
                 # TODO HACK to make the command visible to cli

--- a/miio/device.py
+++ b/miio/device.py
@@ -68,9 +68,9 @@ class Device(metaclass=DeviceGroupMeta):
         model: str = None,
     ) -> None:
         self.ip = ip
-        self.token = token
-        self._model = model
-        self._info = None
+        self.token: Optional[str] = token
+        self._model: Optional[str] = model
+        self._info: Optional[DeviceInfo] = None
         timeout = timeout if timeout is not None else self.timeout
         self._protocol = MiIOProtocol(
             ip, token, start_id, debug, lazy_discover, timeout
@@ -143,7 +143,7 @@ class Device(metaclass=DeviceGroupMeta):
 
         return self._fetch_info()
 
-    def _fetch_info(self):
+    def _fetch_info(self) -> DeviceInfo:
         """Perform miIO.info query on the device and cache the result."""
         try:
             devinfo = DeviceInfo(self.send("miIO.info"))

--- a/miio/fan_miot.py
+++ b/miio/fan_miot.py
@@ -681,7 +681,7 @@ class FanZA5(MiotDevice):
         model: str = MODEL_FAN_ZA5,
     ) -> None:
         super().__init__(ip, token, start_id, debug, lazy_discover)
-        self.model = model
+        self._model = model
 
     @command(
         default_output=format_output(

--- a/miio/g1vacuum.py
+++ b/miio/g1vacuum.py
@@ -285,7 +285,7 @@ class G1Vacuum(MiotDevice):
         model: str = MIJIA_VACUUM_V2,
     ) -> None:
         super().__init__(ip, token, start_id, debug, lazy_discover)
-        self.model = model
+        self._model = model
 
     @command(
         default_output=format_output(

--- a/miio/tests/test_fan_miot.py
+++ b/miio/tests/test_fan_miot.py
@@ -364,7 +364,7 @@ class TestFan1C(TestCase):
 
 class DummyFanZA5(DummyMiotDevice, FanZA5):
     def __init__(self, *args, **kwargs):
-        self.model = MODEL_FAN_ZA5
+        self._model = MODEL_FAN_ZA5
         self.state = {
             "anion": True,
             "buzzer": False,

--- a/miio/tests/test_vacuum.py
+++ b/miio/tests/test_vacuum.py
@@ -281,7 +281,9 @@ class TestVacuum(TestCase):
         """Test the info functionality for non-cloud connected device."""
         from miio.exceptions import DeviceInfoUnavailableException
 
-        with patch("miio.Device.info", side_effect=DeviceInfoUnavailableException()):
+        with patch(
+            "miio.Device._fetch_info", side_effect=DeviceInfoUnavailableException()
+        ):
             assert self.device.info().model == "rockrobo.vacuum.v1"
 
     def test_carpet_cleaning_mode(self):

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -189,19 +189,17 @@ class Vacuum(Device):
 
         return self.start()
 
-    @command(skip_autodetect=True)
-    def info(self, *, force=False):
+    def _fetch_info(self) -> DeviceInfo:
         """Return info about the device.
 
         This is overrides the base class info to account for gen1 devices that do not
         respond to info query properly when not connected to the cloud.
         """
         try:
-            info = super().info(force=force)
+            info = super()._fetch_info()
             return info
         except (TypeError, DeviceInfoUnavailableException):
-            # cloud-blocked vacuums will not return proper payloads
-
+            # cloud-blocked gen1 vacuums will not return proper payloads
             dummy_v1 = DeviceInfo(
                 {
                     "model": ROCKROBO_V1,


### PR DESCRIPTION
* `Vacuum` overrides now the internal `_fetch_info`
* Fix tests for new integrations that were assigning now-readonly `model` 