### PR TITLE
airpurifier_miot: force aqi update prior fetching data

### DIFF
--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -46,7 +46,7 @@ _MAPPING = {
     # AQI (siid=13)
     "purify_volume": {"siid": 13, "piid": 1},
     "average_aqi": {"siid": 13, "piid": 2},
-    "aqi_realtime_update_duration": {"siid": 13, "piid": 9},  # see #1281
+    "aqi_realtime_update_duration": {"siid": 13, "piid": 9},
     # RFID (siid=14)
     "filter_rfid_tag": {"siid": 14, "piid": 1},
     "filter_rfid_product_id": {"siid": 14, "piid": 3},
@@ -402,6 +402,9 @@ class AirPurifierMiot(BasicAirPurifierMiot):
     )
     def status(self) -> AirPurifierMiotStatus:
         """Retrieve properties."""
+        # Some devices update the aqi information only every 30min.
+        # This forces the device to poll the sensor for 5 seconds,
+        # so that we get always the most recent values. See #1281.
         if self.model == "zhimi.airpurifier.mb3":
             self.set_property("aqi_realtime_update_duration", 5)
 

--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -46,7 +46,7 @@ _MAPPING = {
     # AQI (siid=13)
     "purify_volume": {"siid": 13, "piid": 1},
     "average_aqi": {"siid": 13, "piid": 2},
-    "aqi_heartbeat": {"siid": 13, "piid": 9},
+    "aqi_realtime_update_duration": {"siid": 13, "piid": 9},  # see #1281
     # RFID (siid=14)
     "filter_rfid_tag": {"siid": 14, "piid": 1},
     "filter_rfid_product_id": {"siid": 14, "piid": 3},
@@ -403,7 +403,7 @@ class AirPurifierMiot(BasicAirPurifierMiot):
     def status(self) -> AirPurifierMiotStatus:
         """Retrieve properties."""
         if self.model == "zhimi.airpurifier.mb3":
-            self.set_property("aqi_heartbeat", 1)
+            self.set_property("aqi_realtime_update_duration", 5)
 
         return AirPurifierMiotStatus(
             {

--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -46,6 +46,7 @@ _MAPPING = {
     # AQI (siid=13)
     "purify_volume": {"siid": 13, "piid": 1},
     "average_aqi": {"siid": 13, "piid": 2},
+    "aqi_heartbeat": {"siid": 13, "piid": 9},
     # RFID (siid=14)
     "filter_rfid_tag": {"siid": 14, "piid": 1},
     "filter_rfid_product_id": {"siid": 14, "piid": 3},
@@ -401,6 +402,8 @@ class AirPurifierMiot(BasicAirPurifierMiot):
     )
     def status(self) -> AirPurifierMiotStatus:
         """Retrieve properties."""
+        if self.model == "zhimi.airpurifier.mb3":
+            self.set_property("aqi_heartbeat", 1)
 
         return AirPurifierMiotStatus(
             {


### PR DESCRIPTION
First attempt to fix #1281 - it's unknown if other models besides `zhimi.airpurifier.mb3` are affected, so this may need to be changed later.