### PR TITLE
Add smb share feature for Chuangmi Camera

### DIFF
--- a/miio/chuangmi_camera.py
+++ b/miio/chuangmi_camera.py
@@ -379,7 +379,7 @@ class ChuangmiCamera(Device):
     ):
         """Set NAS configuration."""
 
-        params: dict[str, Any] = {
+        params: Dict[str, Any] = {
             "state": state,
             "sync_interval": sync_interval,
             "video_retention_time": video_retention_time,

--- a/miio/chuangmi_camera.py
+++ b/miio/chuangmi_camera.py
@@ -1,11 +1,10 @@
 """Xiaomi Chuangmi camera (chuangmi.camera.ipc009, ipc013, ipc019, 038a2) support."""
 
 import enum
-import logging
-from typing import Any, Dict
-
 import ipaddress
+import logging
 import socket
+from typing import Any, Dict
 from urllib.parse import urlparse
 
 import click

--- a/miio/chuangmi_camera.py
+++ b/miio/chuangmi_camera.py
@@ -396,7 +396,7 @@ class ChuangmiCamera(Device):
                 "type": 1,
                 "name": share.hostname,
                 "addr": addr,
-                "dir": share.path.lstrip('/'),
+                "dir": share.path.lstrip("/"),
                 "group": "WORKGROUP",
                 "user": share.username,
                 "pass": share.password,

--- a/miio/chuangmi_camera.py
+++ b/miio/chuangmi_camera.py
@@ -379,7 +379,7 @@ class ChuangmiCamera(Device):
     ):
         """Set NAS configuration."""
 
-        params = {
+        params: dict[str, Any] = {
             "state": state,
             "sync_interval": sync_interval,
             "video_retention_time": video_retention_time,

--- a/miio/chuangmi_camera.py
+++ b/miio/chuangmi_camera.py
@@ -366,7 +366,7 @@ class ChuangmiCamera(Device):
 
     @command(
         click.argument("state", type=EnumType(NASState)),
-        click.argument("share", type=click.STRING),
+        click.argument("share", type=str),
         click.argument("sync-interval", type=EnumType(NASSyncInterval)),
         click.argument("video-retention-time", type=EnumType(NASVideoRetentionTime)),
         default_output=format_output("Setting NAS config to '{state.name}'"),

--- a/miio/chuangmi_camera.py
+++ b/miio/chuangmi_camera.py
@@ -379,14 +379,20 @@ class ChuangmiCamera(Device):
         video_retention_time: NASVideoRetentionTime = NASVideoRetentionTime.Week,
     ):
         """Set NAS configuration."""
-        share_obj = None
+
+        params = {
+            "state": state,
+            "sync_interval": sync_interval,
+            "video_retention_time": video_retention_time,
+        }
+
         share = urlparse(share)
         if share.scheme == "smb":
             ip = socket.gethostbyname(share.hostname)
             reversed_ip = ".".join(reversed(ip.split(".")))
             addr = int(ipaddress.ip_address(reversed_ip))
 
-            share_obj = {
+            params["share"] = {
                 "type": 1,
                 "name": share.hostname,
                 "addr": addr,
@@ -395,13 +401,5 @@ class ChuangmiCamera(Device):
                 "user": share.username,
                 "pass": share.password,
             }
-        
-        params = {
-            "state": state,
-            "sync_interval": sync_interval,
-            "video_retention_time": video_retention_time,
-        }
-        if share_obj != None:
-            params["share"] = share_obj
-        
+
         return self.send("nas_set_config", params)


### PR DESCRIPTION
The Xiaomi App have limitation in setting NAS location, it has to be in the local network. It discover the NAS then list them then let me choose. I have a NAS across the VPN and actually it's accessible, but not able to be discovered and set.
This function can help people config NAS outside the local network.

Example:
```shell
miiocli chuangmicamera --ip 192.168.60.11 --token xxxxxxxxxx set_nas_config on "smb://user:pass@192.168.40.2/camera" realtime quarter
```

If the `share` param left empty, It will keep the last config.

Tested on `chuangmi.camera.ipc013`