### PR TITLE
Catch exceptions during quirk handling

### DIFF
--- a/miio/protocol.py
+++ b/miio/protocol.py
@@ -190,8 +190,8 @@ class EncryptionAdapter(Adapter):
         ]
 
         for i, quirk in enumerate(decrypted_quirks):
-            decoded = quirk(decrypted).decode("utf-8")
             try:
+                decoded = quirk(decrypted).decode("utf-8")
                 return json.loads(decoded)
             except Exception as ex:
                 # log the error when decrypted bytes couldn't be loaded


### PR DESCRIPTION
Quirk handling causes an exception if the payload cannot be utf-8 decoded.
This wraps all exceptions (instead of just those happening during json decoding) inside `PayloadDecodeException` for easier downstream handling.

Reported at https://github.com/home-assistant/core/issues/61482