### PR TITLE
Perform pypi release on github release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,7 @@
 name: Publish packages
 on:
-  push:
-    branches:
-    - master
+  release:
+    types: [published]
 
 jobs:
   build-n-publish:
@@ -32,15 +31,7 @@ jobs:
         --outdir dist/
         .
 
-    - name: Publish on test pypi
-      uses: pypa/gh-action-pypi-publish@master
-      continue-on-error: true
-      with:
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
-
     - name: Publish release on pypi
-      if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
The previous try used (or tried to use) tag pushs on master, this will convert to use github releases as a trigger to perform a pypi release, and it has already been tested to work.

* Remove testpypi uploads