### PR TITLE
Fix bug for zhimi.fan.za5 resulting in user ack timeout

### DIFF
--- a/miio/integrations/fan/zhimi/zhimi_miot.py
+++ b/miio/integrations/fan/zhimi/zhimi_miot.py
@@ -169,7 +169,7 @@ class FanStatusZA5(DeviceStatus):
 
 
 class FanZA5(MiotDevice):
-    mapping = MIOT_MAPPING
+    mapping = MIOT_MAPPING[MODEL_FAN_ZA5]
     _supported_models = list(MIOT_MAPPING.keys())
 
     @command(

--- a/miio/integrations/fan/zhimi/zhimi_miot.py
+++ b/miio/integrations/fan/zhimi/zhimi_miot.py
@@ -169,7 +169,7 @@ class FanStatusZA5(DeviceStatus):
 
 
 class FanZA5(MiotDevice):
-    mapping = MIOT_MAPPING[MODEL_FAN_ZA5]
+    _mappings = MIOT_MAPPING
     _supported_models = list(MIOT_MAPPING.keys())
 
     @command(


### PR DESCRIPTION
This should fix #1344, at least for my simple tests of getting the status, turning the fan on and off.

# Before

## Status ❌
`miiocli --debug fanza5 --ip 192.168.x.xxx --token <TOKEN>`
```
DEBUG:miio.device:Detected model zhimi.fan.za5
DEBUG:miio.miioprotocol:192.168.x.xxx:54321 >>: {'id': 2, 'method': 'get_properties', 'params': [{'did': 'zhimi.fan.za5', 'power': {'siid': 2, 'piid': 1}, 'fan_level': {'siid': 2, 'piid': 2}, 'swing_mode': {'siid': 2, 'piid': 3}, 'swing_mode_angle': {'siid': 2, 'piid': 5}, 'mode': {'siid': 2, 'piid': 7}, 'power_off_time': {'siid': 2, 'piid': 10}, 'anion': {'siid': 2, 'piid': 11}, 'child_lock': {'siid': 3, 'piid': 1}, 'light': {'siid': 4, 'piid': 3}, 'buzzer': {'siid': 5, 'piid': 1}, 'buttons_pressed': {'siid': 6, 'piid': 1}, 'battery_supported': {'siid': 6, 'piid': 2}, 'set_move': {'siid': 6, 'piid': 3}, 'speed_rpm': {'siid': 6, 'piid': 4}, 'powersupply_attached': {'siid': 6, 'piid': 5}, 'fan_speed': {'siid': 6, 'piid': 8}, 'humidity': {'siid': 7, 'piid': 1}, 'temperature': {'siid': 7, 'piid': 7}}]}

DEBUG:miio.miioprotocol:192.168.x.xxx:54321 (ts: 1970-01-04 06:02:27, id: 2) << {'id': 2, 'error': {'code': -9999, 'message': 'user ack timeout'}, 'exe_time': 4010}
DEBUG:miio.click_common:Exception: {'code': -9999, 'message': 'user ack timeout'}
Traceback (most recent call last):
  File "/home/saxel/python-miio/miio/click_common.py", line 51, in __call__
    return self.main(*args, **kwargs)
  File "/home/saxel/.cache/pypoetry/virtualenvs/python-miio-RxGJ_yqw-py3.8/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/home/saxel/.cache/pypoetry/virtualenvs/python-miio-RxGJ_yqw-py3.8/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/saxel/.cache/pypoetry/virtualenvs/python-miio-RxGJ_yqw-py3.8/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/saxel/.cache/pypoetry/virtualenvs/python-miio-RxGJ_yqw-py3.8/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/saxel/.cache/pypoetry/virtualenvs/python-miio-RxGJ_yqw-py3.8/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/home/saxel/python-miio/miio/click_common.py", line 300, in wrap
    kwargs["result"] = func(*args, **kwargs)
  File "/home/saxel/.cache/pypoetry/virtualenvs/python-miio-RxGJ_yqw-py3.8/lib/python3.8/site-packages/click/decorators.py", line 84, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/saxel/.cache/pypoetry/virtualenvs/python-miio-RxGJ_yqw-py3.8/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/home/saxel/python-miio/miio/click_common.py", line 265, in command_callback
    return miio_command.call(miio_device, *args, **kwargs)
  File "/home/saxel/python-miio/miio/click_common.py", line 212, in call
    return method(*args, **kwargs)
  File "/home/saxel/python-miio/miio/click_common.py", line 179, in _wrap
    return func(self, *args, **kwargs)
  File "/home/saxel/python-miio/miio/integrations/fan/zhimi/zhimi_miot.py", line 202, in status
    for prop in self.get_properties_for_mapping()
  File "/home/saxel/python-miio/miio/miot_device.py", line 72, in get_properties_for_mapping
    return self.get_properties(
  File "/home/saxel/python-miio/miio/device.py", line 232, in get_properties
    values.extend(self.send(property_getter, _props[:max_properties]))
  File "/home/saxel/python-miio/miio/device.py", line 106, in send
    return self._protocol.send(
  File "/home/saxel/python-miio/miio/miioprotocol.py", line 214, in send
    self._handle_error(payload["error"])
  File "/home/saxel/python-miio/miio/miioprotocol.py", line 274, in _handle_error
    raise DeviceError(error)
miio.exceptions.DeviceError: {'code': -9999, 'message': 'user ack timeout'}
Error: {'code': -9999, 'message': 'user ack timeout'}
```

## Turn on ❌
`miiocli --debug fanza5 --ip 192.168.x.xxx --token <TOKEN>`
```
INFO:miio.cli:Debug mode active
Powering on
DEBUG:miio.click_common:Unknown model, trying autodetection. None None
DEBUG:miio.miioprotocol:Got a response: Container:
    data = Container:
        data = b'' (total 0)
        value = b'' (total 0)
        offset1 = 32
        offset2 = 32
        length = 0
    header = Container:
        data = ...
        value = Container:
            length = 32
            unknown = 0
            device_id = unhexlify('<deviceid>')
            ts = 1970-01-04 06:03:36
        offset1 = 0
        offset2 = 16
        length = 16
    checksum = b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff' (total 16)
DEBUG:miio.device:Detected model zhimi.fan.za5
Traceback (most recent call last):
  File "/home/saxel/.cache/pypoetry/virtualenvs/python-miio-RxGJ_yqw-py3.8/bin/miiocli", line 5, in <module>
    create_cli()
  File "/home/saxel/python-miio/miio/cli.py", line 63, in create_cli
    return cli(auto_envvar_prefix="MIIO")
  File "/home/saxel/python-miio/miio/click_common.py", line 51, in __call__
    return self.main(*args, **kwargs)
  File "/home/saxel/.cache/pypoetry/virtualenvs/python-miio-RxGJ_yqw-py3.8/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/home/saxel/.cache/pypoetry/virtualenvs/python-miio-RxGJ_yqw-py3.8/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/saxel/.cache/pypoetry/virtualenvs/python-miio-RxGJ_yqw-py3.8/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/saxel/.cache/pypoetry/virtualenvs/python-miio-RxGJ_yqw-py3.8/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/saxel/.cache/pypoetry/virtualenvs/python-miio-RxGJ_yqw-py3.8/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/home/saxel/python-miio/miio/click_common.py", line 300, in wrap
    kwargs["result"] = func(*args, **kwargs)
  File "/home/saxel/.cache/pypoetry/virtualenvs/python-miio-RxGJ_yqw-py3.8/lib/python3.8/site-packages/click/decorators.py", line 84, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/saxel/.cache/pypoetry/virtualenvs/python-miio-RxGJ_yqw-py3.8/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwabrgs)
  File "/home/saxel/python-miio/miio/click_common.py", line 265, in command_callback
    return miio_command.call(miio_device, *args, **kwargs)
  File "/home/saxel/python-miio/miio/click_common.py", line 212, in call
    return method(*args, **kwargs)
  File "/home/saxel/python-miio/miio/click_common.py", line 179, in _wrap
    return func(self, *args, **kwargs)
  File "/home/saxel/python-miio/miio/integrations/fan/zhimi/zhimi_miot.py", line 209, in on
    return self.set_property("power", True)
  File "/home/saxel/python-miio/miio/miot_device.py", line 154, in set_property
    [{"did": property_key, **mapping[property_key], "value": value}],
KeyError: 'power'
```

# After

## Status ✔
`miiocli fanza5 --debug --ip 192.168.x.xxx --token <TOKEN> status`

```
DEBUG:miio.device:Detected model zhimi.fan.za5
DEBUG:miio.miioprotocol:192.168.x.xxx:54321 >>: {'id': 2, 'method': 'get_properties', 'params': [{'did': 'power', 'siid': 2, 'piid': 1}, {'did': 'fan_level', 'siid': 2, 'piid': 2}, {'did': 'swing_mode', 'siid': 2, 'piid': 3}, {'did': 'swing_mode_angle', 'siid': 2, 'piid': 5}, {'did': 'mode', 'siid': 2, 'piid': 7}, {'did': 'power_off_time', 'siid': 2, 'piid': 10}, {'did': 'anion', 'siid': 2, 'piid': 11}, {'did': 'child_lock', 'siid': 3, 'piid': 1}, {'did': 'light', 'siid': 4, 'piid': 3}, {'did': 'buzzer', 'siid': 5, 'piid': 1}, {'did': 'buttons_pressed', 'siid': 6, 'piid': 1}, {'did': 'battery_supported', 'siid': 6, 'piid': 2}, {'did': 'set_move', 'siid': 6, 'piid': 3}, {'did': 'speed_rpm', 'siid': 6, 'piid': 4}, {'did': 'powersupply_attached', 'siid': 6, 'piid': 5}]}
DEBUG:miio.miioprotocol:192.168.x.xxx:54321 (ts: 1970-01-04 06:09:30, id: 2) << {'id': 2, 'result': [{'did': 'power', 'siid': 2, 'piid': 1, 'code': 0, 'value': False}, {'did': 'fan_level', 'siid': 2, 'piid': 2, 'code': 0, 'value': 2}, {'did': 'swing_mode', 'siid': 2, 'piid': 3, 'code': 0, 'value': True}, {'did': 'swing_mode_angle', 'siid': 2, 'piid': 5, 'code': 0, 'value': 30}, {'did': 'mode', 'siid': 2, 'piid': 7, 'code': 0, 'value': 1}, {'did': 'power_off_time', 'siid': 2, 'piid': 10, 'code': 0, 'value': 0}, {'did': 'anion', 'siid': 2, 'piid': 11, 'code': 0, 'value': True}, {'did': 'child_lock', 'siid': 3, 'piid': 1, 'code': 0, 'value': False}, {'did': 'light', 'siid': 4, 'piid': 3, 'code': 0, 'value': 0}, {'did': 'buzzer', 'siid': 5, 'piid': 1, 'code': 0, 'value': False}, {'did': 'buttons_pressed', 'siid': 6, 'piid': 1, 'code': 0, 'value': 0}, {'did': 'battery_supported', 'siid': 6, 'piid': 2, 'code': 0, 'value': False}, {'did': 'set_move', 'siid': 6, 'piid': 3, 'code': -4005}, {'did': 'speed_rpm', 'siid': 6, 'piid': 4, 'code': 0, 'value': 0}, {'did': 'powersupply_attached', 'siid': 6, 'piid': 5, 'code': 0, 'value': True}], 'exe_time': 310}
DEBUG:miio.miioprotocol:192.168.x.xxx:54321 >>: {'id': 3, 'method': 'get_properties', 'params': [{'did': 'fan_speed', 'siid': 6, 'piid': 8}, {'did': 'humidity', 'siid': 7, 'piid': 1}, {'did': 'temperature', 'siid': 7, 'piid': 7}]}
DEBUG:miio.miioprotocol:192.168.x.xxx:54321 (ts: 1970-01-04 06:09:30, id: 3) << {'id': 3, 'result': [{'did': 'fan_speed', 'siid': 6, 'piid': 8, 'code': 0, 'value': 35}, {'did': 'humidity', 'siid': 7, 'piid': 1, 'code': 0, 'value': 59}, {'did': 'temperature', 'siid': 7, 'piid': 7, 'code': 0, 'value': 31.4}], 'exe_time': 110}
Angle: 30
Battery Supported: False
Buttons Pressed: None
Buzzer: False
Child Lock: False
Delay Off Countdown: 0
Fan Level: 2
Fan Speed: 35
Humidity: 59
Ionizer: True
LED Brightness: 0
Mode: Normal
Oscillate: True
Power: off
Powersupply Attached: True
Speed RPM: 0
Temperature: 31.4
```

## Turn ON ✔
`miiocli fanza5 --debug --ip 192.168.x.xxx --token <TOKEN> on`
```
DEBUG:miio.device:Detected model zhimi.fan.za5
DEBUG:miio.miioprotocol:192.168.x.xxx:54321 >>: {'id': 2, 'method': 'set_properties', 'params': [{'did': 'power', 'siid': 2, 'piid': 1, 'value': True}]}
DEBUG:miio.miioprotocol:192.168.x.xxx:54321 (ts: 1970-01-04 06:10:07, id: 2) << {'id': 2, 'result': [{'did': 'power', 'siid': 2, 'piid': 1, 'code': 0}], 'exe_time': 210}
[{'did': 'power', 'siid': 2, 'piid': 1, 'code': 0}]
```
