### PR TITLE
yeelight: use and expose the color temp range from specs

### DIFF
--- a/miio/integrations/yeelight/__init__.py
+++ b/miio/integrations/yeelight/__init__.py
@@ -363,7 +363,9 @@ class Yeelight(Device):
     )
     def set_color_temp(self, level, transition=500):
         """Set color temp in kelvin."""
-        color_temp = self._model_info.lamps[YeelightSubLightType.Main].color_temp #for now only main light support
+        color_temp = self._model_info.lamps[
+            YeelightSubLightType.Main
+        ].color_temp  # for now only main light support
         if level > color_temp.max or level < color_temp.min:
             raise YeelightException("Invalid color temperature: %s" % level)
         if transition > 0:

--- a/miio/integrations/yeelight/__init__.py
+++ b/miio/integrations/yeelight/__init__.py
@@ -265,7 +265,6 @@ class Yeelight(Device):
         debug: int = 0,
         lazy_discover: bool = True,
         model: str = None,
-        light_type: YeelightSubLightType = YeelightSubLightType.Main,  # for now only Main support this is for future PR.
     ) -> None:
         super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
         if Yeelight._spec_helper is None:
@@ -273,7 +272,7 @@ class Yeelight(Device):
             Yeelight._supported_models = Yeelight._spec_helper.supported_models
 
         self._model_info = Yeelight._spec_helper.get_model_info(self.model)
-        self._light_type = light_type
+        self._light_type = YeelightSubLightType.Main
         self._light_info = self._model_info.lamps[self._light_type]
         self._color_temp_range = self._light_info.color_temp
 

--- a/miio/integrations/yeelight/__init__.py
+++ b/miio/integrations/yeelight/__init__.py
@@ -363,7 +363,8 @@ class Yeelight(Device):
     )
     def set_color_temp(self, level, transition=500):
         """Set color temp in kelvin."""
-        if level > 6500 or level < 1700:
+        color_temp = self._model_info.lamps[YeelightSubLightType.Main].color_temp #for now only main light support
+        if level > color_temp.max or level < color_temp.min:
             raise YeelightException("Invalid color temperature: %s" % level)
         if transition > 0:
             return self.send("set_ct_abx", [level, "smooth", transition])

--- a/miio/integrations/yeelight/specs.yaml
+++ b/miio/integrations/yeelight/specs.yaml
@@ -80,7 +80,7 @@ yeelink.light.ceiling20:
     supports_color: True
 yeelink.light.ceiling22:
   night_light: True
-  color_temp: [2700, 6500]
+  color_temp: [2600, 6100]
   supports_color: False
 yeelink.light.ceiling24:
   night_light: True
@@ -159,7 +159,7 @@ yeelink.light.strip1:
   supports_color: True
 yeelink.light.strip2:
   night_light: False
-  color_temp: [2700, 6500]
+  color_temp: [1700, 6500]
   supports_color: True
 yeelink.light.strip4:
   night_light: False

--- a/miio/integrations/yeelight/tests/test_yeelight.py
+++ b/miio/integrations/yeelight/tests/test_yeelight.py
@@ -2,7 +2,10 @@ from unittest import TestCase
 
 import pytest
 
-from miio.integrations.yeelight.spec_helper import YeelightSpecHelper
+from miio.integrations.yeelight.spec_helper import (
+    YeelightSpecHelper,
+    YeelightSubLightType,
+)
 from miio.tests.dummies import DummyDevice
 
 from .. import Yeelight, YeelightException, YeelightMode, YeelightStatus
@@ -31,6 +34,9 @@ class DummyLight(DummyDevice, Yeelight):
             Yeelight._supported_models = Yeelight._spec_helper.supported_models
 
         self._model_info = Yeelight._spec_helper.get_model_info(self.model)
+        self._light_type = YeelightSubLightType.Main
+        self._light_info = self._model_info.lamps[self._light_type]
+        self._color_temp_range = self._light_info.color_temp
 
     def set_config(self, x):
         key, value = x

--- a/miio/integrations/yeelight/tests/test_yeelight.py
+++ b/miio/integrations/yeelight/tests/test_yeelight.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 
 import pytest
 
+from miio.integrations.yeelight.spec_helper import YeelightSpecHelper
 from miio.tests.dummies import DummyDevice
 
 from .. import Yeelight, YeelightException, YeelightMode, YeelightStatus
@@ -25,6 +26,11 @@ class DummyLight(DummyDevice, Yeelight):
         }
 
         super().__init__(*args, **kwargs)
+        if Yeelight._spec_helper is None:
+            Yeelight._spec_helper = YeelightSpecHelper()
+            Yeelight._supported_models = Yeelight._spec_helper.supported_models
+
+        self._model_info = Yeelight._spec_helper.get_model_info(self.model)
 
     def set_config(self, x):
         key, value = x


### PR DESCRIPTION
This PR is next stage to integrate spec file. For more information look to https://github.com/rytilahti/python-miio/pull/1094 

@rytilahti I decided that it would be easier to go function by function and at the end try to add support for background lighting. It's slower, but honestly I don't see any other way to move at least somehow. 

Also fix the incorrect parameters while testing on my device.  