### PR TITLE
roborock: auto empty dustbin support

### DIFF
--- a/docs/device_docs/vacuum.rst
+++ b/docs/device_docs/vacuum.rst
@@ -184,7 +184,7 @@ for original firmwares.
 
 This feature works similarly to the sound updates,
 so passing a local file will create a self-hosting server
-and updating from an URL requires you to pass the md5 hash of the file.  
+and updating from an URL requires you to pass the md5 hash of the file.
 
 ::
 

--- a/miio/integrations/vacuum/roborock/vacuum.py
+++ b/miio/integrations/vacuum/roborock/vacuum.py
@@ -773,7 +773,7 @@ class Vacuum(Device):
 
     @command(click.argument("enabled", required=True, type=bool))
     def set_dust_collection(self, enabled: bool) -> bool:
-        """Turn automatic dust collection on or off"""
+        """Turn automatic dust collection on or off."""
         self._verify_auto_empty_support()
         return (
             self.send("set_dust_collection_switch_status", {"status": int(enabled)})[0]
@@ -784,10 +784,7 @@ class Vacuum(Device):
     def set_dust_collection_mode(self, mode: DustCollectionMode) -> bool:
         """Set dust collection mode setting."""
         self._verify_auto_empty_support()
-        return (
-            self.send("set_dust_collection_mode", {"mode": mode.value})[0]
-            == "ok"
-        )
+        return self.send("set_dust_collection_mode", {"mode": mode.value})[0] == "ok"
 
     @command()
     def start_dust_collection(self):
@@ -803,9 +800,7 @@ class Vacuum(Device):
 
     def _verify_auto_empty_support(self) -> None:
         if self.model not in self._auto_empty_models:
-            raise VacuumException(
-                "Device does not support auto emptying"
-            )
+            raise VacuumException("Device does not support auto emptying")
 
     @command()
     def stop_zoned_clean(self):


### PR DESCRIPTION
addresses #1107

This is just an initial pass at this, probably more needs to be done. Will also look at the home assistant component.

Example CLI run:

```
(miio-runtime) [craigcabrey@alto python-miio]$ python3 miio/cli.py vacuum --ip 192.168.10.222 --token XXXX dust_collection_mode
Running command dust_collection_mode
DustCollectionMode.Smart
```