### PR TITLE
gateway: remove click support for gateway devices

### DIFF
--- a/miio/gateway/alarm.py
+++ b/miio/gateway/alarm.py
@@ -2,77 +2,62 @@
 
 from datetime import datetime
 
-import click
-
-from ..click_common import command, format_output
 from .gatewaydevice import GatewayDevice
 
 
 class Alarm(GatewayDevice):
     """Class representing the Xiaomi Gateway Alarm."""
 
-    @command(default_output=format_output("[alarm_status]"))
     def status(self) -> str:
         """Return the alarm status from the device."""
         # Response: 'on', 'off', 'oning'
         return self._gateway.send("get_arming").pop()
 
-    @command(default_output=format_output("Turning alarm on"))
     def on(self):
         """Turn alarm on."""
         return self._gateway.send("set_arming", ["on"])
 
-    @command(default_output=format_output("Turning alarm off"))
     def off(self):
         """Turn alarm off."""
         return self._gateway.send("set_arming", ["off"])
 
-    @command()
     def arming_time(self) -> int:
         """Return time in seconds the alarm stays 'oning' before transitioning to
         'on'."""
         # Response: 5, 15, 30, 60
         return self._gateway.send("get_arm_wait_time").pop()
 
-    @command(click.argument("seconds"))
     def set_arming_time(self, seconds):
         """Set time the alarm stays at 'oning' before transitioning to 'on'."""
         return self._gateway.send("set_arm_wait_time", [seconds])
 
-    @command()
     def triggering_time(self) -> int:
         """Return the time in seconds the alarm is going off when triggered."""
         # Response: 30, 60, etc.
         return self._gateway.get_prop("alarm_time_len").pop()
 
-    @command(click.argument("seconds"))
     def set_triggering_time(self, seconds):
         """Set the time in seconds the alarm is going off when triggered."""
         return self._gateway.set_prop("alarm_time_len", seconds)
 
-    @command()
     def triggering_light(self) -> int:
         """Return the time the gateway light blinks when the alarm is triggerd."""
         # Response: 0=do not blink, 1=always blink, x>1=blink for x seconds
         return self._gateway.get_prop("en_alarm_light").pop()
 
-    @command(click.argument("seconds"))
     def set_triggering_light(self, seconds):
         """Set the time the gateway light blinks when the alarm is triggerd."""
         # values: 0=do not blink, 1=always blink, x>1=blink for x seconds
         return self._gateway.set_prop("en_alarm_light", seconds)
 
-    @command()
     def triggering_volume(self) -> int:
         """Return the volume level at which alarms go off [0-100]."""
         return self._gateway.send("get_alarming_volume").pop()
 
-    @command(click.argument("volume"))
     def set_triggering_volume(self, volume):
         """Set the volume level at which alarms go off [0-100]."""
         return self._gateway.send("set_alarming_volume", [volume])
 
-    @command()
     def last_status_change_time(self) -> datetime:
         """Return the last time the alarm changed status."""
         return datetime.fromtimestamp(self._gateway.send("get_arming_time").pop())

--- a/miio/gateway/gatewaydevice.py
+++ b/miio/gateway/gatewaydevice.py
@@ -32,4 +32,5 @@ class GatewayDevice(Device):
             )
 
         self._gateway = parent
-        super().__init__(ip, token, start_id, debug, lazy_discover)
+        self.ip = self._gateway.ip
+        self.token = self._gateway.token

--- a/miio/gateway/gatewaydevice.py
+++ b/miio/gateway/gatewaydevice.py
@@ -3,7 +3,6 @@
 import logging
 from typing import TYPE_CHECKING
 
-from ..device import Device
 from ..exceptions import DeviceException
 
 _LOGGER = logging.getLogger(__name__)
@@ -13,17 +12,12 @@ if TYPE_CHECKING:
     from .gateway import Gateway
 
 
-class GatewayDevice(Device):
+class GatewayDevice:
     """GatewayDevice class Specifies the init method for all gateway device
     functionalities."""
 
     def __init__(
         self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
         parent: "Gateway" = None,
     ) -> None:
         if parent is None:
@@ -32,5 +26,3 @@ class GatewayDevice(Device):
             )
 
         self._gateway = parent
-        self.ip = self._gateway.ip
-        self.token = self._gateway.token

--- a/miio/gateway/light.py
+++ b/miio/gateway/light.py
@@ -2,9 +2,6 @@
 
 from typing import Tuple
 
-import click
-
-from ..click_common import command
 from ..utils import brightness_and_color_to_int, int_to_brightness, int_to_rgb
 from .gatewaydevice import GatewayDevice
 
@@ -31,7 +28,6 @@ class Light(GatewayDevice):
     the state of the 'rgb' light.
     """
 
-    @command()
     def rgb_status(self):
         """Get current status of the light. Always represents the current status of the
         light as opposed to 'night_light_status'.
@@ -47,7 +43,6 @@ class Light(GatewayDevice):
 
         return {"is_on": is_on, "brightness": brightness, "rgb": rgb}
 
