### PR TITLE
Disable 3.11-dev builds on mac and windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,10 @@ jobs:
             os: macos-latest
           - python-version: pypy3
             os: windows-latest
+          - python-version: 3.11-dev
+            os: macos-latest
+          - python-version: 3.11-dev
+            os: windows-latest
 
     steps:
       - uses: "actions/checkout@v2"


### PR DESCRIPTION
Tests on mac and windows platforms for 3.11 are flaky, so this PR disables them for the time being. Related to #1450