### PR TITLE
Add yeelink.light.strip6 support

### DIFF
--- a/miio/integrations/light/yeelight/specs.yaml
+++ b/miio/integrations/light/yeelight/specs.yaml
@@ -169,6 +169,10 @@ yeelink.light.strip4:
   night_light: False
   color_temp: [2700, 6500]
   supports_color: True
+yeelink.light.strip6:
+  night_light: False
+  color_temp: [2700, 6500]
+  supports_color: True
 yeelink.bhf_light.v2:
   night_light: False
   color_temp: [0, 0]


### PR DESCRIPTION
Model: yeelink.light.strip6                               
Hardware version: esp32                                              
Firmware version: 2.0.6_0009

Fixes #1483