### PR TITLE
gateway: use main device model for subdevices

### DIFF
--- a/miio/gateway/gatewaydevice.py
+++ b/miio/gateway/gatewaydevice.py
@@ -33,5 +33,7 @@ class GatewayDevice(Device):
                 "This should never be initialized without gateway object."
             )
 
+        self._info = parent.info()
+        self._model = parent.model
         self._gateway = parent
         super().__init__(ip, token, start_id, debug, lazy_discover)


### PR DESCRIPTION
This fixes the issue where invoking a method on gateway subdevice causes model discovery,
which fails as the subdevices do not have a host by themselves.

Related to downstream report https://github.com/home-assistant/core/issues/61234 . Replaces #1229 