### PR TITLE
Add Vacuum protocol for enforcing interface among vacuum integrations

### DIFF
--- a/miio/device.py
+++ b/miio/device.py
@@ -3,6 +3,7 @@ import logging
 import warnings
 from enum import Enum
 from pprint import pformat as pf
+from typing import _ProtocolMeta  # type: ignore[attr-defined]
 from typing import Any, Dict, List, Optional  # noqa: F401
 
 import click
@@ -47,7 +48,16 @@ class DeviceStatus:
         return s
 
 
-class Device(metaclass=DeviceGroupMeta):
+class _CombinedMeta(DeviceGroupMeta, _ProtocolMeta):
+    """Combine typing._ProtocolMeta and our own meta class to allow inheriting from
+    interfaces.
+
+    This is necessary as typing.Protocol defines its own metaclass causing a metaclass
+    conflict with the DeviceGroupMeta due to differing base classes.
+    """
+
+
+class Device(metaclass=_CombinedMeta):
     """Base class for all device implementations.
 
     This is the main class providing the basic protocol handling for devices using the

--- a/miio/integrations/vacuum/roborock/vacuum.py
+++ b/miio/integrations/vacuum/roborock/vacuum.py
@@ -22,6 +22,7 @@ from miio.click_common import (
 )
 from miio.device import Device, DeviceInfo
 from miio.exceptions import DeviceException, DeviceInfoUnavailableException
+from miio.interfaces import Vacuum
 
 from .vacuumcontainers import (
     CarpetModeStatus,
@@ -169,7 +170,7 @@ SUPPORTED_MODELS = [
 ]
 
 
-class RoborockVacuum(Device):
+class RoborockVacuum(Device, Vacuum):
     """Main class for roborock vacuums (roborock.vacuum.*)."""
 
     _supported_models = SUPPORTED_MODELS

--- a/miio/interfaces/__init__.py
+++ b/miio/interfaces/__init__.py
@@ -1,0 +1,2 @@
+# flake8: noqa
+from .vacuum import Vacuum

--- a/miio/interfaces/vacuum.py
+++ b/miio/interfaces/vacuum.py
@@ -1,0 +1,32 @@
+from typing import Dict, Protocol, runtime_checkable
+
+from miio import DeviceStatus
+
+FanspeedPresets = Dict[str, int]
+
+
+@runtime_checkable
+class Vacuum(Protocol):
+    def start(self):
+        """Start vacuuming."""
+
+    def pause(self):
+        """Pause vacuuming."""
+
+    def stop(self):
+        """Stop vacuuming."""
+
+    def home(self):
+        """Return back to base."""
+
+    def find(self):
+        """Request vacuum to play a sound to reveal its location."""
+
+    def status(self) -> DeviceStatus:
+        """Return device status."""
+
+    def set_fan_speed(self, int):
+        """Set fan speed."""
+
+    def fan_speed_presets(self) -> FanspeedPresets:
+        """Return available fan speed presets."""


### PR DESCRIPTION
This is a first draft towards enforcing interfaces among vacuum integrations,
aimed to consolidate them to allow easier downstream support no matter implementation details.

Open questions:
- [ ] Is this even a sane approach, wrt. simply creating an abstract base-class to inherit from
- [ ] Status containers need their own interface
- [ ] Find out a better way than importing typing internals for metaclass handling
- [ ] Tests