### PR TITLE
Add missing functools.wraps() for @command decorated methods

### DIFF
--- a/miio/click_common.py
+++ b/miio/click_common.py
@@ -167,6 +167,7 @@ class DeviceGroup(click.MultiCommand):
             self.kwargs.setdefault("help", self.func.__doc__)
 
             def _autodetect_model_if_needed(func):
+                @wraps(func)
                 def _wrap(self, *args, **kwargs):
                     skip_autodetect = func._device_group_command.kwargs.pop(
                         "skip_autodetect", False


### PR DESCRIPTION
This makes defined methods show a proper function signature instead
of the repr of the wrapper.

Example:

`<function miio.click_common.DeviceGroup.Command.__call__.<locals>._autodetect_model_if_needed.<locals>._wrap(self, *args, **kwargs)>`

becomes

`<function miio.integrations.vacuum.roborock.vacuum.RoborockVacuum.status(self) -> miio.integrations.vacuum.roborock.vacuumcontainers.VacuumStatus>`