-    @command()
     def night_light_status(self):
         """Get status of the night light. This command only gives the correct status of
         the LEDs if the last command was a 'night_light' command and not a 'rgb' light
@@ -63,27 +58,18 @@ class Light(GatewayDevice):
 
         return {"is_on": is_on, "brightness": brightness, "rgb": rgb}
 
-    @command(
-        click.argument("brightness", type=int),
-        click.argument("rgb", type=(int, int, int)),
-    )
     def set_rgb(self, brightness: int, rgb: Tuple[int, int, int]):
         """Set gateway light using brightness and rgb tuple."""
         brightness_and_color = brightness_and_color_to_int(brightness, rgb)
 
         return self._gateway.send("set_rgb", [brightness_and_color])
 
-    @command(
-        click.argument("brightness", type=int),
-        click.argument("rgb", type=(int, int, int)),
-    )
     def set_night_light(self, brightness: int, rgb: Tuple[int, int, int]):
         """Set gateway night light using brightness and rgb tuple."""
         brightness_and_color = brightness_and_color_to_int(brightness, rgb)
 
         return self._gateway.send("set_night_light_rgb", [brightness_and_color])
 
-    @command(click.argument("brightness", type=int))
     def set_rgb_brightness(self, brightness: int):
         """Set gateway light brightness (0-100)."""
         if 100 < brightness < 0:
@@ -92,7 +78,6 @@ class Light(GatewayDevice):
 
         return self.set_rgb(brightness, current_color)
 
-    @command(click.argument("brightness", type=int))
     def set_night_light_brightness(self, brightness: int):
         """Set night light brightness (0-100)."""
         if 100 < brightness < 0:
@@ -101,7 +86,6 @@ class Light(GatewayDevice):
 
         return self.set_night_light(brightness, current_color)
 
-    @command(click.argument("color_name", type=str))
     def set_rgb_color(self, color_name: str):
         """Set gateway light color using color name ('color_map' variable in the source
         holds the valid values)."""
@@ -115,7 +99,6 @@ class Light(GatewayDevice):
 
         return self.set_rgb(current_brightness, color_map[color_name])
 
-    @command(click.argument("color_name", type=str))
     def set_night_light_color(self, color_name: str):
         """Set night light color using color name ('color_map' variable in the source
         holds the valid values)."""
@@ -129,10 +112,6 @@ class Light(GatewayDevice):
 
         return self.set_night_light(current_brightness, color_map[color_name])
 
-    @command(
-        click.argument("color_name", type=str),
-        click.argument("brightness", type=int),
-    )
     def set_rgb_using_name(self, color_name: str, brightness: int):
         """Set gateway light color (using color name, 'color_map' variable in the source
         holds the valid values) and brightness (0-100)."""
@@ -147,10 +126,6 @@ class Light(GatewayDevice):
 
         return self.set_rgb(brightness, color_map[color_name])
 
-    @command(
-        click.argument("color_name", type=str),
-        click.argument("brightness", type=int),
-    )
     def set_night_light_using_name(self, color_name: str, brightness: int):
         """Set night light color (using color name, 'color_map' variable in the source
         holds the valid values) and brightness (0-100)."""

--- a/miio/gateway/radio.py
+++ b/miio/gateway/radio.py
@@ -2,19 +2,16 @@
 
 import click
 
-from ..click_common import command
 from .gatewaydevice import GatewayDevice
 
 
 class Radio(GatewayDevice):
     """Radio controls for the gateway."""
 
-    @command()
     def get_radio_info(self):
         """Radio play info."""
         return self._gateway.send("get_prop_fm")
 
-    @command(click.argument("volume"))
     def set_radio_volume(self, volume):
         """Set radio volume."""
         return self._gateway.send("set_fm_volume", [volume])
@@ -68,7 +65,6 @@ class Radio(GatewayDevice):
         raise NotImplementedError()
         return self._gateway.send("get_default_music")
 
-    @command()
     def get_music_info(self):
         """Unknown."""
         info = self._gateway.send("get_music_info")
@@ -76,7 +72,6 @@ class Radio(GatewayDevice):
         free_space = self._gateway.send("get_music_free_space")
         click.echo("free space: %s" % free_space)
 
-    @command()
     def get_mute(self):
         """mute of what?"""
         return self._gateway.send("get_mute")
@@ -102,7 +97,6 @@ class Radio(GatewayDevice):
         raise NotImplementedError()
         return self._gateway.send("get_download_progress")
 
-    @command()
     def set_sound_playing(self):
         """stop playing?"""
         return self._gateway.send("set_sound_playing", ["off"])

--- a/miio/gateway/zigbee.py
+++ b/miio/gateway/zigbee.py
@@ -1,30 +1,23 @@
 """Xiaomi Gateway Zigbee control implementation."""
 
-import click
-
-from ..click_common import command
 from .gatewaydevice import GatewayDevice
 
 
 class Zigbee(GatewayDevice):
     """Zigbee controls."""
 
-    @command()
     def get_zigbee_version(self):
         """timeouts on device."""
         return self._gateway.send("get_zigbee_device_version")
 
-    @command()
     def get_zigbee_channel(self):
         """Return currently used zigbee channel."""
         return self._gateway.send("get_zigbee_channel")[0]
 
-    @command(click.argument("channel"))
     def set_zigbee_channel(self, channel):
         """Set zigbee channel."""
         return self._gateway.send("set_zigbee_channel", [channel])
 
-    @command(click.argument("timeout", type=int))
     def zigbee_pair(self, timeout):
         """Start pairing, use 0 to disable."""
         return self._gateway.send("start_zigbee_join", [timeout])
@@ -52,7 +45,6 @@ class Zigbee(GatewayDevice):
         raise NotImplementedError()
         return self._gateway.send("write_zigbee_attribute")
 
-    @command()
     def zigbee_unpair_all(self):
         """Unpair all devices."""
         return self._gateway.send("remove_all_device")


### PR DESCRIPTION
see https://github.com/home-assistant/core/issues/61234#issuecomment-991856052
the new python-miio release broke the alarm and light entity of the gateway

(by rytilahti: the click support was never working for these "subdevices" as they require to be initialized with the gateway instance. this fixes the issue by avoiding calling `info()`/accessing `model` – which is done automatically since #1038 – on a device instance that has no host nor token.)