### PR TITLE
Improve gateway get_devices_from_dict

### DIFF
--- a/miio/gateway/gateway.py
+++ b/miio/gateway/gateway.py
@@ -223,23 +223,32 @@ class Gateway(Device):
 
         # find the gateway
         for device in device_dict:
-            if device["mac"] == self.mac:
-                self._did = device["did"]
-                break
+            if device["did"] == str(self.device_id):
+                if device["mac"] == self.mac:
+                    found_gateway = True
+                    break
+                _LOGGER.error(
+                    "Mac and device id of gateway with ip '%s', mac '%s', did '%i', model '%s' did not match in the cloud device list response",
+                    self.ip,
+                    self.mac,
+                    self.device_id,
+                    self.model,
+                )
 
         # check if the gateway is found
-        if self._did is None:
+        if not found_gateway:
             _LOGGER.error(
-                "Could not find gateway with ip '%s', mac '%s', model '%s' in the cloud device list response",
+                "Could not find gateway with ip '%s', mac '%s', did '%i', model '%s' in the cloud device list response",
                 self.ip,
                 self.mac,
+                self.device_id,
                 self.model,
             )
             return self._devices
 
         # find the subdevices belonging to this gateway
         for device in device_dict:
-            if device.get("parent_id") == self._did:
+            if device.get("parent_id") == str(self.device_id):
                 # Match 'model' to get the type_id
                 model_info = self.match_zigbee_model(device["model"], device["did"])
 

--- a/miio/gateway/gateway.py
+++ b/miio/gateway/gateway.py
@@ -222,6 +222,7 @@ class Gateway(Device):
         self._devices = {}
 
         # find the gateway
+        found_gateway = False
         for device in device_dict:
             if device["did"] == str(self.device_id):
                 if device["mac"] == self.mac:

--- a/miio/gateway/gateway.py
+++ b/miio/gateway/gateway.py
@@ -109,7 +109,6 @@ class Gateway(Device):
         self._devices: Dict[str, SubDevice] = {}
         self._info = None
         self._subdevice_model_map = None
-        self._did = None
 
     def _get_unknown_model(self):
         for model_info in self.subdevice_model_map:


### PR DESCRIPTION
Improve the get_devices_from_dict function of the gateway:
Now the device_id from direct communication is checked against the device_id received from the cloud.
Besides the already presend mac matching.
The _did is removed from the gateway since it is the same as the device_id which was already presend.