### PR TITLE
Add yeelink.bhf_light.v2 and yeelink.light.lamp22 support

### DIFF
--- a/miio/integrations/yeelight/specs.yaml
+++ b/miio/integrations/yeelight/specs.yaml
@@ -165,3 +165,11 @@ yeelink.light.strip4:
   night_light: False
   color_temp: [2700, 6500]
   supports_color: True
+yeelink.bhf_light.v2:
+  night_light: False
+  supports_color: False
+yeelink.light.lamp22:
+  night_light: False
+  color_temp: [2700,6500]
+  supports_color: True
+

--- a/miio/integrations/yeelight/specs.yaml
+++ b/miio/integrations/yeelight/specs.yaml
@@ -167,9 +167,10 @@ yeelink.light.strip4:
   supports_color: True
 yeelink.bhf_light.v2:
   night_light: False
+  color_temp: [0, 0]
   supports_color: False
 yeelink.light.lamp22:
   night_light: False
-  color_temp: [2700,6500]
+  color_temp: [2700, 6500]
   supports_color: True
 


### PR DESCRIPTION
Hi, I have these two devices but not list in specs.yaml. 
`yeelink.bhf_light.v2` do not have `color_temp` feature, I'm not sure if deleting this line is ok.