### PR TITLE
Mark roborock q5 (roborock.vacuum.a34) as supported

### DIFF
--- a/miio/integrations/vacuum/roborock/vacuum.py
+++ b/miio/integrations/vacuum/roborock/vacuum.py
@@ -153,6 +153,7 @@ ROCKROBO_T7 = "roborock.vacuum.a11"  # cn s7
 ROCKROBO_T7S = "roborock.vacuum.a14"
 ROCKROBO_T7SPLUS = "roborock.vacuum.a23"
 ROCKROBO_S7_MAXV = "roborock.vacuum.a27"
+ROCKROBO_Q5 = "roborock.vacuum.a34"
 ROCKROBO_G10S = "roborock.vacuum.a46"
 ROCKROBO_S7 = "roborock.vacuum.a15"
 ROCKROBO_S6_MAXV = "roborock.vacuum.a10"
@@ -174,6 +175,7 @@ SUPPORTED_MODELS = [
     ROCKROBO_T7SPLUS,
     ROCKROBO_S7,
     ROCKROBO_S7_MAXV,
+    ROCKROBO_Q5,
     ROCKROBO_G10S,
     ROCKROBO_S6_MAXV,
     ROCKROBO_E2,


### PR DESCRIPTION
Fixes #1444