### PR TITLE
Add support for dreame.vacuum.p2150o

### DIFF
--- a/miio/integrations/vacuum/dreame/dreamevacuum_miot.py
+++ b/miio/integrations/vacuum/dreame/dreamevacuum_miot.py
@@ -20,7 +20,7 @@ DREAME_D9 = "dreame.vacuum.p2009"
 DREAME_Z10_PRO = "dreame.vacuum.p2028"
 DREAME_MOP_2_PRO_PLUS = "dreame.vacuum.p2041o"
 DREAME_MOP_2_ULTRA = "dreame.vacuum.p2150a"
-
+DREAME_MOP_2 = "dreame.vacuum.p2150o"
 
 _DREAME_1C_MAPPING: MiotMapping = {
     # https://home.miot-spec.com/spec/dreame.vacuum.mc1808
@@ -74,6 +74,7 @@ _DREAME_F9_MAPPING: MiotMapping = {
     # https://home.miot-spec.com/spec/dreame.vacuum.p2028
     # https://home.miot-spec.com/spec/dreame.vacuum.p2041o
     # https://home.miot-spec.com/spec/dreame.vacuum.p2150a
+    # https://home.miot-spec.com/spec/dreame.vacuum.p2150o
     "battery_level": {"siid": 3, "piid": 1},
     "charging_state": {"siid": 3, "piid": 2},
     "device_fault": {"siid": 2, "piid": 2},
@@ -121,6 +122,7 @@ MIOT_MAPPING: Dict[str, MiotMapping] = {
     DREAME_Z10_PRO: _DREAME_F9_MAPPING,
     DREAME_MOP_2_PRO_PLUS: _DREAME_F9_MAPPING,
     DREAME_MOP_2_ULTRA: _DREAME_F9_MAPPING,
+    DREAME_MOP_2: _DREAME_F9_MAPPING,
 }
 
 
@@ -196,6 +198,7 @@ def _get_cleaning_mode_enum_class(model):
         DREAME_Z10_PRO,
         DREAME_MOP_2_PRO_PLUS,
         DREAME_MOP_2_ULTRA,
+        DREAME_MOP_2
     ):
         return CleaningModeDreameF9
     return None

--- a/miio/integrations/vacuum/dreame/dreamevacuum_miot.py
+++ b/miio/integrations/vacuum/dreame/dreamevacuum_miot.py
@@ -198,7 +198,7 @@ def _get_cleaning_mode_enum_class(model):
         DREAME_Z10_PRO,
         DREAME_MOP_2_PRO_PLUS,
         DREAME_MOP_2_ULTRA,
-        DREAME_MOP_2
+        DREAME_MOP_2,
     ):
         return CleaningModeDreameF9
     return None


### PR DESCRIPTION
[米家集尘扫拖机器人](https://home.miot-spec.com/s/dreame.vacuum.p2150o) and [Mi Robot Vacuum-Mop 2 Ultra](https://home.miot-spec.com/s/dreame.vacuum.p2150a) have almost the same hardware. It can work fine with `DREAME_F9_MAPPING` by my test.