### PR TITLE
Allow failure to publish on test pypi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,7 @@ jobs:
 
     - name: Publish on test pypi
       uses: pypa/gh-action-pypi-publish@master
+      continue-on-error: true
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
A stop-gap solution to avoid all merges on master to fail just because a testpypi release already exists.

Something like https://github.com/pypa/setuptools_scm should probably used instead, and the real releases should be made on github releases and not on tags..