### PR TITLE
airhumidifer_(mj)jsq: Add use_time for better API compatibility

### DIFF
--- a/miio/airhumidifier_jsq.py
+++ b/miio/airhumidifier_jsq.py
@@ -1,6 +1,6 @@
 import enum
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import click
 
@@ -128,6 +128,14 @@ class AirHumidifierStatus(DeviceStatus):
     def lid_opened(self) -> bool:
         """True if the water tank is detached."""
         return self.data["lid_opened"] == 1
+
+    @property
+    def use_time(self) -> Optional[int]:
+        """How long the device has been active in seconds.
+
+        Not supported by the device, so we return none here.
+        """
+        return None
 
 
 class AirHumidifierJsq(Device):

--- a/miio/airhumidifier_mjjsq.py
+++ b/miio/airhumidifier_mjjsq.py
@@ -120,6 +120,14 @@ class AirHumidifierStatus(DeviceStatus):
 
         return None
 
+    @property
+    def use_time(self) -> Optional[int]:
+        """How long the device has been active in seconds.
+
+        Not supported by the device, so we return none here.
+        """
+        return None
+
 
 class AirHumidifierMjjsq(Device):
     """Support for deerma.humidifier.(mj)jsq."""


### PR DESCRIPTION
Not all humidifiers support `use_time`, this adds the properties to return None on those cases for better API compatibility among devices. The proper fix will be adding base classes to define the minimal common API, but that takes some time. 

Spotted at https://github.com/home-assistant/core/issues/59045