### PR TITLE
Add S7 mop scrub intensity

### DIFF
--- a/miio/integrations/vacuum/roborock/tests/test_vacuum.py
+++ b/miio/integrations/vacuum/roborock/tests/test_vacuum.py
@@ -318,12 +318,12 @@ class TestVacuum(TestCase):
         with patch.object(self.device, "send", return_value=[32453]):
             assert self.device.mop_mode() is None
 
-    def test_mop_intensity(self):
+    def test_mop_intensity_model_check(self):
         """Test Roborock S7 check when getting mop intensity."""
         with pytest.raises(VacuumException):
             self.device.mop_intensity()
 
-    def test_set_mop_intensity(self):
+    def test_set_mop_intensity_model_check(self):
         """Test Roborock S7 check when setting mop intensity."""
         with pytest.raises(VacuumException):
             self.device.set_mop_intensity(MopIntensity.Intense)
@@ -349,7 +349,7 @@ def dummyvacuums7(request):
 
 @pytest.mark.usefixtures("dummyvacuums7")
 class TestVacuumS7(TestCase):
-    def test_get_mop_intensity(self):
+    def test_mop_intensity(self):
         """Test getting mop intensity."""
         with patch.object(self.device, "send", return_value=[203]) as mock_method:
             assert self.device.mop_intensity()

--- a/miio/integrations/vacuum/roborock/tests/test_vacuum.py
+++ b/miio/integrations/vacuum/roborock/tests/test_vacuum.py
@@ -7,7 +7,7 @@ import pytest
 from miio import RoborockVacuum, Vacuum, VacuumStatus
 from miio.tests.dummies import DummyDevice
 
-from ..vacuum import CarpetCleaningMode, MopMode
+from ..vacuum import CarpetCleaningMode, MopIntensity, MopMode, VacuumException
 
 
 class DummyVacuum(DummyDevice, RoborockVacuum):
@@ -311,6 +311,16 @@ class TestVacuum(TestCase):
 
         with patch.object(self.device, "send", return_value=[32453]):
             assert self.device.mop_mode() is None
+
+    def test_mop_intensity(self):
+        """Test getting mop intensity."""
+        with pytest.raises(VacuumException):
+            self.device.mop_intensity()
+
+    def test_set_mop_intensity(self):
+        """Test setting mop intensity."""
+        with pytest.raises(VacuumException):
+            self.device.set_mop_intensity(MopIntensity.Intense)
 
 
 def test_deprecated_vacuum(caplog):

--- a/miio/integrations/vacuum/roborock/vacuum.py
+++ b/miio/integrations/vacuum/roborock/vacuum.py
@@ -847,11 +847,17 @@ class RoborockVacuum(Device):
     @command()
     def mop_intensity(self) -> MopIntensity:
         """Get mop scrub intensity setting."""
+        if self.model != ROCKROBO_S7:
+            raise VacuumException("Mop scrub intensity not supported by %s", self.model)
+
         return MopIntensity(self.send("get_water_box_custom_mode")[0])
 
     @command(click.argument("mop_intensity", type=EnumType(MopIntensity)))
     def set_mop_intensity(self, mop_intensity: MopIntensity):
         """Set mop scrub intensity setting."""
+        if self.model != ROCKROBO_S7:
+            raise VacuumException("Mop scrub intensity not supported by %s", self.model)
+
         return self.send("set_water_box_custom_mode", [mop_intensity.value])
 
     @command()

--- a/miio/integrations/vacuum/roborock/vacuum.py
+++ b/miio/integrations/vacuum/roborock/vacuum.py
@@ -114,6 +114,15 @@ class MopMode(enum.Enum):
     Deep = 301
 
 
+class MopIntensity(enum.Enum):
+    """Mop scrub intensity on S7."""
+
+    Close = 200
+    Mild = 201
+    Moderate = 202
+    Intense = 203
+
+
 class CarpetCleaningMode(enum.Enum):
     """Type of carpet cleaning/avoidance."""
 
@@ -834,6 +843,16 @@ class RoborockVacuum(Device):
     def set_mop_mode(self, mop_mode: MopMode):
         """Set mop mode setting."""
         return self.send("set_mop_mode", [mop_mode.value])[0] == "ok"
+
+    @command()
+    def mop_intensity(self) -> MopIntensity:
+        """Get mop scrub intensity setting."""
+        return MopIntensity(self.send("get_water_box_custom_mode")[0])
+
+    @command(click.argument("mop_intensity", type=EnumType(MopIntensity)))
+    def set_mop_intensity(self, mop_intensity: MopIntensity):
+        """Set mop scrub intensity setting."""
+        return self.send("set_water_box_custom_mode", [mop_intensity.value])
 
     @command()
     def child_lock(self) -> bool:


### PR DESCRIPTION
The Roborock S7 has the option to control the scrub intensity with four different settings:

- Close (raised position)
- Mild
- Moderate
- Intense

The way to control these settings is actually identical to the current waterflow code using `self.send("get_water_box_custom_mode")` and `self.send("set_water_box_custom_mode")`. My initial thought was to just add a new `MopIntensity` class since the names of the settings are different and add a case to the existing `waterflow` and `set_waterflow` methods, so if it's an S7 it uses the new `MopIntensity`. However, the method names don't really make sense (which I'm assuming we don't want to change to prevent breaking apps relying on this library) so my thought is the better option is just to duplicate the methods with a new name.

Addresses #1215 