### PR TITLE
Add more supported models

### DIFF
--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -16,6 +16,11 @@ SUPPORTED_MODELS = [
     "zhimi.airpurifier.vb2",  # airpurifier proh
 ]
 
+SUPPORTED_MODELS_MB4 = [
+    "zhimi.airpurifier.mb4",  # airpurifier 3c
+    "zhimi.airp.mb4a",  # airpurifier 3c
+]
+
 _LOGGER = logging.getLogger(__name__)
 _MAPPING = {
     # Air Purifier (siid=2)
@@ -468,7 +473,7 @@ class AirPurifierMB4(BasicAirPurifierMiot):
     """Main class representing the air purifier which uses MIoT protocol."""
 
     mapping = _MODEL_AIRPURIFIER_MB4
-    _supported_models = ["zhimi.airpurifier.mb4"]  # airpurifier 3c
+    _supported_models = SUPPORTED_MODELS_MB4
 
     @command(
         default_output=format_output(

--- a/miio/integrations/vacuum/roborock/vacuum.py
+++ b/miio/integrations/vacuum/roborock/vacuum.py
@@ -137,6 +137,7 @@ ROCKROBO_S4_MAX = "roborock.vacuum.a19"
 ROCKROBO_S5 = "roborock.vacuum.s5"
 ROCKROBO_S5_MAX = "roborock.vacuum.s5e"
 ROCKROBO_S6 = "roborock.vacuum.s6"
+ROCKROBO_T6 = "roborock.vacuum.t6"  # cn s6
 ROCKROBO_S6_PURE = "roborock.vacuum.a08"
 ROCKROBO_T7S = "roborock.vacuum.a14"
 ROCKROBO_S7 = "roborock.vacuum.a15"
@@ -151,6 +152,7 @@ SUPPORTED_MODELS = [
     ROCKROBO_S5,
     ROCKROBO_S5_MAX,
     ROCKROBO_S6,
+    ROCKROBO_T6,
     ROCKROBO_S6_PURE,
     ROCKROBO_T7S,
     ROCKROBO_S7,

--- a/miio/integrations/vacuum/viomi/viomivacuum.py
+++ b/miio/integrations/vacuum/viomi/viomivacuum.py
@@ -62,7 +62,7 @@ from miio.utils import pretty_seconds
 
 _LOGGER = logging.getLogger(__name__)
 
-SUPPORTED_MODELS = ["viomi.vacuum.v7", "viomi.vacuum.v8"]
+SUPPORTED_MODELS = ["viomi.vacuum.v7", "viomi.vacuum.v8", "viomi.vacuum.v10"]
 
 ERROR_CODES = {
     0: "Sleeping and not charging",


### PR DESCRIPTION
* airpurifier_miot: add zhimi.airp.mb4a (mentioned in #1270)
* roborock: add roborock.vacuum.t6
* roborock: add roborock.vacuum.a11 (fixes #1277)
* viomi: add viomi.vacuum.v10 (fixes #1279)