### PR TITLE
Fix Roborock S7 fan speed

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ Contributing
 ------------
 
 We welcome all sorts of contributions from patches to add improvements or fixing bugs to improving the documentation.
-To ease the process of setting up a development environment we have prepared `a short guide <https://python-miio.readthedocs.io/en/latest/new_devices.html>`__ for getting you started.
+To ease the process of setting up a development environment we have prepared `a short guide <https://python-miio.readthedocs.io/en/latest/contributing.html>`__ for getting you started.
 
 
 Supported devices

--- a/miio/integrations/vacuum/roborock/vacuum.py
+++ b/miio/integrations/vacuum/roborock/vacuum.py
@@ -608,7 +608,7 @@ class RoborockVacuum(Device):
         elif self.model == ROCKROBO_E2:
             fanspeeds = FanspeedE2
         elif self.model == ROCKROBO_S7:
-            self._fanspeeds = FanspeedS7
+            fanspeeds = FanspeedS7
         else:
             fanspeeds = FanspeedV2
 


### PR DESCRIPTION
Small fix to return fan speeds for the Roborock S7. Also updated a broken link in the read me. Tested with latest Home Assistant 2021.12.0 and confirmed it resolved the issue of fan speeds not being displayed correctly.