### PR TITLE
Remove unnecessary subclass constructors, deprecate subclasses only setting the model

### DIFF
--- a/miio/airdehumidifier.py
+++ b/miio/airdehumidifier.py
@@ -158,19 +158,6 @@ class AirDehumidifierStatus(DeviceStatus):
 class AirDehumidifier(Device):
     """Implementation of Xiaomi Mi Air Dehumidifier."""
 
-    def __init__(
-        self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-        model: str = MODEL_DEHUMIDIFIER_V1,
-    ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
-
-        self.device_info: DeviceInfo
-
     @command(
         default_output=format_output(
             "",
@@ -193,15 +180,14 @@ class AirDehumidifier(Device):
     def status(self) -> AirDehumidifierStatus:
         """Retrieve properties."""
 
-        if self.device_info is None:
-            self.device_info = self.info()
-
-        properties = AVAILABLE_PROPERTIES[self.model]
+        properties = AVAILABLE_PROPERTIES.get(
+            self.model, AVAILABLE_PROPERTIES[MODEL_DEHUMIDIFIER_V1]
+        )
 
         values = self.get_properties(properties, max_properties=1)
 
         return AirDehumidifierStatus(
-            defaultdict(lambda: None, zip(properties, values)), self.device_info
+            defaultdict(lambda: None, zip(properties, values)), self.info()
         )
 
     @command(default_output=format_output("Powering on"))

--- a/miio/airfresh.py
+++ b/miio/airfresh.py
@@ -8,6 +8,7 @@ import click
 from .click_common import EnumType, command, format_output
 from .device import Device, DeviceStatus
 from .exceptions import DeviceException
+from .utils import deprecated
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -218,17 +219,6 @@ class AirFreshStatus(DeviceStatus):
 class AirFresh(Device):
     """Main class representing the air fresh."""
 
-    def __init__(
-        self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-        model: str = MODEL_AIRFRESH_VA2,
-    ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
-
     @command(
         default_output=format_output(
             "",
@@ -254,7 +244,9 @@ class AirFresh(Device):
     def status(self) -> AirFreshStatus:
         """Retrieve properties."""
 
-        properties = AVAILABLE_PROPERTIES[self.model]
+        properties = AVAILABLE_PROPERTIES.get(
+            self.model, AVAILABLE_PROPERTIES[MODEL_AIRFRESH_VA2]
+        )
         values = self.get_properties(properties, max_properties=15)
 
         return AirFreshStatus(
@@ -356,6 +348,9 @@ class AirFresh(Device):
             return self.send("set_ptc_state", ["off"])
 
 
+@deprecated(
+    "This will be removed in the future, use AirFresh(..., model='zhimi.airfresh.va4'"
+)
 class AirFreshVA4(AirFresh):
     """Main class representing the air fresh va4."""
 

--- a/miio/airfresh_t2017.py
+++ b/miio/airfresh_t2017.py
@@ -224,17 +224,6 @@ class AirFreshStatus(DeviceStatus):
 class AirFreshA1(Device):
     """Main class representing the air fresh a1."""
 
-    def __init__(
-        self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-        model: str = MODEL_AIRFRESH_A1,
-    ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
-
     @command(
         default_output=format_output(
             "",
@@ -257,7 +246,9 @@ class AirFreshA1(Device):
     def status(self) -> AirFreshStatus:
         """Retrieve properties."""
 
-        properties = AVAILABLE_PROPERTIES[self.model]
+        properties = AVAILABLE_PROPERTIES.get(
+            self.model, AVAILABLE_PROPERTIES[MODEL_AIRFRESH_A1]
+        )
         values = self.get_properties(properties, max_properties=15)
 
         return AirFreshStatus(defaultdict(lambda: None, zip(properties, values)))
@@ -366,17 +357,6 @@ class AirFreshA1(Device):
 class AirFreshT2017(AirFreshA1):
     """Main class representing the air fresh t2017."""
 
-    def __init__(
-        self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-        model: str = MODEL_AIRFRESH_T2017,
-    ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
-
     @command(
         default_output=format_output(
             "",
@@ -400,11 +380,6 @@ class AirFreshT2017(AirFreshA1):
             "Display orientation: {result.display_orientation}\n",
         )
     )
-    def status(self) -> AirFreshStatus:
-        """Retrieve properties."""
-
-        return super().status()
-
     @command(
         click.argument("speed", type=int),
         default_output=format_output("Setting favorite speed to {speed}"),

--- a/miio/airhumidifier.py
+++ b/miio/airhumidifier.py
@@ -8,6 +8,7 @@ import click
 from .click_common import EnumType, command, format_output
 from .device import Device, DeviceInfo, DeviceStatus
 from .exceptions import DeviceError, DeviceException
+from .utils import deprecated
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -246,20 +247,6 @@ class AirHumidifierStatus(DeviceStatus):
 class AirHumidifier(Device):
     """Implementation of Xiaomi Mi Air Humidifier."""
 
-    def __init__(
-        self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-        model: str = MODEL_HUMIDIFIER_V1,
-    ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
-
-        # TODO: convert to use generic device info in the future
-        self.device_info: Optional[DeviceInfo] = None
-
     @command(
         default_output=format_output(
             "",
@@ -284,10 +271,10 @@ class AirHumidifier(Device):
     )
     def status(self) -> AirHumidifierStatus:
         """Retrieve properties."""
-        if self.device_info is None:
-            self.device_info = self.info()
 
-        properties = AVAILABLE_PROPERTIES[self.model]
+        properties = AVAILABLE_PROPERTIES.get(
+            self.model, AVAILABLE_PROPERTIES[MODEL_HUMIDIFIER_V1]
+        )
 
         # A single request is limited to 16 properties. Therefore the
         # properties are divided into multiple requests
@@ -304,7 +291,7 @@ class AirHumidifier(Device):
         values = self.get_properties(properties, max_properties=_props_per_request)
 
         return AirHumidifierStatus(
-            defaultdict(lambda: None, zip(properties, values)), self.device_info
+            defaultdict(lambda: None, zip(properties, values)), self.info()
         )
 
     @command(default_output=format_output("Powering on"))
@@ -407,6 +394,7 @@ class AirHumidifier(Device):
             return self.send("set_dry", ["off"])
 
 
+@deprecated("Use AirHumidifer(model='zhimi.humidifier.ca1")
 class AirHumidifierCA1(AirHumidifier):
     def __init__(
         self,
@@ -421,6 +409,7 @@ class AirHumidifierCA1(AirHumidifier):
         )
 
 
+@deprecated("Use AirHumidifer(model='zhimi.humidifier.cb1")
 class AirHumidifierCB1(AirHumidifier):
     def __init__(
         self,
@@ -435,6 +424,7 @@ class AirHumidifierCB1(AirHumidifier):
         )
 
 
+@deprecated("Use AirHumidifier(model='zhimi.humidifier.cb2')")
 class AirHumidifierCB2(AirHumidifier):
     def __init__(
         self,

--- a/miio/airhumidifier_mjjsq.py
+++ b/miio/airhumidifier_mjjsq.py
@@ -122,16 +122,7 @@ class AirHumidifierStatus(DeviceStatus):
 
 
 class AirHumidifierMjjsq(Device):
-    def __init__(
-        self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-        model: str = MODEL_HUMIDIFIER_MJJSQ,
-    ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
+    """Support for deerma.humidifier.(mj)jsq."""
 
     @command(
         default_output=format_output(
@@ -151,7 +142,9 @@ class AirHumidifierMjjsq(Device):
     def status(self) -> AirHumidifierStatus:
         """Retrieve properties."""
 
-        properties = AVAILABLE_PROPERTIES[self.model]
+        properties = AVAILABLE_PROPERTIES.get(
+            self.model, AVAILABLE_PROPERTIES[MODEL_HUMIDIFIER_MJJSQ]
+        )
         values = self.get_properties(properties, max_properties=1)
 
         return AirHumidifierStatus(defaultdict(lambda: None, zip(properties, values)))

--- a/miio/airpurifier_airdog.py
+++ b/miio/airpurifier_airdog.py
@@ -8,6 +8,7 @@ import click
 from .click_common import EnumType, command, format_output
 from .device import Device, DeviceStatus
 from .exceptions import DeviceException
+from .utils import deprecated
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -100,17 +101,6 @@ class AirDogStatus(DeviceStatus):
 
 
 class AirDogX3(Device):
-    def __init__(
-        self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-        model: str = MODEL_AIRDOG_X3,
-    ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
-
     @command(
         default_output=format_output(
             "",
@@ -126,7 +116,9 @@ class AirDogX3(Device):
     def status(self) -> AirDogStatus:
         """Retrieve properties."""
 
-        properties = AVAILABLE_PROPERTIES[self.model]
+        properties = AVAILABLE_PROPERTIES.get(
+            self.model, AVAILABLE_PROPERTIES[MODEL_AIRDOG_X3]
+        )
         values = self.get_properties(properties, max_properties=10)
 
         return AirDogStatus(defaultdict(lambda: None, zip(properties, values)))
@@ -185,6 +177,7 @@ class AirDogX3(Device):
         return self.send("set_clean")
 
 
+@deprecated("Use AirDogX3(model='airdog.airpurifier.x5')")
 class AirDogX5(AirDogX3):
     def __init__(
         self,
@@ -198,6 +191,7 @@ class AirDogX5(AirDogX3):
         super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
 
 
+@deprecated("Use AirDogX3(model='airdog.airpurifier.x7sm')")
 class AirDogX7SM(AirDogX3):
     def __init__(
         self,

--- a/miio/airpurifier_airdog.py
+++ b/miio/airpurifier_airdog.py
@@ -177,8 +177,8 @@ class AirDogX3(Device):
         return self.send("set_clean")
 
 
-@deprecated("Use AirDogX3(model='airdog.airpurifier.x5')")
 class AirDogX5(AirDogX3):
+    @deprecated("Use AirDogX3(model='airdog.airpurifier.x5')")
     def __init__(
         self,
         ip: str = None,
@@ -191,8 +191,8 @@ class AirDogX5(AirDogX3):
         super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
 
 
-@deprecated("Use AirDogX3(model='airdog.airpurifier.x7sm')")
 class AirDogX7SM(AirDogX3):
+    @deprecated("Use AirDogX3(model='airdog.airpurifier.x7sm')")
     def __init__(
         self,
         ip: str = None,

--- a/miio/airqualitymonitor.py
+++ b/miio/airqualitymonitor.py
@@ -151,22 +151,6 @@ class AirQualityMonitorStatus(DeviceStatus):
 class AirQualityMonitor(Device):
     """Xiaomi PM2.5 Air Quality Monitor."""
 
-    def __init__(
-        self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-        model: str = MODEL_AIRQUALITYMONITOR_V1,
-    ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
-
-        if model not in AVAILABLE_PROPERTIES:
-            _LOGGER.error(
-                "Device model %s unsupported. Falling back to %s.", model, self.model
-            )
-
     @command(
         default_output=format_output(
             "",
@@ -185,7 +169,9 @@ class AirQualityMonitor(Device):
     )
     def status(self) -> AirQualityMonitorStatus:
         """Return device status."""
-        properties = AVAILABLE_PROPERTIES[self.model]
+        properties = AVAILABLE_PROPERTIES.get(
+            self.model, AVAILABLE_PROPERTIES[MODEL_AIRQUALITYMONITOR_V1]
+        )
 
         if self.model == MODEL_AIRQUALITYMONITOR_B1:
             values = self.send("get_air_data")

--- a/miio/fan_leshow.py
+++ b/miio/fan_leshow.py
@@ -93,17 +93,6 @@ class FanLeshowStatus(DeviceStatus):
 class FanLeshow(Device):
     """Main class representing the Xiaomi Rosou SS4 Ventilator."""
 
-    def __init__(
-        self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-        model: str = MODEL_FAN_LESHOW_SS4,
-    ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
-
     @command(
         default_output=format_output(
             "",
@@ -118,7 +107,9 @@ class FanLeshow(Device):
     )
     def status(self) -> FanLeshowStatus:
         """Retrieve properties."""
-        properties = AVAILABLE_PROPERTIES[self.model]
+        properties = AVAILABLE_PROPERTIES.get(
+            self.model, AVAILABLE_PROPERTIES[MODEL_FAN_LESHOW_SS4]
+        )
         values = self.get_properties(properties, max_properties=15)
 
         return FanLeshowStatus(dict(zip(properties, values)))

--- a/miio/g1vacuum.py
+++ b/miio/g1vacuum.py
@@ -275,17 +275,6 @@ class G1Vacuum(MiotDevice):
 
     mapping = MIOT_MAPPING[MIJIA_VACUUM_V2]
 
-    def __init__(
-        self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-        model: str = MIJIA_VACUUM_V2,
-    ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
-
     @command(
         default_output=format_output(
             "",

--- a/miio/g1vacuum.py
+++ b/miio/g1vacuum.py
@@ -284,8 +284,7 @@ class G1Vacuum(MiotDevice):
         lazy_discover: bool = True,
         model: str = MIJIA_VACUUM_V2,
     ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover)
-        self._model = model
+        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
 
     @command(
         default_output=format_output(

--- a/miio/heater.py
+++ b/miio/heater.py
@@ -127,17 +127,6 @@ class HeaterStatus(DeviceStatus):
 class Heater(Device):
     """Main class representing the Smartmi Zhimi Heater."""
 
-    def __init__(
-        self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-        model: str = MODEL_HEATER_ZA1,
-    ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
-
     @command(
         default_output=format_output(
             "",
@@ -153,7 +142,9 @@ class Heater(Device):
     )
     def status(self) -> HeaterStatus:
         """Retrieve properties."""
-        properties = SUPPORTED_MODELS[self.model]["available_properties"]
+        properties = SUPPORTED_MODELS.get(
+            self.model, SUPPORTED_MODELS[MODEL_HEATER_ZA1]
+        )["available_properties"]
 
         # A single request is limited to 16 properties. Therefore the
         # properties are divided into multiple requests
@@ -185,7 +176,9 @@ class Heater(Device):
         """Set target temperature."""
         min_temp: int
         max_temp: int
-        min_temp, max_temp = SUPPORTED_MODELS[self.model]["temperature_range"]
+        min_temp, max_temp = SUPPORTED_MODELS.get(
+            self.model, SUPPORTED_MODELS[MODEL_HEATER_ZA1]
+        )["temperature_range"]
         if not min_temp <= temperature <= max_temp:
             raise HeaterException("Invalid target temperature: %s" % temperature)
 
@@ -233,7 +226,9 @@ class Heater(Device):
         """Set delay off seconds."""
         min_delay: int
         max_delay: int
-        min_delay, max_delay = SUPPORTED_MODELS[self.model]["delay_off_range"]
+        min_delay, max_delay = SUPPORTED_MODELS.get(
+            self.model, SUPPORTED_MODELS[MODEL_HEATER_ZA1]
+        )["delay_off_range"]
         if not min_delay <= seconds <= max_delay:
             raise HeaterException("Invalid delay time: %s" % seconds)
 

--- a/miio/philips_bulb.py
+++ b/miio/philips_bulb.py
@@ -68,17 +68,6 @@ class PhilipsBulbStatus(DeviceStatus):
 class PhilipsWhiteBulb(Device):
     """Main class representing Xiaomi Philips White LED Ball Lamp."""
 
-    def __init__(
-        self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-        model: str = MODEL_PHILIPS_LIGHT_HBULB,
-    ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
-
     @command(
         default_output=format_output(
             "",
@@ -92,7 +81,9 @@ class PhilipsWhiteBulb(Device):
     def status(self) -> PhilipsBulbStatus:
         """Retrieve properties."""
 
-        properties = AVAILABLE_PROPERTIES[self.model]
+        properties = AVAILABLE_PROPERTIES.get(
+            self.model, AVAILABLE_PROPERTIES[MODEL_PHILIPS_LIGHT_HBULB]
+        )
         values = self.get_properties(properties)
 
         return PhilipsBulbStatus(defaultdict(lambda: None, zip(properties, values)))
@@ -134,17 +125,6 @@ class PhilipsWhiteBulb(Device):
 
 
 class PhilipsBulb(PhilipsWhiteBulb):
-    def __init__(
-        self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-        model: str = MODEL_PHILIPS_LIGHT_BULB,
-    ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
-
     @command(
         click.argument("level", type=int),
         default_output=format_output("Setting color temperature to {level}"),

--- a/miio/philips_rwread.py
+++ b/miio/philips_rwread.py
@@ -83,17 +83,6 @@ class PhilipsRwreadStatus(DeviceStatus):
 class PhilipsRwread(Device):
     """Main class representing Xiaomi Philips RW Read."""
 
-    def __init__(
-        self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-        model: str = MODEL_PHILIPS_LIGHT_RWREAD,
-    ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
-
     @command(
         default_output=format_output(
             "",
@@ -108,7 +97,9 @@ class PhilipsRwread(Device):
     )
     def status(self) -> PhilipsRwreadStatus:
         """Retrieve properties."""
-        properties = AVAILABLE_PROPERTIES[self.model]
+        properties = AVAILABLE_PROPERTIES.get(
+            self.model, AVAILABLE_PROPERTIES[MODEL_PHILIPS_LIGHT_RWREAD]
+        )
         values = self.get_properties(properties)
 
         return PhilipsRwreadStatus(defaultdict(lambda: None, zip(properties, values)))

--- a/miio/powerstrip.py
+++ b/miio/powerstrip.py
@@ -138,17 +138,6 @@ class PowerStrip(Device):
 
     _supported_models = [MODEL_POWER_STRIP_V1, MODEL_POWER_STRIP_V2]
 
-    def __init__(
-        self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-        model: str = MODEL_POWER_STRIP_V1,
-    ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
-
     @command(
         default_output=format_output(
             "",
@@ -166,7 +155,9 @@ class PowerStrip(Device):
     )
     def status(self) -> PowerStripStatus:
         """Retrieve properties."""
-        properties = AVAILABLE_PROPERTIES[self.model]
+        properties = AVAILABLE_PROPERTIES.get(
+            self.model, AVAILABLE_PROPERTIES[MODEL_POWER_STRIP_V1]
+        )
         values = self.get_properties(properties)
 
         return PowerStripStatus(defaultdict(lambda: None, zip(properties, values)))

--- a/miio/pwzn_relay.py
+++ b/miio/pwzn_relay.py
@@ -99,22 +99,13 @@ class PwznRelayStatus(DeviceStatus):
 class PwznRelay(Device):
     """Main class representing the PWZN Relay."""
 
-    def __init__(
-        self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-        model: str = MODEL_PWZN_RELAY_APPLE,
-    ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
-
     @command(default_output=format_output("", "on_count: {result.on_count}\n"))
     def status(self) -> PwznRelayStatus:
         """Retrieve properties."""
 
-        properties = AVAILABLE_PROPERTIES[self.model].copy()
+        properties = AVAILABLE_PROPERTIES.get(
+            self.model, AVAILABLE_PROPERTIES[MODEL_PWZN_RELAY_APPLE]
+        ).copy()
         values = self.get_properties(properties)
 
         return PwznRelayStatus(defaultdict(lambda: None, zip(properties, values)))

--- a/miio/toiletlid.py
+++ b/miio/toiletlid.py
@@ -71,17 +71,6 @@ class ToiletlidStatus(DeviceStatus):
 
 
 class Toiletlid(Device):
-    def __init__(
-        self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-        model: str = MODEL_TOILETLID_V1,
-    ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
-
     @command(
         default_output=format_output(
             "",
@@ -95,7 +84,9 @@ class Toiletlid(Device):
     )
     def status(self) -> ToiletlidStatus:
         """Retrieve properties."""
-        properties = AVAILABLE_PROPERTIES[self.model]
+        properties = AVAILABLE_PROPERTIES.get(
+            self.model, AVAILABLE_PROPERTIES[MODEL_TOILETLID_V1]
+        )
         values = self.get_properties(properties)
 
         color = self.get_ambient_light()

--- a/miio/wifispeaker.py
+++ b/miio/wifispeaker.py
@@ -1,6 +1,5 @@
 import enum
 import logging
-import warnings
 
 import click
 
@@ -94,15 +93,6 @@ class WifiSpeakerStatus(DeviceStatus):
 
 class WifiSpeaker(Device):
     """Device class for Xiaomi Smart Wifi Speaker."""
-
-    def __init__(self, *args, **kwargs):
-        warnings.warn(
-            "Please help to complete this by providing more "
-            "information about possible values for `state`, "
-            "`play_mode` and `transport_channel`.",
-            stacklevel=2,
-        )
-        super().__init__(*args, **kwargs)
 
     @command(
         default_output=format_output(


### PR DESCRIPTION
In order to simplify refactoring the constructor parameters in the future, this PR will remove the unnecessary constructors.
This PR also deprecates subclasses that were merely used to expose the parent device using a given model to miiocli, which is no longer necessary thanks to #1038.

* Remove constructors that just called the super class constructor with the model information
* Deprecate subclasses that were previously there to allow miiocli usage when no model parameter passing was possible
* Fixes also https://github.com/syssi/xiaomi_airpurifier/issues/206

The device class requires better handling for model specific properties (esp. for miotdevice which currently uses `self.mapping` which makes it harder to get rid of those extra classes), but that's a task for another PR.