### PR TITLE
Support for Xiaomi Vaccum Mop 2 Ultra and Pro+ (dreame)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,6 +154,7 @@ Supported devices
 -  Xiaomi Walkingpad A1 (ksmb.walkingpad.v3)
 -  Xiaomi Smart Pet Water Dispenser (mmgg.pet_waterer.s1, s4)
 -  Xiaomi Mi Smart Humidifer S (jsqs, jsq5)
+-  Xiaomi Mi Robot Vacuum Mop 2 (Pro+, Ultra)
 
 
 *Feel free to create a pull request to add support for new devices as

--- a/miio/integrations/vacuum/dreame/dreamevacuum_miot.py
+++ b/miio/integrations/vacuum/dreame/dreamevacuum_miot.py
@@ -399,14 +399,6 @@ class DreameVacuumStatus(DeviceStatusContainer):
 
 
 class DreameVacuum(MiotDevice):
-    _supported_models = [
-        DREAME_1C,
-        DREAME_D9,
-        DREAME_F9,
-        DREAME_Z10_PRO,
-        DREAME_MOP_2_PRO_PLUS,
-        DREAME_MOP_2_ULTRA,
-    ]
     _mappings = MIOT_MAPPING
 
     @command(

--- a/miio/integrations/vacuum/dreame/dreamevacuum_miot.py
+++ b/miio/integrations/vacuum/dreame/dreamevacuum_miot.py
@@ -190,7 +190,13 @@ def _get_cleaning_mode_enum_class(model):
     """Return cleaning mode enum class for model if found or None."""
     if model == DREAME_1C:
         return CleaningModeDreame1C
-    elif model in (DREAME_F9, DREAME_D9, DREAME_Z10_PRO, DREAME_MOP_2_PRO_PLUS, DREAME_MOP_2_ULTRA):
+    elif model in (
+        DREAME_F9,
+        DREAME_D9,
+        DREAME_Z10_PRO,
+        DREAME_MOP_2_PRO_PLUS,
+        DREAME_MOP_2_ULTRA,
+    ):
         return CleaningModeDreameF9
 
 

--- a/miio/integrations/vacuum/dreame/dreamevacuum_miot.py
+++ b/miio/integrations/vacuum/dreame/dreamevacuum_miot.py
@@ -198,6 +198,7 @@ def _get_cleaning_mode_enum_class(model):
         DREAME_MOP_2_ULTRA,
     ):
         return CleaningModeDreameF9
+    return None
 
 
 class DreameVacuumStatus(DeviceStatusContainer):

--- a/miio/integrations/vacuum/dreame/dreamevacuum_miot.py
+++ b/miio/integrations/vacuum/dreame/dreamevacuum_miot.py
@@ -18,6 +18,8 @@ DREAME_1C = "dreame.vacuum.mc1808"
 DREAME_F9 = "dreame.vacuum.p2008"
 DREAME_D9 = "dreame.vacuum.p2009"
 DREAME_Z10_PRO = "dreame.vacuum.p2028"
