### PR TITLE
Add common API for constructing device instances, improve introspection

### DIFF
--- a/miio/airconditioningcompanion.py
+++ b/miio/airconditioningcompanion.py
@@ -14,7 +14,8 @@ MODEL_ACPARTNER_V1 = "lumi.acpartner.v1"
 MODEL_ACPARTNER_V2 = "lumi.acpartner.v2"
 MODEL_ACPARTNER_V3 = "lumi.acpartner.v3"
 
-MODELS_SUPPORTED = [MODEL_ACPARTNER_V1, MODEL_ACPARTNER_V2, MODEL_ACPARTNER_V3]
+MODELS_SUPPORTED = [MODEL_ACPARTNER_V1, MODEL_ACPARTNER_V2]
+MODELS_SUPPORTED_V3 = [MODEL_ACPARTNER_V3]  # TODO: merge v3 to the main class
 
 
 class AirConditioningCompanionException(DeviceException):
@@ -417,17 +418,7 @@ class AirConditioningCompanion(Device):
 
 
 class AirConditioningCompanionV3(AirConditioningCompanion):
-    def __init__(
-        self,
-        ip: str = None,
-        token: str = None,
-        start_id: int = 0,
-        debug: int = 0,
-        lazy_discover: bool = True,
-    ) -> None:
-        super().__init__(
-            ip, token, start_id, debug, lazy_discover, model=MODEL_ACPARTNER_V3
-        )
+    _supported_models = MODELS_SUPPORTED_V3
 
     @command(default_output=format_output("Powering socket on"))
     def socket_on(self):

--- a/miio/airfresh_t2017.py
+++ b/miio/airfresh_t2017.py
@@ -224,7 +224,7 @@ class AirFreshStatus(DeviceStatus):
 class AirFreshA1(Device):
     """Main class representing the air fresh a1."""
 
