### PR TITLE
Add more supported devices to their corresponding classes

### DIFF
--- a/miio/airhumidifier_miot.py
+++ b/miio/airhumidifier_miot.py
@@ -248,7 +248,7 @@ class AirHumidifierMiotStatus(DeviceStatus):
         return self.data["clean_mode"]
 
 
-SMARTMI_EVAPORATIVE_HUMIDIFIER_2 = "zhimi.humidfier.ca4"
+SMARTMI_EVAPORATIVE_HUMIDIFIER_2 = "zhimi.humidifier.ca4"
 
 SUPPORTED_MODELS = [SMARTMI_EVAPORATIVE_HUMIDIFIER_2]
 

--- a/miio/airpurifier.py
+++ b/miio/airpurifier.py
@@ -14,11 +14,20 @@ _LOGGER = logging.getLogger(__name__)
 
 
 SUPPORTED_MODELS = [
+    "zhimi.airpurifier.v1",
+    "zhimi.airpurifier.v2",
     "zhimi.airpurifier.v3",
+    "zhimi.airpurifier.v5",
     "zhimi.airpurifier.v6",
     "zhimi.airpurifier.v7",
     "zhimi.airpurifier.m1",
     "zhimi.airpurifier.m2",
+    "zhimi.airpurifier.ma1",
+    "zhimi.airpurifier.ma2",
+    "zhimi.airpurifier.sa1",
+    "zhimi.airpurifier.sa2",
+    "zhimi.airpurifier.mc1",
+    "zhimi.airpurifier.mc2",
 ]
 
 

--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -9,6 +9,12 @@ from .click_common import EnumType, command, format_output
 from .exceptions import DeviceException
 from .miot_device import DeviceStatus, MiotDevice
 
+SUPPORTED_MODELS = [
+    "zhimi.airpurifier.ma4",  # airpurifier 3
+    "zhimi.airpurifier.mb3",  # airpurifier 3h
+    "zhimi.airpurifier.va1",  # airpurifier proh
+]
+
 _LOGGER = logging.getLogger(__name__)
 _MAPPING = {
     # Air Purifier (siid=2)
@@ -364,6 +370,7 @@ class AirPurifierMiot(BasicAirPurifierMiot):
     """Main class representing the air purifier which uses MIoT protocol."""
 
     mapping = _MAPPING
+    _supported_models = SUPPORTED_MODELS
 
     @command(
         default_output=format_output(
@@ -460,6 +467,7 @@ class AirPurifierMB4(BasicAirPurifierMiot):
     """Main class representing the air purifier which uses MIoT protocol."""
 
     mapping = _MODEL_AIRPURIFIER_MB4
+    _supported_models = ["zhimi.airpurifier.mb4"]  # airpurifier 3c
 
     @command(
         default_output=format_output(

--- a/miio/integrations/vacuum/roborock/vacuum.py
+++ b/miio/integrations/vacuum/roborock/vacuum.py
@@ -133,6 +133,7 @@ ROCKROBO_T7S = "roborock.vacuum.a14"
 ROCKROBO_S7 = "roborock.vacuum.a15"
 ROCKROBO_S6_MAXV = "roborock.vacuum.a10"
 ROCKROBO_E2 = "roborock.vacuum.e2"
+ROCKROBO_1S = "roborock.vacuum.m1s"
 
 SUPPORTED_MODELS = [
     ROCKROBO_V1,
@@ -146,6 +147,7 @@ SUPPORTED_MODELS = [
     ROCKROBO_S7,
     ROCKROBO_S6_MAXV,
     ROCKROBO_E2,
+    ROCKROBO_1S,
 ]
 
 

--- a/miio/integrations/vacuum/viomi/viomivacuum.py
+++ b/miio/integrations/vacuum/viomi/viomivacuum.py
@@ -62,7 +62,7 @@ from miio.utils import pretty_seconds
 
 _LOGGER = logging.getLogger(__name__)
 
-SUPPORTED_MODELS = ["viomi.vacuum.v7"]
+SUPPORTED_MODELS = ["viomi.vacuum.v7", "viomi.vacuum.v8"]
 
 ERROR_CODES = {
     0: "Sleeping and not charging",

--- a/miio/philips_bulb.py
+++ b/miio/philips_bulb.py
@@ -91,7 +91,7 @@ class PhilipsWhiteBulb(Device):
         """Retrieve properties."""
 
         properties = AVAILABLE_PROPERTIES.get(
-            self.model, AVAILABLE_PROPERTIES[MODEL_PHILIPS_LIGHT_HBULB]
+            self.model, AVAILABLE_PROPERTIES[MODEL_PHILIPS_LIGHT_BULB]
         )
         values = self.get_properties(properties)
 

--- a/miio/philips_bulb.py
+++ b/miio/philips_bulb.py
@@ -13,6 +13,8 @@ _LOGGER = logging.getLogger(__name__)
 MODEL_PHILIPS_LIGHT_BULB = "philips.light.bulb"
 MODEL_PHILIPS_LIGHT_HBULB = "philips.light.hbulb"
 MODEL_PHILIPS_ZHIRUI_DOWNLIGHT = "philips.light.downlight"
+MODEL_PHILIPS_CANDLE = "philips.light.candle"
+MODEL_PHILIPS_CANDLE2 = "philips.light.candle2"
 
 AVAILABLE_PROPERTIES_COMMON = ["power", "dv"]
 AVAILABLE_PROPERTIES_COLORTEMP = AVAILABLE_PROPERTIES_COMMON + ["bright", "cct", "snm"]
@@ -21,6 +23,8 @@ AVAILABLE_PROPERTIES = {
     MODEL_PHILIPS_LIGHT_HBULB: AVAILABLE_PROPERTIES_COMMON + ["bri"],
     MODEL_PHILIPS_LIGHT_BULB: AVAILABLE_PROPERTIES_COLORTEMP,
     MODEL_PHILIPS_ZHIRUI_DOWNLIGHT: AVAILABLE_PROPERTIES_COLORTEMP,
+    MODEL_PHILIPS_CANDLE: AVAILABLE_PROPERTIES_COLORTEMP,
+    MODEL_PHILIPS_CANDLE2: AVAILABLE_PROPERTIES_COLORTEMP,
 }
 
 
@@ -71,7 +75,7 @@ class PhilipsBulbStatus(DeviceStatus):
 class PhilipsWhiteBulb(Device):
     """Main class representing Xiaomi Philips White LED Ball Lamp."""
 
-    _supported_models = list(AVAILABLE_PROPERTIES.keys())
+    _supported_models = [MODEL_PHILIPS_LIGHT_HBULB]
 
     @command(
         default_output=format_output(
@@ -130,8 +134,9 @@ class PhilipsWhiteBulb(Device):
 
 
 class PhilipsBulb(PhilipsWhiteBulb):
+    """Support for philips bulbs that support color temperature and scenes."""
 
-    _supported_models = [MODEL_PHILIPS_ZHIRUI_DOWNLIGHT]
+    _supported_models = list(AVAILABLE_PROPERTIES.keys())
 
     @command(
         click.argument("level", type=int),


### PR DESCRIPTION
This is based on issue reports & on homeassistant's manually constructed list of models.

I leave this PR open for a while as more models are likely to be reported in the upcoming days.

This also changes the default properties to be requested for philips_bulb to have the color temperature, as only a single model is currently known to use different, white-only properties. @syssi do you have any philips bulbs and could you give a test if this fixes https://github.com/home-assistant/core/issues/61523 for good?

Fixes #1227 fixes #1234 fixes #1231 fixes #1241 fixes #1237 fixes #1239