### PR TITLE
Add device_id property to Device class

### DIFF
--- a/miio/device.py
+++ b/miio/device.py
@@ -169,7 +169,7 @@ class Device(metaclass=DeviceGroupMeta):
             ) from ex
 
     @property
-    def device_id(self):
+    def device_id(self) -> int:
         """Return device id (did), if available."""
         if not self._protocol._device_id:
             self._info = self.info()

--- a/miio/device.py
+++ b/miio/device.py
@@ -171,7 +171,7 @@ class Device(metaclass=DeviceGroupMeta):
     @property
     def device_id(self):
         """Return device id (did), if available."""
-        if self._protocol._device_id == b"":
+        if not self._protocol._device_id:
             self._info = self.info()
         return int.from_bytes(self._protocol._device_id, byteorder="big")
 

--- a/miio/device.py
+++ b/miio/device.py
@@ -169,6 +169,13 @@ class Device(metaclass=DeviceGroupMeta):
             ) from ex
 
     @property
+    def device_id(self):
+        """Return device id (did), if available."""
+        if self._protocol._device_id == b"":
+            self._info = self.info()
+        return int.from_bytes(self._protocol._device_id, byteorder="big")
+
+    @property
     def raw_id(self) -> int:
         """Return the last used protocol sequence id."""
         return self._protocol.raw_id

--- a/miio/device.py
+++ b/miio/device.py
@@ -171,9 +171,9 @@ class Device(metaclass=DeviceGroupMeta):
     @property
     def device_id(self):
         """Return device id (did), if available."""
-        if self._protocol._device_id == b"":
+        if self._protocol.device_id == b"":
             self._info = self.info()
-        return int.from_bytes(self._protocol._device_id, byteorder="big")
+        return int.from_bytes(self._protocol.device_id, byteorder="big")
 
     @property
     def raw_id(self) -> int:

--- a/miio/device.py
+++ b/miio/device.py
@@ -172,7 +172,7 @@ class Device(metaclass=DeviceGroupMeta):
     def device_id(self) -> int:
         """Return device id (did), if available."""
         if not self._protocol._device_id:
-            self._info = self.info()
+            self.send_handshake()
         return int.from_bytes(self._protocol._device_id, byteorder="big")
 
     @property

--- a/miio/device.py
+++ b/miio/device.py
@@ -171,9 +171,9 @@ class Device(metaclass=DeviceGroupMeta):
     @property
     def device_id(self):
         """Return device id (did), if available."""
-        if self._protocol.device_id == b"":
+        if self._protocol._device_id == b"":
             self._info = self.info()
-        return int.from_bytes(self._protocol.device_id, byteorder="big")
+        return int.from_bytes(self._protocol._device_id, byteorder="big")
 
     @property
     def raw_id(self) -> int:

--- a/miio/miioprotocol.py
+++ b/miio/miioprotocol.py
@@ -47,8 +47,8 @@ class MiIOProtocol:
 
         self._discovered = False
         # these come from the device, but we initialize them here to make mypy happy
-        self.device_id = bytes()
         self._device_ts: datetime = datetime.utcnow()
+        self._device_id = bytes()
 
     def send_handshake(self, *, retry_count=3) -> Message:
         """Send a handshake to the device.
@@ -74,7 +74,7 @@ class MiIOProtocol:
             raise DeviceException("Unable to discover the device %s" % self.ip)
 
         header = m.header.value
-        self.device_id = header.device_id
+        self._device_id = header.device_id
         self._device_ts = header.ts
         self._discovered = True
 
@@ -82,7 +82,7 @@ class MiIOProtocol:
             _LOGGER.debug(m)
         _LOGGER.debug(
             "Discovered %s with ts: %s, token: %s",
-            binascii.hexlify(self.device_id).decode(),
+            binascii.hexlify(self._device_id).decode(),
             self._device_ts,
             codecs.encode(m.checksum, "hex"),
         )
@@ -166,7 +166,7 @@ class MiIOProtocol:
         header = {
             "length": 0,
             "unknown": 0x00000000,
-            "device_id": self.device_id,
+            "device_id": self._device_id,
             "ts": send_ts,
         }
 

--- a/miio/miioprotocol.py
+++ b/miio/miioprotocol.py
@@ -47,8 +47,8 @@ class MiIOProtocol:
 
         self._discovered = False
         # these come from the device, but we initialize them here to make mypy happy
+        self.device_id = bytes()
         self._device_ts: datetime = datetime.utcnow()
-        self._device_id = bytes()
 
     def send_handshake(self, *, retry_count=3) -> Message:
         """Send a handshake to the device.
@@ -74,7 +74,7 @@ class MiIOProtocol:
             raise DeviceException("Unable to discover the device %s" % self.ip)
 
         header = m.header.value
-        self._device_id = header.device_id
+        self.device_id = header.device_id
         self._device_ts = header.ts
         self._discovered = True
 
@@ -82,7 +82,7 @@ class MiIOProtocol:
             _LOGGER.debug(m)
         _LOGGER.debug(
             "Discovered %s with ts: %s, token: %s",
-            binascii.hexlify(self._device_id).decode(),
+            binascii.hexlify(self.device_id).decode(),
             self._device_ts,
             codecs.encode(m.checksum, "hex"),
         )
@@ -166,7 +166,7 @@ class MiIOProtocol:
         header = {
             "length": 0,
             "unknown": 0x00000000,
-            "device_id": self._device_id,
+            "device_id": self.device_id,
             "ts": send_ts,
         }
 

--- a/miio/tests/test_device.py
+++ b/miio/tests/test_device.py
@@ -59,6 +59,18 @@ def test_unavailable_device_info_raises(mocker):
     assert send.call_count == 1
 
 
+def test_device_id_handshake(mocker):
+    """Make sure send_handshake() gets called if did is unknown."""
+    handshake = mocker.patch("miio.Device.send_handshake")
+    _ = mocker.patch("miio.Device.send")
+
+    d = Device("127.0.0.1", "68ffffffffffffffffffffffffffffff")
+
+    d.device_id
+
+    handshake.assert_called()
+
+
 def test_model_autodetection(mocker):
     """Make sure info() gets called if the model is unknown."""
     info = mocker.patch("miio.Device._fetch_info")

--- a/miio/tests/test_device.py
+++ b/miio/tests/test_device.py
@@ -71,6 +71,19 @@ def test_device_id_handshake(mocker):
     handshake.assert_called()
 
 
+def test_device_id(mocker):
+    """Make sure send_handshake() does not get called if did is already known."""
+    handshake = mocker.patch("miio.Device.send_handshake")
+    _ = mocker.patch("miio.Device.send")
+
+    d = Device("127.0.0.1", "68ffffffffffffffffffffffffffffff")
+    d._protocol._device_id = b"12345678"
+
+    d.device_id
+
+    handshake.assert_not_called()
+
+
 def test_model_autodetection(mocker):
     """Make sure info() gets called if the model is unknown."""
     info = mocker.patch("miio.Device._fetch_info")


### PR DESCRIPTION
This PR adds new `device_id` property to `Device` class.
The `device_id` is part of the handshake reply and thus available also on devices with unknown tokens (i.e., it can be useful for use cases where the token is extract from the cloud or other external sources).

This is also needed for push server implementation: https://github.com/rytilahti/python-miio/pull/1288