-    _supported_models = list(AVAILABLE_PROPERTIES.keys())
+    _supported_models = [MODEL_AIRFRESH_A1]
 
     @command(
         default_output=format_output(
@@ -358,6 +358,9 @@ class AirFreshA1(Device):
 
 class AirFreshT2017(AirFreshA1):
     """Main class representing the air fresh t2017."""
+
+    # TODO: merge to AirFreshA1, as this has just more features and slightly different command set
+    _supported_models = [MODEL_AIRFRESH_T2017]
 
     @command(
         default_output=format_output(

--- a/miio/cli.py
+++ b/miio/cli.py
@@ -2,7 +2,7 @@ import logging
 
 import click
 
-from miio import Discovery
+from miio import Device, Discovery
 from miio.click_common import (
     DeviceGroupMeta,
     ExceptionHandlerGroup,
@@ -57,6 +57,18 @@ def discover(mdns, handshake, network, timeout):
 
 
 cli.add_command(discover)
+
+
+@click.command()
+def supported_models():
+    """Print out the list of supported models."""
+    for model, cls in Device.all_supported_models().items():
+        click.echo(
+            f"* {model} = {cls.__name__} (command: miiocli {cls.__name__.lower()})"
+        )
+
+
+cli.add_command(supported_models)
 
 
 def create_cli():

--- a/miio/cli.py
+++ b/miio/cli.py
@@ -62,7 +62,7 @@ cli.add_command(discover)
 @click.command()
 def supported_models():
     """Print out the list of supported models."""
-    for model, cls in Device.all_supported_models().items():
+    for model, cls in Device.all_supported_models.items():
         click.echo(
             f"* {model} = {cls.__name__} (command: miiocli {cls.__name__.lower()})"
         )

--- a/miio/click_common.py
+++ b/miio/click_common.py
@@ -8,7 +8,7 @@ import json
 import logging
 import re
 from functools import partial, wraps
-from typing import Callable, Set, Type, Union
+from typing import Callable, Dict, Set, Type, Union
 
 import click
 
@@ -110,6 +110,7 @@ class GlobalContextObject:
 class DeviceGroupMeta(type):
 
     _device_classes: Set[Type] = set()
+    _model_for_device_class: Dict[str, Type] = {}
 
     def __new__(mcs, name, bases, namespace):
         commands = {}
@@ -143,6 +144,14 @@ class DeviceGroupMeta(type):
 
         cls = super().__new__(mcs, name, bases, namespace)
         mcs._device_classes.add(cls)
+
+        supported_models = namespace.get("_supported_models")
+        if not supported_models:
+            _LOGGER.debug("No supported models for %s", cls)
+        else:
+            for model in supported_models:
+                mcs._model_for_device_class[model] = cls
+
         return cls
 
     @property

--- a/miio/click_common.py
+++ b/miio/click_common.py
@@ -150,19 +150,15 @@ class DeviceGroupMeta(type):
         cls = super().__new__(mcs, name, bases, namespace)
         mcs._device_classes.add(cls)
 
-        supported_models = cls.supported_models
-        if not supported_models:
-            _LOGGER.debug("No supported models for %s", cls)
-        else:
-            for model in supported_models:
-                if model in mcs._model_for_device_class:
-                    _LOGGER.debug(
-                        "%s is already supported by %s, ignoring",
-                        model,
-                        mcs._model_for_device_class[model],
-                    )
-                    continue
-                mcs._model_for_device_class[model] = cls
+        for model in cls.supported_models:
+            if model in mcs._model_for_device_class:
+                _LOGGER.debug(
+                    "%s is already supported by %s, ignoring",
+                    model,
+                    mcs._model_for_device_class[model],
+                )
+                continue
+            mcs._model_for_device_class[model] = cls
 
         return cls
 
@@ -174,8 +170,6 @@ class DeviceGroupMeta(type):
     @property
     def all_supported_models(cls) -> Dict[str, Type[Device]]:
         """Return a dict of all models supported by the library.
-
-        This is not a property as class properties are only valid using python >= 3.9
 
         This is provisional and may be moved into its own class later.
         """

--- a/miio/device.py
+++ b/miio/device.py
@@ -345,18 +345,24 @@ class Device(metaclass=DeviceGroupMeta):
         return "Done"
 
     @classmethod
-    def all_supported_models(cls) -> Dict[str, Type["Device"]]:
-        """Return a list of all models supported by the library."""
-        return Device._model_for_device_class
-
-    @classmethod
     def class_for_model(cls, model: str):
-        """Return implementation for the given model string, if available."""
-        model_to_cls = cls.all_supported_models()
+        """Return implementation class for the given model, if available.
+
+        This is provisional and may be moved into its own class later.
+        """
+        model_to_cls = cls.all_supported_models
         if model in model_to_cls:
             return model_to_cls[model]
 
-        raise DeviceException("No implementation for %s", model)
+        wildcard_models = {
+            m: impl for m, impl in model_to_cls.items() if m.endswith("*")
+        }
+        for m, impl in wildcard_models.items():
+            m = m.rstrip("*")
+            if model.startswith(m):
+                return impl
+
+        raise DeviceException("No implementation found for model %s" % model)
 
     @classmethod
     def create(
@@ -365,6 +371,8 @@ class Device(metaclass=DeviceGroupMeta):
         """Return instance for the given host and token, with optional model override.
 
         The optional model parameter can be used to override the model detection.
+
+        This is provisional and may be moved into its own class later.
         """
         if model is None:
             dev: Device = cls(host, token)

--- a/miio/integrations/yeelight/__init__.py
+++ b/miio/integrations/yeelight/__init__.py
@@ -254,7 +254,7 @@ class Yeelight(Device):
     which however requires enabling the developer mode on the bulbs.
     """
 
-    _supported_models: List[str] = []
+    _supported_models: List[str] = ["yeelink.light.*", "yeelink.bhf_light.*"]
     _spec_helper = None
 
     def __init__(

--- a/miio/integrations/yeelight/spec_helper.py
+++ b/miio/integrations/yeelight/spec_helper.py
@@ -9,6 +9,9 @@ import yaml
 _LOGGER = logging.getLogger(__name__)
 
 
+WILDCARD_MODEL = "yeelink.light.*"
+
+
 class YeelightSubLightType(IntEnum):
     Main = 0
     Background = 1
@@ -43,7 +46,7 @@ class YeelightSpecHelper:
 
     def _parse_specs_yaml(self):
         generic_info = YeelightModelInfo(
-            "generic",
+            WILDCARD_MODEL,
             False,
             {
                 YeelightSubLightType.Main: YeelightLampInfo(
@@ -51,7 +54,7 @@ class YeelightSpecHelper:
                 )
             },
         )
-        YeelightSpecHelper._models["generic"] = generic_info
+        YeelightSpecHelper._models[WILDCARD_MODEL] = generic_info
         # read the yaml file to populate the internal model cache
         with open(os.path.dirname(__file__) + "/specs.yaml") as filedata:
             models = yaml.safe_load(filedata)
@@ -82,5 +85,5 @@ class YeelightSpecHelper:
                 "Unknown model %s, please open an issue and supply features for this light. Returning generic information.",
                 model,
             )
-            return self._models["generic"]
+            return self._models[WILDCARD_MODEL]
         return self._models[model]

--- a/miio/integrations/yeelight/tests/test_yeelight_spec_helper.py
+++ b/miio/integrations/yeelight/tests/test_yeelight_spec_helper.py
@@ -15,8 +15,8 @@ def test_get_model_info():
 
 def test_get_unknown_model_info():
     spec_helper = YeelightSpecHelper()
-    model_info = spec_helper.get_model_info("notreal")
-    assert model_info.model == "generic"
+    model_info = spec_helper.get_model_info("yeelink.light.notreal")
+    assert model_info.model == "yeelink.light.*"
     assert model_info.night_light is False
     assert model_info.lamps[YeelightSubLightType.Main].color_temp == ColorTempRange(
         1700, 6500


### PR DESCRIPTION
New class methods in Device:
* all_supported_models() to return a dictionary model=>implementation class
* class_for_model(model: str) to return implementation class for the given model
* create(host: str, token: str, model: Optional[str]) to create a device instance

New cli commands:
* `miiocli supported-models` will print a list of supported models

TBD:
- [x] Tests
- [ ] Extract the factory into its own class
- [ ] Update README and docs for changes

Fixes #1117