### PR TITLE
Use poetry-core as build-system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,5 +99,5 @@ exclude_lines = [
 ignore = ["devtools/*"]
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Using [poetry-core](https://github.com/python-poetry/poetry-core) allows performing installation without having full poetry setup installed, e.g.:
```
$ pip install .
```
should work now directly.