### PR TITLE
Retry on error code -9999

### DIFF
--- a/miio/miioprotocol.py
+++ b/miio/miioprotocol.py
@@ -269,7 +269,8 @@ class MiIOProtocol:
 
     def _handle_error(self, error):
         """Raise exception based on the given error code."""
-        if "code" in error and error["code"] == -30001:
+        RECOVERABLE_ERRORS = [-30001, -9999]
+        if "code" in error and error["code"] in RECOVERABLE_ERRORS:
             raise RecoverableError(error)
         raise DeviceError(error)
 

--- a/miio/tests/test_protocol.py
+++ b/miio/tests/test_protocol.py
@@ -75,8 +75,8 @@ def test_request_extra_params(proto):
     assert req["sid"] == 1234
 
 
-def test_device_error_handling(proto: MiIOProtocol):
-    retry_error = -30001
+@pytest.mark.parametrize("retry_error", [-30001, -9999])
+def test_device_error_handling(proto: MiIOProtocol, retry_error):
     with pytest.raises(RecoverableError):
         proto._handle_error({"code": retry_error})
 


### PR DESCRIPTION
Error code -9999 is a common occurence when sending invalid command to a device,
but which also seems to be recoverable error on others.

This PR changes the protocol behavior by retrying when -9999 response is received.

Fixes #757