### PR TITLE
Make sure miotdevice implementations define supported models

### DIFF
--- a/miio/curtain_youpin.py
+++ b/miio/curtain_youpin.py
@@ -115,6 +115,7 @@ class CurtainMiot(MiotDevice):
     """Main class representing the lumi.curtain.hagl05 curtain."""
 
     mapping = _MAPPING
+    _supported_models = ["lumi.curtain.hagl05"]
 
     @command(
         default_output=format_output(

--- a/miio/heater_miot.py
+++ b/miio/heater_miot.py
@@ -143,6 +143,7 @@ class HeaterMiot(MiotDevice):
     (zhimi.heater.za2)."""
 
     _mappings = _MAPPINGS
+    _supported_models = list(_MAPPINGS.keys())
 
     @command(
         default_output=format_output(

--- a/miio/huizuo.py
+++ b/miio/huizuo.py
@@ -211,6 +211,7 @@ class Huizuo(MiotDevice):
     """
 
     mapping = _MAPPING
+    _supported_models = MODELS_SUPPORTED
 
     def __init__(
         self,

--- a/miio/integrations/fan/dmaker/fan_miot.py
+++ b/miio/integrations/fan/dmaker/fan_miot.py
@@ -231,6 +231,8 @@ class FanStatus1C(DeviceStatus):
 
 class FanMiot(MiotDevice):
     _mappings = MIOT_MAPPING
+    # TODO Fan1C should be merged to FanMiot
+    _supported_models = list(set(MIOT_MAPPING) - {MODEL_FAN_1C})
 
     @command(
         default_output=format_output(
@@ -372,6 +374,7 @@ class FanMiot(MiotDevice):
 
 class Fan1C(MiotDevice):
     mapping = MIOT_MAPPING[MODEL_FAN_1C]
+    _supported_models = [MODEL_FAN_1C]
 
     def __init__(
         self,

--- a/miio/integrations/fan/zhimi/zhimi_miot.py
+++ b/miio/integrations/fan/zhimi/zhimi_miot.py
@@ -170,7 +170,7 @@ class FanStatusZA5(DeviceStatus):
 
 class FanZA5(MiotDevice):
     mapping = MIOT_MAPPING
-    _supported_models = ["zhimi.fan.za5 "]
+    _supported_models = list(MIOT_MAPPING.keys())
 
     @command(
         default_output=format_output(

--- a/miio/integrations/fan/zhimi/zhimi_miot.py
+++ b/miio/integrations/fan/zhimi/zhimi_miot.py
@@ -170,6 +170,7 @@ class FanStatusZA5(DeviceStatus):
 
 class FanZA5(MiotDevice):
     mapping = MIOT_MAPPING
+    _supported_models = ["zhimi.fan.za5 "]
 
     @command(
         default_output=format_output(

--- a/miio/integrations/vacuum/roidmi/roidmivacuum_miot.py
+++ b/miio/integrations/vacuum/roidmi/roidmivacuum_miot.py
@@ -536,6 +536,7 @@ class RoidmiVacuumMiot(MiotDevice):
     """Interface for Vacuum Eve Plus (roidmi.vacuum.v60)"""
 
     mapping = _MAPPING
+    _supported_models = ["roidmi.vacuum.v60"]
 
     @command()
     def status(self) -> RoidmiVacuumStatus:

--- a/miio/tests/test_device.py
+++ b/miio/tests/test_device.py
@@ -5,6 +5,8 @@ import pytest
 from miio import Device, MiotDevice, RoborockVacuum
 from miio.exceptions import DeviceInfoUnavailableException, PayloadDecodeException
 
+DEVICE_CLASSES = Device.__subclasses__() + MiotDevice.__subclasses__()  # type: ignore
+
 
 @pytest.mark.parametrize("max_properties", [None, 1, 15])
 def test_get_properties_splitting(mocker, max_properties):
@@ -101,10 +103,11 @@ def test_missing_supported(mocker, caplog, cls, hidden):
         assert f"for class '{cls.__name__}'" in caplog.text
 
 
-@pytest.mark.parametrize("cls", Device.__subclasses__())
+@pytest.mark.parametrize("cls", DEVICE_CLASSES)
 def test_device_ctor_model(cls):
     """Make sure that every device subclass ctor accepts model kwarg."""
-    ignore_classes = ["GatewayDevice", "CustomDevice"]
+    # TODO Huizuo implements custom model fallback, so it needs to be ignored for now
+    ignore_classes = ["GatewayDevice", "CustomDevice", "Huizuo"]
     if cls.__name__ in ignore_classes:
         return
 
@@ -113,7 +116,7 @@ def test_device_ctor_model(cls):
     assert dev.model == dummy_model
 
 
-@pytest.mark.parametrize("cls", Device.__subclasses__())
+@pytest.mark.parametrize("cls", DEVICE_CLASSES)
 def test_device_supported_models(cls):
     """Make sure that every device subclass has a non-empty supported models."""
     if cls.__name__ == "MiotDevice":  # skip miotdevice

--- a/miio/yeelight_dual_switch.py
+++ b/miio/yeelight_dual_switch.py
@@ -108,6 +108,7 @@ class YeelightDualControlModule(MiotDevice):
     which uses MIoT protocol."""
 
     mapping = _MAPPING
+    _supported_models = ["yeelink.switch.sw1"]
 
     @command(
         default_output=format_output(


### PR DESCRIPTION
Previously only implementations directly inheriting from `Device` were tested to ensure the existence of `_supported_models`.
This PR extends the tests to check it for `MiotDevice` inheriting classes, and adds model information for:
* CurtainMiot
* Huizuo
* FanMiot, Fan1C
* FanZA5
* RoidmiVacuumMiot
* YeelightDualControlModule


Fixes #1344