### PR TITLE
Build readthedocs on python3.9

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,8 +1,9 @@
-build:
-  image: latest
+version: 2
 
 python:
-  version: 3.7
-  pip_install: true
-  extra_requirements:
-    - docs
+  version: "3.9"
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,3 +7,6 @@ python:
       path: .
       extra_requirements:
         - docs
+
+sphinx:
+   configuration: docs/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,12 +1,16 @@
 version: 2
 
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
 python:
-  version: "3.9"
   install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
+  - method: pip
+    path: .
+    extra_requirements:
+    - docs
 
 sphinx:
    configuration: docs/conf.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,7 +73,7 @@ release = ""
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
Also, updates to use the v2 config file: https://docs.readthedocs.io/en/stable/config-file/v2.html