### PR TITLE
Disable fail-fast on CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev", "pypy3"]
         os: [ubuntu-latest, macos-latest, windows-latest]


### PR DESCRIPTION
Mac builds (and potentially windows, too) on 3.11-dev are failing with the error shown below, so this disables `fail-fast` to avoid canceling the rest of the tests. This is necessary as the master is a protected branch that requires that specific tests are passing prior merging.

```
Command ['/Users/runner/Library/Caches/pypoetry/virtualenvs/python-miio-T8lMymkM-py3.11/bin/pip', 'install', '--no-deps', '/Users/runner/Library/Caches/pypoetry/artifacts/be/39/d8/f0989f51991610d463a30d1624ab1eb3f110ba5d028fc976d08166e36d/imagesize-1.3.0-py2.py3-none-any.whl'] errored with the following return code 1, and output: 
Processing /Users/runner/Library/Caches/pypoetry/artifacts/be/39/d8/f0989f51991610d463a30d1624ab1eb3f110ba5d028fc976d08166e36d/imagesize-1.3.0-py2.py3-none-any.whl
Installing collected packages: imagesize
Successfully installed imagesize
Traceback (most recent call last):
  File "/Users/runner/Library/Caches/pypoetry/virtualenvs/python-miio-T8lMymkM-py3.11/bin/pip", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/runner/Library/Caches/pypoetry/virtualenvs/python-miio-T8lMymkM-py3.11/lib/python3.11/site-packages/pip/_internal/cli/main.py", line 70, in main
    return command.main(cmd_args)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/pypoetry/virtualenvs/python-miio-T8lMymkM-py3.11/lib/python3.11/site-packages/pip/_internal/cli/base_command.py", line 101, in main
    return self._main(args)
           ^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/pypoetry/virtualenvs/python-miio-T8lMymkM-py3.11/lib/python3.11/site-packages/pip/_internal/cli/base_command.py", line 223, in _main
    self.handle_pip_version_check(options)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/pypoetry/virtualenvs/python-miio-T8lMymkM-py3.11/lib/python3.11/site-packages/pip/_internal/cli/req_command.py", line 144, in handle_pip_version_check
    session = self._build_session(
              ^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/pypoetry/virtualenvs/python-miio-T8lMymkM-py3.11/lib/python3.11/site-packages/pip/_internal/cli/req_command.py", line 89, in _build_session
    session = PipSession(
              ^^^^^^^^^^^
  File "/Users/runner/Library/Caches/pypoetry/virtualenvs/python-miio-T8lMymkM-py3.11/lib/python3.11/site-packages/pip/_internal/network/session.py", line 282, in __init__
    self.headers["User-Agent"] = user_agent()
                                 ^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/pypoetry/virtualenvs/python-miio-T8lMymkM-py3.11/lib/python3.11/site-packages/pip/_internal/network/session.py", line 157, in user_agent
    setuptools_dist = get_default_environment().get_distribution("setuptools")
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/pypoetry/virtualenvs/python-miio-T8lMymkM-py3.11/lib/python3.11/site-packages/pip/_internal/metadata/importlib/_envs.py", line 163, in get_distribution
    return next(matches, None)
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/pypoetry/virtualenvs/python-miio-T8lMymkM-py3.11/lib/python3.11/site-packages/pip/_internal/metadata/importlib/_envs.py", line 158, in <genexpr>
    matches = (
              ^
  File "/Users/runner/Library/Caches/pypoetry/virtualenvs/python-miio-T8lMymkM-py3.11/lib/python3.11/site-packages/pip/_internal/metadata/base.py", line 485, in iter_all_distributions
    for dist in self._iter_distributions():
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/pypoetry/virtualenvs/python-miio-T8lMymkM-py3.11/lib/python3.11/site-packages/pip/_internal/metadata/importlib/_envs.py", line 150, in _iter_distributions
    yield from finder.find(location)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/pypoetry/virtualenvs/python-miio-T8lMymkM-py3.11/lib/python3.11/site-packages/pip/_internal/metadata/importlib/_envs.py", line 54, in find
    for dist, info_location in self._find_impl(location):
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/pypoetry/virtualenvs/python-miio-T8lMymkM-py3.11/lib/python3.11/site-packages/pip/_internal/metadata/importlib/_envs.py", line 42, in _find_impl
    normalized_name = canonicalize_name(get_dist_name(dist))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/Library/Caches/pypoetry/virtualenvs/python-miio-T8lMymkM-py3.11/lib/python3.11/site-packages/pip/_vendor/packaging/utils.py", line 34, in canonicalize_name
    value = _canonicalize_regex.sub("-", name).lower()
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: expected string or bytes-like object, got 'NoneType'
```