### PR TITLE
Add more supported models based on discovery.py's mdns records

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -90,10 +90,12 @@ Development checklist
    or :class:`miio.miot_device.MiotDevice` (for MiOT) (:ref:`Minimal example`).
 2. All commands and their arguments should be decorated with `@command` decorator,
    which will make them accessible to `miiocli` (:ref:`miiocli`).
-3. Status containers is derived from `DeviceStatus` class and all properties should
+3. All implementations must define :ref:`Device._supported_models` variable in the class
+   listing the known models (as reported by `info()`).
+4. Status containers is derived from `DeviceStatus` class and all properties should
    have type annotations for their return values.
-4. Creating tests (:ref:`adding_tests`).
-5. Updating documentation is generally not needed as the API documentation
+5. Creating tests (:ref:`adding_tests`).
+6. Updating documentation is generally not needed as the API documentation
    will be generated automatically.
 
 

--- a/miio/airconditioner_miot.py
+++ b/miio/airconditioner_miot.py
@@ -10,6 +10,14 @@ from .exceptions import DeviceException
 from .miot_device import DeviceStatus, MiotDevice
 
 _LOGGER = logging.getLogger(__name__)
+
+SUPPORTED_MODELS = [
+    "xiaomi.aircondition.mc1",
+    "xiaomi.aircondition.mc2",
+    "xiaomi.aircondition.mc4",
+    "xiaomi.aircondition.mc5",
+]
+
 _MAPPING = {
     # Source http://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:air-conditioner:0000A004:xiaomi-mc4:1
     # Air Conditioner (siid=2)
@@ -273,6 +281,7 @@ class AirConditionerMiotStatus(DeviceStatus):
 class AirConditionerMiot(MiotDevice):
     """Main class representing the air conditioner which uses MIoT protocol."""
 
+    _supported_models = SUPPORTED_MODELS
     mapping = _MAPPING
 
     @command(

--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -13,6 +13,7 @@ SUPPORTED_MODELS = [
     "zhimi.airpurifier.ma4",  # airpurifier 3
     "zhimi.airpurifier.mb3",  # airpurifier 3h
     "zhimi.airpurifier.va1",  # airpurifier proh
+    "zhimi.airpurifier.vb2",  # airpurifier proh
 ]
 
 _LOGGER = logging.getLogger(__name__)

--- a/miio/aqaracamera.py
+++ b/miio/aqaracamera.py
@@ -156,7 +156,7 @@ class CameraStatus(DeviceStatus):
 class AqaraCamera(Device):
     """Main class representing the Xiaomi Aqara Camera."""
 
-    _supported_models = ["lumi.camera.aq1"]
+    _supported_models = ["lumi.camera.aq1", "lumi.camera.aq2"]
 
     @command(
         default_output=format_output(

--- a/miio/ceil.py
+++ b/miio/ceil.py
@@ -11,6 +11,9 @@ from .exceptions import DeviceException
 _LOGGER = logging.getLogger(__name__)
 
 
+SUPPORTED_MODELS = ["philips.light.ceiling", "philips.light.zyceiling"]
+
+
 class CeilException(DeviceException):
     pass
 
@@ -73,7 +76,7 @@ class Ceil(Device):
     # TODO: - Auto On/Off Not Supported
     #       - Adjust Scenes with Wall Switch Not Supported
 
-    _supported_models = ["unknown.models"]
+    _supported_models = SUPPORTED_MODELS
 
     @command(
         default_output=format_output(

--- a/miio/chuangmi_ir.py
+++ b/miio/chuangmi_ir.py
@@ -31,7 +31,10 @@ class ChuangmiIrException(DeviceException):
 class ChuangmiIr(Device):
     """Main class representing Chuangmi IR Remote Controller."""
 
-    _supported_models = ["unknown.models"]
+    _supported_models = [
+        "chuangmi.ir.v2",
+        "chuangmi-remote-h102a03",  # maybe?
+    ]
 
     PRONTO_RE = re.compile(r"^([\da-f]{4}\s?){3,}([\da-f]{4})$", re.IGNORECASE)
 

--- a/miio/waterpurifier.py
+++ b/miio/waterpurifier.py
@@ -93,7 +93,9 @@ class WaterPurifierStatus(DeviceStatus):
 class WaterPurifier(Device):
     """Main class representing the water purifier."""
 
-    _supported_models = ["unknown.models"]
+    _supported_models = [
+        "yunmi.waterpuri.v2",  # unknown if correct, based on mdns response
+    ]
 
     @command(
         default_output=format_output(


### PR DESCRIPTION
* Converts the most obvious mdns names to models
* Adds a note about `_supported_models` to the developer checklist.