+DREAME_MOP_2_PRO_PLUS = "dreame.vacuum.p2041o"
+DREAME_MOP_2_ULTRA = "dreame.vacuum.p2150a"
 
 
 _DREAME_1C_MAPPING: MiotMapping = {
@@ -70,6 +72,8 @@ _DREAME_F9_MAPPING: MiotMapping = {
     # https://home.miot-spec.com/spec/dreame.vacuum.p2008
     # https://home.miot-spec.com/spec/dreame.vacuum.p2009
     # https://home.miot-spec.com/spec/dreame.vacuum.p2028
+    # https://home.miot-spec.com/spec/dreame.vacuum.p2041o
+    # https://home.miot-spec.com/spec/dreame.vacuum.p2150a
     "battery_level": {"siid": 3, "piid": 1},
     "charging_state": {"siid": 3, "piid": 2},
     "device_fault": {"siid": 2, "piid": 2},
@@ -115,6 +119,8 @@ MIOT_MAPPING: Dict[str, MiotMapping] = {
     DREAME_F9: _DREAME_F9_MAPPING,
     DREAME_D9: _DREAME_F9_MAPPING,
     DREAME_Z10_PRO: _DREAME_F9_MAPPING,
+    DREAME_MOP_2_PRO_PLUS: _DREAME_F9_MAPPING,
+    DREAME_MOP_2_ULTRA: _DREAME_F9_MAPPING,
 }
 
 
@@ -184,7 +190,7 @@ def _get_cleaning_mode_enum_class(model):
     """Return cleaning mode enum class for model if found or None."""
     if model == DREAME_1C:
         return CleaningModeDreame1C
-    elif model in [DREAME_F9, DREAME_D9, DREAME_Z10_PRO]:
+    elif model in (DREAME_F9, DREAME_D9, DREAME_Z10_PRO, DREAME_MOP_2_PRO_PLUS, DREAME_MOP_2_ULTRA):
         return CleaningModeDreameF9
 
 
@@ -387,6 +393,14 @@ class DreameVacuumStatus(DeviceStatusContainer):
 
 
 class DreameVacuum(MiotDevice):
+    _supported_models = [
+        DREAME_1C,
+        DREAME_D9,
+        DREAME_F9,
+        DREAME_Z10_PRO,
+        DREAME_MOP_2_PRO_PLUS,
+        DREAME_MOP_2_ULTRA,
+    ]
     _mappings = MIOT_MAPPING
 
     @command(

--- a/miio/integrations/vacuum/dreame/tests/test_dreamevacuum_miot.py
+++ b/miio/integrations/vacuum/dreame/tests/test_dreamevacuum_miot.py
@@ -15,7 +15,7 @@ from ..dreamevacuum_miot import (
     FaultStatus,
     OperatingMode,
     WaterFlow,
-    MIOT_MAPPING
+    MIOT_MAPPING,
 )
 
 _INITIAL_STATE_1C = {
@@ -251,9 +251,7 @@ class TestDreameF9Vacuum(TestCase):
         assert value == {"Medium": 2}
 
 
-@pytest.mark.parametrize(
-    "model", MIOT_MAPPING.keys()
-)
+@pytest.mark.parametrize("model", MIOT_MAPPING.keys())
 def test_dreame_models(model: str):
     vac = DreameVacuum(model=model)
     # test _get_cleaning_mode_enum_class returns non-empty mapping
@@ -262,6 +260,6 @@ def test_dreame_models(model: str):
 
 
 def test_invalid_dreame_model():
-    vac = DreameVacuum(model='model.invalid')
+    vac = DreameVacuum(model="model.invalid")
     fp = vac.fan_speed_presets()
     assert fp == {}

--- a/miio/integrations/vacuum/dreame/tests/test_dreamevacuum_miot.py
+++ b/miio/integrations/vacuum/dreame/tests/test_dreamevacuum_miot.py
@@ -15,6 +15,7 @@ from ..dreamevacuum_miot import (
     FaultStatus,
     OperatingMode,
     WaterFlow,
+    MIOT_MAPPING
 )
 
 _INITIAL_STATE_1C = {
@@ -248,3 +249,13 @@ class TestDreameF9Vacuum(TestCase):
     def test_waterflow(self):
         value = self.device.waterflow()
         assert value == {"Medium": 2}
+
+
+@pytest.mark.parametrize(
+    "model", MIOT_MAPPING.keys()
+)
+def test_dreame_models(model: str):
+    vac = DreameVacuum(model=model)
+    # test _get_cleaning_mode_enum_class returns non-empty mapping
+    fp = vac.fan_speed_presets()
+    assert (fp is not None) and (len(fp) > 0)

--- a/miio/integrations/vacuum/dreame/tests/test_dreamevacuum_miot.py
+++ b/miio/integrations/vacuum/dreame/tests/test_dreamevacuum_miot.py
@@ -259,3 +259,9 @@ def test_dreame_models(model: str):
     # test _get_cleaning_mode_enum_class returns non-empty mapping
     fp = vac.fan_speed_presets()
     assert (fp is not None) and (len(fp) > 0)
+
+
+def test_invalid_dreame_model():
+    vac = DreameVacuum(model='model.invalid')
+    fp = vac.fan_speed_presets()
+    assert fp == {}

--- a/miio/integrations/vacuum/dreame/tests/test_dreamevacuum_miot.py
+++ b/miio/integrations/vacuum/dreame/tests/test_dreamevacuum_miot.py
@@ -8,6 +8,7 @@ from miio.tests.dummies import DummyMiotDevice
 from ..dreamevacuum_miot import (
     DREAME_1C,
     DREAME_F9,
+    MIOT_MAPPING,
     ChargingState,
     CleaningModeDreame1C,
     CleaningModeDreameF9,
@@ -15,7 +16,6 @@ from ..dreamevacuum_miot import (
     FaultStatus,
     OperatingMode,
     WaterFlow,
-    MIOT_MAPPING,
 )
 
 _INITIAL_STATE_1C = {


### PR DESCRIPTION
Support for 2 new dreame devices:
* Xiaomi Vaccum Mop 2 Ultra (dreame.vacuum.p2150a)
* Pro+ (dreame.vacuum.p2041o)

Fixes https://github.com/rytilahti/python-miio/issues/1274