### PR TITLE
fix bright level in set_led_brightness for miot purifiers

### DIFF
--- a/miio/integrations/airpurifier/zhimi/airpurifier_miot.py
+++ b/miio/integrations/airpurifier/zhimi/airpurifier_miot.py
@@ -692,7 +692,7 @@ class AirPurifierMiot(MiotDevice):
         if (
             self.model
             in ("zhimi.airp.va2", "zhimi.airp.mb5", "zhimi.airp.vb4", "zhimi.airp.rmb1")
-            and value
+            and value is not None
         ):
             value = 2 - value
         return self.set_property("led_brightness", value)

--- a/miio/integrations/airpurifier/zhimi/tests/test_airpurifier_miot.py
+++ b/miio/integrations/airpurifier/zhimi/tests/test_airpurifier_miot.py
@@ -350,6 +350,19 @@ class TestAirPurifierVA2(TestCase):
         )
         assert status.filter_type == FilterType.AntiBacterial
 
+    def test_set_led_brightness(self):
+        def led_brightness():
+            return self.device.status().led_brightness
+
+        self.device.set_led_brightness(LedBrightness.Bright)
+        assert led_brightness() == LedBrightness.Bright
+
+        self.device.set_led_brightness(LedBrightness.Dim)
+        assert led_brightness() == LedBrightness.Dim
+
+        self.device.set_led_brightness(LedBrightness.Off)
+        assert led_brightness() == LedBrightness.Off
+
     def test_set_anion(self):
         def anion():
             return self.device.status().anion


### PR DESCRIPTION
For MIOT air purifiers the led brightness value is 0 for the Bright level and due to wrong check the Bright level could not be set. This PR fixes the check and adds tests to cover this device type.