### PR TITLE
Add support for Air Purifier 4 (zhimi.airp.mb5)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ Supported devices
 -  Xiaomi Mi Robot Vacuum V1, S4, S4 MAX, S5, S5 MAX, S6 Pure, M1S, S7
 -  Xiaomi Mi Home Air Conditioner Companion
 -  Xiaomi Mi Smart Air Conditioner A (xiaomi.aircondition.mc1, mc2, mc4, mc5)
--  Xiaomi Mi Air Purifier 2, 3H, 3C, Pro, Pro H, 4 Pro (zhimi.airpurifier.m2, mb3, mb4, v7, vb2, va2)
+-  Xiaomi Mi Air Purifier 2, 3H, 3C, 4, Pro, Pro H, 4 Pro (zhimi.airpurifier.m2, mb3, mb4, mb5, v7, vb2, va2)
 -  Xiaomi Mi Air (Purifier) Dog X3, X5, X7SM (airdog.airpurifier.x3, airdog.airpurifier.x5, airdog.airpurifier.x7sm)
 -  Xiaomi Mi Air Humidifier
 -  Xiaomi Aqara Camera

--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -69,6 +69,7 @@ _MAPPING_MB4 = {
 }
 
 # https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:air-purifier:0000A007:zhimi-va2:2
+# https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:air-purifier:0000A007:zhimi-mb5:1
 _MAPPING_VA2 = {
     # Air Purifier
     "power": {"siid": 2, "piid": 1},
@@ -109,6 +110,7 @@ _MAPPINGS = {
     "zhimi.airpurifier.vb2": _MAPPING,  # airpurifier proh
     "zhimi.airpurifier.mb4": _MAPPING_MB4,  # airpurifier 3c
     "zhimi.airp.mb4a": _MAPPING_MB4,  # airpurifier 3c
+    "zhimi.airp.mb5": _MAPPING_VA2,  # airpurifier 4 
     "zhimi.airp.va2": _MAPPING_VA2,  # airpurifier 4 pro
 }
 
@@ -254,7 +256,7 @@ class AirPurifierMiotStatus(DeviceStatus):
 
         value = self.data.get("led_brightness")
         if value is not None:
-            if self.model == "zhimi.airp.va2":
+            if self.model == "zhimi.airp.va2" or self.model == "zhimi.airp.mb5":
                 value = 2 - value
             try:
                 return LedBrightness(value)
@@ -510,7 +512,7 @@ class AirPurifierMiot(MiotDevice):
             )
 
         value = brightness.value
-        if self.model == "zhimi.airp.va2" and value:
+        if (self.model == "zhimi.airp.va2" or self.model == "zhimi.airp.mb5") and value:
             value = 2 - value
         return self.set_property("led_brightness", value)
 

--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -110,7 +110,7 @@ _MAPPINGS = {
     "zhimi.airpurifier.vb2": _MAPPING,  # airpurifier proh
     "zhimi.airpurifier.mb4": _MAPPING_MB4,  # airpurifier 3c
     "zhimi.airp.mb4a": _MAPPING_MB4,  # airpurifier 3c
-    "zhimi.airp.mb5": _MAPPING_VA2,  # airpurifier 4 
+    "zhimi.airp.mb5": _MAPPING_VA2,  # airpurifier 4
     "zhimi.airp.va2": _MAPPING_VA2,  # airpurifier 4 pro
 }
 

--- a/miio/airpurifier_miot.py
+++ b/miio/airpurifier_miot.py
@@ -256,7 +256,7 @@ class AirPurifierMiotStatus(DeviceStatus):
 
         value = self.data.get("led_brightness")
         if value is not None:
-            if self.model == "zhimi.airp.va2" or self.model == "zhimi.airp.mb5":
+            if self.model in ("zhimi.airp.va2", "zhimi.airp.mb5"):
                 value = 2 - value
             try:
                 return LedBrightness(value)
@@ -512,7 +512,7 @@ class AirPurifierMiot(MiotDevice):
             )
 
         value = brightness.value
-        if (self.model == "zhimi.airp.va2" or self.model == "zhimi.airp.mb5") and value:
+        if self.model in ("zhimi.airp.va2", "zhimi.airp.mb5") and value:
             value = 2 - value
         return self.set_property("led_brightness", value)
 

--- a/miio/tests/test_airpurifier_miot.py
+++ b/miio/tests/test_airpurifier_miot.py
@@ -304,6 +304,7 @@ class DummyAirPurifierMiotVA2(DummyAirPurifierMiot):
         self.state = _INITIAL_STATE_VA2
         super().__init__(*args, **kwargs)
 
+
 class DummyAirPurifierMiotMB5(DummyAirPurifierMiot):
     def __init__(self, *args, **kwargs):
         self._model = "zhimi.airp.mb5"

--- a/miio/tests/test_airpurifier_miot.py
+++ b/miio/tests/test_airpurifier_miot.py
@@ -304,6 +304,12 @@ class DummyAirPurifierMiotVA2(DummyAirPurifierMiot):
         self.state = _INITIAL_STATE_VA2
         super().__init__(*args, **kwargs)
 
+class DummyAirPurifierMiotMB5(DummyAirPurifierMiot):
+    def __init__(self, *args, **kwargs):
+        self._model = "zhimi.airp.mb5"
+        self.state = _INITIAL_STATE_VA2
+        super().__init__(*args, **kwargs)
+
 
 @pytest.fixture(scope="function")
 def airpurifierVA2(request):


### PR DESCRIPTION
This fixes #1352
https://home.miot-spec.com/spec/zhimi.airp.mb5

VA2 code shares everything that python-miio needs.