### PR TITLE
Deprecate roborock specific miio.Vacuum

### DIFF
--- a/miio/__init__.py
+++ b/miio/__init__.py
@@ -43,7 +43,7 @@ from miio.huizuo import Huizuo, HuizuoLampFan, HuizuoLampHeater, HuizuoLampScene
 from miio.integrations.petwaterdispenser import PetWaterDispenser
 from miio.integrations.vacuum.dreame.dreamevacuum_miot import DreameVacuumMiot
 from miio.integrations.vacuum.mijia import G1Vacuum
-from miio.integrations.vacuum.roborock import Vacuum, VacuumException
+from miio.integrations.vacuum.roborock import RoborockVacuum, Vacuum, VacuumException
 from miio.integrations.vacuum.roborock.vacuumcontainers import (
     CleaningDetails,
     CleaningSummary,

--- a/miio/integrations/vacuum/roborock/__init__.py
+++ b/miio/integrations/vacuum/roborock/__init__.py
@@ -1,2 +1,2 @@
 # flake8: noqa
-from .vacuum import Vacuum, VacuumException, VacuumStatus
+from .vacuum import RoborockVacuum, Vacuum, VacuumException, VacuumStatus

--- a/miio/integrations/vacuum/roborock/tests/test_vacuum.py
+++ b/miio/integrations/vacuum/roborock/tests/test_vacuum.py
@@ -4,13 +4,13 @@ from unittest.mock import patch
 
 import pytest
 
-from miio import Vacuum, VacuumStatus
+from miio import RoborockVacuum, Vacuum, VacuumStatus
 from miio.tests.dummies import DummyDevice
 
 from ..vacuum import CarpetCleaningMode, MopMode
 
 
-class DummyVacuum(DummyDevice, Vacuum):
+class DummyVacuum(DummyDevice, RoborockVacuum):
     STATE_CHARGING = 8
     STATE_CLEANING = 5
     STATE_ZONED_CLEAN = 9
@@ -311,3 +311,8 @@ class TestVacuum(TestCase):
 
         with patch.object(self.device, "send", return_value=[32453]):
             assert self.device.mop_mode() is None
+
+
+def test_deprecated_vacuum(caplog):
+    with pytest.deprecated_call():
+        Vacuum("127.1.1.1", "68ffffffffffffffffffffffffffffff")

--- a/miio/integrations/vacuum/roborock/tests/test_vacuum.py
+++ b/miio/integrations/vacuum/roborock/tests/test_vacuum.py
@@ -316,3 +316,6 @@ class TestVacuum(TestCase):
 def test_deprecated_vacuum(caplog):
     with pytest.deprecated_call():
         Vacuum("127.1.1.1", "68ffffffffffffffffffffffffffffff")
+
+    with pytest.deprecated_call():
+        from miio.vacuum import ROCKROBO_S6  # noqa: F401

--- a/miio/integrations/vacuum/roborock/vacuum.py
+++ b/miio/integrations/vacuum/roborock/vacuum.py
@@ -22,6 +22,7 @@ from miio.click_common import (
 )
 from miio.device import Device, DeviceInfo
 from miio.exceptions import DeviceException, DeviceInfoUnavailableException
+from miio.utils import deprecated
 
 from .vacuumcontainers import (
     CarpetModeStatus,
@@ -140,8 +141,8 @@ SUPPORTED_MODELS = [
 ]
 
 
-class Vacuum(Device):
-    """Main class representing the vacuum."""
+class RoborockVacuum(Device):
+    """Main class for roborock vacuums (roborock.vacuum.*)."""
 
     _supported_models = SUPPORTED_MODELS
 
@@ -886,3 +887,13 @@ class Vacuum(Device):
                 json.dump(seqs, f)
 
         return dg
+
+
+class Vacuum(RoborockVacuum):
+    """Main class for roborock vacuums."""
+
+    @deprecated(
+        "This class will become the base class for all vacuum implementations. Use RoborockVacuum to control roborock vacuums."
+    )
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)

--- a/miio/integrations/vacuum/roborock/vacuum_tui.py
+++ b/miio/integrations/vacuum/roborock/vacuum_tui.py
@@ -8,7 +8,7 @@ except ImportError:
 import enum
 from typing import Tuple
 
-from .vacuum import Vacuum
+from .vacuum import RoborockVacuum as Vacuum
 
 
 class Control(enum.Enum):

--- a/miio/vacuum.py
+++ b/miio/vacuum.py
@@ -1,0 +1,10 @@
+"""This file is just for compat reasons and prints out a deprecated warning when
+executed."""
+import warnings
+
+from .integrations.vacuum.roborock.vacuum import *  # noqa: F403,F401
+
+warnings.warn(
+    "miio.vacuum module has been renamed to miio.integrations.vacuum.roborock.vacuum",
+    DeprecationWarning,
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ packages = [
 keywords = ["xiaomi", "miio", "miot", "smart home"]
 
 [tool.poetry.scripts]
-mirobo = "miio.integrations.roborock.vacuum_cli:cli"
+mirobo = "miio.integrations.vacuum.roborock.vacuum_cli:cli"
 miio-extract-tokens = "miio.extract_tokens:main"
 miiocli = "miio.cli:create_cli"
 


### PR DESCRIPTION
In order to make `Vacuum` as a usable base class for all vacuum implementations in the future, let's inform potential downstream users to convert their code to use the roborockvacuum class:
* Initializing `miio.Vacuum()` instructs now to use the `RoborockVacuum`
* `miio.vacuum` exposes the roborockvacuum internals while giving a deprecation warning

This should not break any existing code but marking it as such anyway to give it more visibility in the changelog.
