### PR TITLE
Print debug recv contents prior accessing its contents

### DIFF
--- a/miio/miioprotocol.py
+++ b/miio/miioprotocol.py
@@ -193,14 +193,14 @@ class MiIOProtocol:
             data, addr = s.recvfrom(4096)
             m = Message.parse(data, token=self.token)
 
+            if self.debug > 1:
+                _LOGGER.debug("recv from %s: %s", addr[0], m)
+
             header = m.header.value
             payload = m.data.value
 
             self.__id = payload["id"]
             self._device_ts = header["ts"]  # type: ignore  # ts uses timeadapter
-
-            if self.debug > 1:
-                _LOGGER.debug("recv from %s: %s", addr[0], m)
 
             _LOGGER.debug(
                 "%s:%s (ts: %s, id: %s) << %s",


### PR DESCRIPTION
The current code tries to access the payload prior to printing it out in the debug mode, which makes it hard to debug issues like https://github.com/home-assistant/core/issues/62903 .

This PR moves the print out to happen directly after the message has been parsed, but it will still require some extra steps (passing the debug=1) to make it visible.