### PR TITLE
Deprecate wifi_led in favor of led

### DIFF
--- a/miio/chuangmi_plug.py
+++ b/miio/chuangmi_plug.py
@@ -78,8 +78,14 @@ class ChuangmiPlugStatus(DeviceStatus):
             return float(self.data["load_power"])
         return None
 
-    @property
+    @property  # type: ignore
+    @deprecated("Use led()")
     def wifi_led(self) -> Optional[bool]:
+        """True if the wifi led is turned on."""
+        return self.led
+
+    @property
+    def led(self) -> Optional[bool]:
         """True if the wifi led is turned on."""
         if "wifi_led" in self.data and self.data["wifi_led"] is not None:
             return self.data["wifi_led"] == "on"
@@ -142,6 +148,7 @@ class ChuangmiPlug(Device):
         """Power off."""
         return self.send("set_usb_off")
 
+    @deprecated("Use set_led instead of set_wifi_led")
     @command(
         click.argument("wifi_led", type=bool),
         default_output=format_output(
@@ -152,6 +159,16 @@ class ChuangmiPlug(Device):
     )
     def set_wifi_led(self, wifi_led: bool):
         """Set the wifi led on/off."""
+        self.set_led(wifi_led)
+
+    @command(
+        click.argument("wifi_led", type=bool),
+        default_output=format_output(
+            lambda wifi_led: "Turning on LED" if wifi_led else "Turning off LED"
+        ),
+    )
+    def set_led(self, wifi_led: bool):
+        """Set the led on/off."""
         if wifi_led:
             return self.send("set_wifi_led", ["on"])
         else:

--- a/miio/device.py
+++ b/miio/device.py
@@ -1,5 +1,6 @@
 import inspect
 import logging
+import warnings
 from enum import Enum
 from pprint import pformat as pf
 from typing import Any, List, Optional  # noqa: F401
@@ -35,7 +36,9 @@ class DeviceStatus:
         for prop_tuple in props:
             name, prop = prop_tuple
             try:
-                prop_value = prop.fget(self)
+                # ignore deprecation warnings
+                with warnings.catch_warnings():
+                    prop_value = prop.fget(self)
             except Exception as ex:
                 prop_value = ex.__class__.__name__
 

--- a/miio/tests/test_chuangmi_plug.py
+++ b/miio/tests/test_chuangmi_plug.py
@@ -164,15 +164,22 @@ class TestChuangmiPlugV3(TestCase):
         self.device.usb_off()
         assert self.device.status().usb_power is False
 
-    def test_set_wifi_led(self):
-        def wifi_led():
-            return self.device.status().wifi_led
+    def test_led(self):
+        def led():
+            return self.device.status().led
 
-        self.device.set_wifi_led(True)
-        assert wifi_led() is True
+        self.device.set_led(True)
+        assert led() is True
 
-        self.device.set_wifi_led(False)
-        assert wifi_led() is False
+        self.device.set_led(False)
+        assert led() is False
+
+    def test_wifi_led_deprecation(self):
+        with pytest.deprecated_call():
+            self.device.set_wifi_led(True)
+
+        with pytest.deprecated_call():
+            self.device.status().wifi_led
 
 
 class DummyChuangmiPlugM1(DummyDevice, ChuangmiPlug):

--- a/miio/tests/test_powerstrip.py
+++ b/miio/tests/test_powerstrip.py
@@ -199,15 +199,22 @@ class TestPowerStripV2(TestCase):
         self.device.set_power_mode(PowerMode.Normal)
         assert mode() == PowerMode.Normal
 
-    def test_set_wifi_led(self):
-        def wifi_led():
-            return self.device.status().wifi_led
+    def test_set_led(self):
+        def led():
+            return self.device.status().led
 
-        self.device.set_wifi_led(True)
-        assert wifi_led() is True
+        self.device.set_led(True)
+        assert led() is True
 
-        self.device.set_wifi_led(False)
-        assert wifi_led() is False
+        self.device.set_led(False)
+        assert led() is False
+
+    def test_set_wifi_led_deprecation(self):
+        with pytest.deprecated_call():
+            self.device.set_wifi_led(True)
+
+        with pytest.deprecated_call():
+            self.device.status().wifi_led
 
     def test_set_power_price(self):
         def power_price():


### PR DESCRIPTION
Doing this makes all devices with leds to have a common interface. chuangmi_plug and powerstrip are affected:
* Use `set_led(bool)` instead of `set_wifi_led(bool)`
* Use `led() -> bool` instead of `wifi_led() -> bool` for status