### PR TITLE
Implement introspectable sensors

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -186,6 +186,11 @@ using :meth:`~miio.device.Device.sensors`.
         pass
 
 
+Note, that all keywords not defined in the descriptor class will be contained
+inside :attr:`~miio.descriptors.SensorDescriptor.extras` variable.
+This information can be used to pass information to the downstream users,
+see the source of :class:`miio.powerstrip.PowerStripStatus` for example of how to pass
+device class information to Home Assistant.
 
 .. _adding_tests:
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -114,16 +114,17 @@ downloading the description files and parsing them into more understandable form
 Development checklist
 ---------------------
 
-1. All device classes are derived from either :class:`miio.device.Device` (for MiIO)
-   or :class:`miio.miot_device.MiotDevice` (for MiOT) (:ref:`minimal_example`).
-2. All commands and their arguments should be decorated with `@command` decorator,
+1. All device classes are derived from either :class:`~miio.device.Device` (for MiIO)
+   or :class:`~miio.miot_device.MiotDevice` (for MiOT) (:ref:`minimal_example`).
+2. All commands and their arguments should be decorated with :meth:`@command <miio.click_common.command>` decorator,
    which will make them accessible to `miiocli` (:ref:`miiocli`).
-3. All implementations must either include a model-keyed ``_mappings`` list (for MiOT),
-   or define ``Device._supported_models`` variable in the class (for MiIO).
-   listing the known models (as reported by `info()`).
-4. Status containers is derived from `DeviceStatus` class and all properties should
-   have type annotations for their return values.
-5. Creating tests (:ref:`adding_tests`).
+3. All implementations must either include a model-keyed :obj:`~miio.device.Device._mappings` list (for MiOT),
+   or define :obj:`~miio.device.Device._supported_models` variable in the class (for MiIO).
+   listing the known models (as reported by :meth:`~miio.device.Device.info()`).
+4. Status containers is derived from :class:`~miio.devicestatus.DeviceStatus` class and all properties should
+   have type annotations for their return values. The information that can be displayed
+   directly to users should be decorated using `@sensor` to make them discoverable (:ref:`status_containers`).
+5. Add tests at least for the status container handling (:ref:`adding_tests`).
 6. Updating documentation is generally not needed as the API documentation
    will be generated automatically.
 
@@ -160,12 +161,29 @@ Produces a command ``miiocli example`` command requiring an argument
 that is passed to the method as string, and an optional integer argument.
 
 
+.. _status_containers:
+
 Status containers
 ~~~~~~~~~~~~~~~~~
 
 The status container (returned by `status()` method of the device class)
 is the main way for library users to access properties exposed by the device.
-The status container should inherit :class:`miio.device.DeviceStatus` to ensure a generic :meth:`__repr__`.
+The status container should inherit :class:`~miio.devicestatus.DeviceStatus`.
+This ensures a generic :meth:`__repr__` that is helpful for debugging,
+and allows defining properties that are especially interesting for end users.
+
+The properties can be decorated with :meth:`@sensor <miio.devicestatus.sensor>` decorator to
+define meta information that enables introspection and programatic creation of user interface elements.
+This will create :class:`~miio.descriptors.SensorDescriptor` objects that are accessible
+using :meth:`~miio.device.Device.sensors`.
+
+.. code-block:: python
+
+    @property
+    @sensor(name="Voltage", unit="V")
+    def voltage(self) -> Optional[float]:
+        """Return the voltage, if available."""
+        pass
 
 
 

--- a/miio/__init__.py
+++ b/miio/__init__.py
@@ -7,7 +7,8 @@ from importlib.metadata import version  # type: ignore
 
 # isort: off
 
-from miio.device import Device, DeviceStatus
+from miio.device import Device
+from miio.devicestatus import DeviceStatus
 from miio.exceptions import DeviceError, DeviceException
 from miio.miot_device import MiotDevice
 from miio.deviceinfo import DeviceInfo

--- a/miio/descriptors.py
+++ b/miio/descriptors.py
@@ -1,0 +1,76 @@
+"""This module contains integration descriptors.
+
+These can be used to make specifically interesting pieces of functionality
+visible to downstream users.
+
+TBD: Some descriptors are created automatically based on the status container classes,
+but developers can override :func:buttons(), :func:sensors(), .. to expose more features.
+"""
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Callable, List, Optional
+
+
+@dataclass
+class ButtonDescriptor:
+    id: str
+    name: str
+    method: Callable
+    icon: Optional[str] = None
+
+
+@dataclass
+class SensorDescriptor:
+    id: str
+    type: str
+    name: str
+    property: str
+    icon: Optional[str] = None
+    unit: Optional[str] = None
+
+
+@dataclass
+class SwitchDescriptor:
+    """Presents toggleable switch."""
+
+    id: str
+    name: str
+    property: str
+    setter: Callable
+    icon: Optional[str] = None
+
+
+@dataclass
+class SettingDescriptor:
+    """Presents a settable value."""
+
+    id: str
+    name: str
+    property: str
+    setter: Callable
+    unit: str
+    icon: str
+
+
+class SettingType(Enum):
+    Number = auto()
+    Boolean = auto()
+    Enum = auto()
+
+
+@dataclass
+class EnumSettingDescriptor(SettingDescriptor):
+    """Presents a settable, enum-based value."""
+
+    choices: List
+    type: SettingType = SettingType.Enum
+
+
+@dataclass
+class NumberSettingDescriptor(SettingDescriptor):
+    """Presents a settable, numerical value."""
+
+    min_value: int
+    max_value: int
+    step: int
+    type: SettingType = SettingType.Number

--- a/miio/descriptors.py
+++ b/miio/descriptors.py
@@ -16,7 +16,7 @@ class ButtonDescriptor:
     id: str
     name: str
     method: Callable
-    icon: Optional[str] = None
+    extras: Optional[Dict] = None
 
 
 @dataclass
@@ -25,7 +25,6 @@ class SensorDescriptor:
     type: str
     name: str
     property: str
-    icon: Optional[str] = None
     unit: Optional[str] = None
     extras: Optional[Dict] = None
 
@@ -38,7 +37,6 @@ class SwitchDescriptor:
     name: str
     property: str
     setter: Callable
-    icon: Optional[str] = None
 
 
 @dataclass
@@ -50,7 +48,6 @@ class SettingDescriptor:
     property: str
     setter: Callable
     unit: str
-    icon: str
 
 
 class SettingType(Enum):
@@ -65,6 +62,7 @@ class EnumSettingDescriptor(SettingDescriptor):
 
     choices: List
     type: SettingType = SettingType.Enum
+    extras: Optional[Dict] = None
 
 
 @dataclass
@@ -75,3 +73,4 @@ class NumberSettingDescriptor(SettingDescriptor):
     max_value: int
     step: int
     type: SettingType = SettingType.Number
+    extras: Optional[Dict] = None

--- a/miio/descriptors.py
+++ b/miio/descriptors.py
@@ -8,7 +8,7 @@ but developers can override :func:buttons(), :func:sensors(), .. to expose more 
 """
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import Callable, List, Optional
+from typing import Callable, Dict, List, Optional
 
 
 @dataclass
@@ -27,6 +27,7 @@ class SensorDescriptor:
     property: str
     icon: Optional[str] = None
     unit: Optional[str] = None
+    extras: Optional[Dict] = None
 
 
 @dataclass

--- a/miio/descriptors.py
+++ b/miio/descriptors.py
@@ -21,6 +21,14 @@ class ButtonDescriptor:
 
 @dataclass
 class SensorDescriptor:
+    """Describes a sensor exposed by the device.
+
+    This information can be used by library users to programatically
+    access information what types of data is available to display to users.
+
+    Prefer :meth:`@sensor <miio.devicestatus.sensor>` for constructing these.
+    """
+
     id: str
     type: str
     name: str

--- a/miio/device.py
+++ b/miio/device.py
@@ -1,18 +1,7 @@
-import inspect
 import logging
-import warnings
 from enum import Enum
 from pprint import pformat as pf
-from typing import (  # noqa: F401
-    Any,
-    Dict,
-    List,
-    Optional,
-    Union,
-    get_args,
-    get_origin,
-    get_type_hints,
-)
+from typing import Any, Dict, List, Optional, Union  # noqa: F401
 
 import click
 
@@ -24,6 +13,7 @@ from .descriptors import (
     SwitchDescriptor,
 )
 from .deviceinfo import DeviceInfo
+from .devicestatus import DeviceStatus
 from .exceptions import DeviceInfoUnavailableException, PayloadDecodeException
 from .miioprotocol import MiIOProtocol
 
@@ -35,95 +25,6 @@ class UpdateState(Enum):
     Installing = "installing"
     Failed = "failed"
     Idle = "idle"
-
-
-def sensor(*, name: str, icon: str = "mdi:sensor", unit: str = "", **kwargs):
-    """Decorator helper to create sensordescriptors for status classes.
-
-    The information can be used by users of the library to programatically find out what
-    types of sensors are available for the device.
-    """
-
-    def decorator_sensor(func):
-        property_name = func.__name__
-
-        def _sensor_type_for_return_type(func):
-            rtype = get_type_hints(func).get("return")
-            if get_origin(rtype) is Union:  # Unwrap Optional[]
-                rtype, _ = get_args(rtype)
-
-            if rtype == bool:
-                return "binary"
-            else:
-                return "sensor"
-
-        sensor_type = _sensor_type_for_return_type(func)
-        descriptor = SensorDescriptor(
-            id=str(property_name),
-            property=str(property_name),
-            name=name,
-            icon=icon,
-            unit=unit,
-            type=sensor_type,
-            **kwargs,
-        )
-        func._sensor = descriptor
-
-        return func
-
-    return decorator_sensor
-
-
-class _StatusMeta(type):
-    """Meta class to provide introspectable properties."""
-
-    def __new__(metacls, name, bases, namespace, **kwargs):
-        cls = super().__new__(metacls, name, bases, namespace)
-        cls._sensors = []
-        for n in namespace:
-            prop = getattr(namespace[n], "fget", None)
-            if prop:
-                sensor = getattr(prop, "_sensor", None)
-                if sensor:
-                    _LOGGER.debug(f"Found sensor: {sensor} for {name}")
-                    cls._sensors.append(sensor)
-
-        return cls
-
-
-class DeviceStatus(metaclass=_StatusMeta):
-    """Base class for status containers.
-
-    All status container classes should inherit from this class:
-
-    * This class allows downstream users to access the available information in an
-      introspectable way.
-    * The __repr__ implementation returns all defined properties and their values.
-    """
-
-    def __repr__(self):
-        props = inspect.getmembers(self.__class__, lambda o: isinstance(o, property))
-
-        s = f"<{self.__class__.__name__}"
-        for prop_tuple in props:
-            name, prop = prop_tuple
-            try:
-                # ignore deprecation warnings
-                with warnings.catch_warnings(record=True):
-                    prop_value = prop.fget(self)
-            except Exception as ex:
-                prop_value = ex.__class__.__name__
-
-            s += f" {name}={prop_value}"
-        s += ">"
-        return s
-
-    def sensors(self):
-        """Return the list of sensors exposed by the status container.
-
-        You can use @sensor decorator to define sensors inside your status class.
-        """
-        return self._sensors
 
 
 class Device(metaclass=DeviceGroupMeta):

--- a/miio/device.py
+++ b/miio/device.py
@@ -339,7 +339,7 @@ class Device(metaclass=DeviceGroupMeta):
         """Return list of settings."""
         return []
 
-    def sensors(self) -> List[SensorDescriptor]:
+    def sensors(self) -> Dict[str, SensorDescriptor]:
         """Return list of sensors."""
         # TODO: the latest status should be cached and re-used by all meta information getters
         sensors = self.status().sensors()

--- a/miio/devicestatus.py
+++ b/miio/devicestatus.py
@@ -60,11 +60,15 @@ class DeviceStatus(metaclass=_StatusMeta):
         return self._sensors  # type: ignore[attr-defined]
 
 
-def sensor(*, name: str, icon: str = "mdi:sensor", unit: str = "", **kwargs):
-    """Decorator helper to create sensordescriptors for status classes.
+def sensor(*, name: str, unit: str = "", **kwargs):
+    """Syntactic sugar to create SensorDescriptor objects.
 
     The information can be used by users of the library to programatically find out what
     types of sensors are available for the device.
+
+    The interface is kept minimal, but you can pass any extra keyword arguments.
+    These extras are made accessible over :attr:`~miio.descriptors.SensorDescriptor.extras`,
+    and can be interpreted downstream users as they wish.
     """
 
     def decorator_sensor(func):

--- a/miio/devicestatus.py
+++ b/miio/devicestatus.py
@@ -1,0 +1,97 @@
+import inspect
+import logging
+import warnings
+from typing import Union, get_args, get_origin, get_type_hints
+
+from .descriptors import SensorDescriptor
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class _StatusMeta(type):
+    """Meta class to provide introspectable properties."""
+
+    def __new__(metacls, name, bases, namespace, **kwargs):
+        cls = super().__new__(metacls, name, bases, namespace)
+        cls._sensors = []
+        for n in namespace:
+            prop = getattr(namespace[n], "fget", None)
+            if prop:
+                sensor = getattr(prop, "_sensor", None)
+                if sensor:
+                    _LOGGER.debug(f"Found sensor: {sensor} for {name}")
+                    cls._sensors.append(sensor)
+
+        return cls
+
+
+class DeviceStatus(metaclass=_StatusMeta):
+    """Base class for status containers.
+
+    All status container classes should inherit from this class:
+
+    * This class allows downstream users to access the available information in an
+      introspectable way.
+    * The __repr__ implementation returns all defined properties and their values.
+    """
+
+    def __repr__(self):
+        props = inspect.getmembers(self.__class__, lambda o: isinstance(o, property))
+
+        s = f"<{self.__class__.__name__}"
+        for prop_tuple in props:
+            name, prop = prop_tuple
+            try:
+                # ignore deprecation warnings
+                with warnings.catch_warnings(record=True):
+                    prop_value = prop.fget(self)
+            except Exception as ex:
+                prop_value = ex.__class__.__name__
+
+            s += f" {name}={prop_value}"
+        s += ">"
+        return s
+
+    def sensors(self):
+        """Return the list of sensors exposed by the status container.
+
+        You can use @sensor decorator to define sensors inside your status class.
+        """
+        return self._sensors
+
+
+def sensor(*, name: str, icon: str = "mdi:sensor", unit: str = "", **kwargs):
+    """Decorator helper to create sensordescriptors for status classes.
+
+    The information can be used by users of the library to programatically find out what
+    types of sensors are available for the device.
+    """
+
+    def decorator_sensor(func):
+        property_name = func.__name__
+
+        def _sensor_type_for_return_type(func):
+            rtype = get_type_hints(func).get("return")
+            if get_origin(rtype) is Union:  # Unwrap Optional[]
+                rtype, _ = get_args(rtype)
+
+            if rtype == bool:
+                return "binary"
+            else:
+                return "sensor"
+
+        sensor_type = _sensor_type_for_return_type(func)
+        descriptor = SensorDescriptor(
+            id=str(property_name),
+            property=str(property_name),
+            name=name,
+            icon=icon,
+            unit=unit,
+            type=sensor_type,
+            **kwargs,
+        )
+        func._sensor = descriptor
+
+        return func
+
+    return decorator_sensor

--- a/miio/devicestatus.py
+++ b/miio/devicestatus.py
@@ -85,7 +85,6 @@ def sensor(*, name: str, icon: str = "mdi:sensor", unit: str = "", **kwargs):
             id=str(property_name),
             property=str(property_name),
             name=name,
-            icon=icon,
             unit=unit,
             type=sensor_type,
             extras=kwargs,

--- a/miio/devicestatus.py
+++ b/miio/devicestatus.py
@@ -88,7 +88,7 @@ def sensor(*, name: str, icon: str = "mdi:sensor", unit: str = "", **kwargs):
             icon=icon,
             unit=unit,
             type=sensor_type,
-            **kwargs,
+            extras=kwargs,
         )
         func._sensor = descriptor
 

--- a/miio/devicestatus.py
+++ b/miio/devicestatus.py
@@ -1,7 +1,7 @@
 import inspect
 import logging
 import warnings
-from typing import Union, get_args, get_origin, get_type_hints
+from typing import Dict, Union, get_args, get_origin, get_type_hints
 
 from .descriptors import SensorDescriptor
 
@@ -13,14 +13,14 @@ class _StatusMeta(type):
 
     def __new__(metacls, name, bases, namespace, **kwargs):
         cls = super().__new__(metacls, name, bases, namespace)
-        cls._sensors = []
+        cls._sensors: Dict[str, SensorDescriptor] = {}
         for n in namespace:
             prop = getattr(namespace[n], "fget", None)
             if prop:
                 sensor = getattr(prop, "_sensor", None)
                 if sensor:
                     _LOGGER.debug(f"Found sensor: {sensor} for {name}")
-                    cls._sensors.append(sensor)
+                    cls._sensors[n] = sensor
 
         return cls
 
@@ -52,12 +52,12 @@ class DeviceStatus(metaclass=_StatusMeta):
         s += ">"
         return s
 
-    def sensors(self):
-        """Return the list of sensors exposed by the status container.
+    def sensors(self) -> Dict[str, SensorDescriptor]:
+        """Return the dict of sensors exposed by the status container.
 
         You can use @sensor decorator to define sensors inside your status class.
         """
-        return self._sensors
+        return self._sensors  # type: ignore[attr-defined]
 
 
 def sensor(*, name: str, icon: str = "mdi:sensor", unit: str = "", **kwargs):

--- a/miio/powerstrip.py
+++ b/miio/powerstrip.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional
 import click
 
 from .click_common import EnumType, command, format_output
-from .device import Device, DeviceStatus
+from .device import Device, DeviceStatus, sensor
 from .exceptions import DeviceException
 from .utils import deprecated
 
@@ -65,16 +65,19 @@ class PowerStripStatus(DeviceStatus):
         return self.data["power"]
 
     @property
+    @sensor(name="Power")
     def is_on(self) -> bool:
         """True if the device is turned on."""
         return self.power == "on"
 
     @property
+    @sensor(name="Temperature", unit="C", icon="mdi:thermometer")
     def temperature(self) -> float:
         """Current temperature."""
         return self.data["temperature"]
 
     @property
+    @sensor(name="Current", unit="A", icon="mdi:current-ac")
     def current(self) -> Optional[float]:
         """Current, if available.
 
@@ -85,6 +88,7 @@ class PowerStripStatus(DeviceStatus):
         return None
 
     @property
+    @sensor(name="Load power", unit="W")
     def load_power(self) -> Optional[float]:
         """Current power load, if available."""
         if self.data["power_consume_rate"] is not None:
@@ -105,6 +109,7 @@ class PowerStripStatus(DeviceStatus):
         return self.led
 
     @property
+    @sensor(name="LED", icon="mdi:led-outline")
     def led(self) -> Optional[bool]:
         """True if the wifi led is turned on."""
         if "wifi_led" in self.data and self.data["wifi_led"] is not None:
@@ -119,6 +124,7 @@ class PowerStripStatus(DeviceStatus):
         return None
 
     @property
+    @sensor(name="Leakage current", unit="A")
     def leakage_current(self) -> Optional[int]:
         """The leakage current, if available."""
         if "elec_leakage" in self.data and self.data["elec_leakage"] is not None:
@@ -126,6 +132,7 @@ class PowerStripStatus(DeviceStatus):
         return None
 
     @property
+    @sensor(name="Voltage", unit="V")
     def voltage(self) -> Optional[float]:
         """The voltage, if available."""
         if "voltage" in self.data and self.data["voltage"] is not None:
@@ -133,6 +140,7 @@ class PowerStripStatus(DeviceStatus):
         return None
 
     @property
+    @sensor(name="Power Factor", unit="%")
     def power_factor(self) -> Optional[float]:
         """The power factor, if available."""
         if "power_factor" in self.data and self.data["power_factor"] is not None:

--- a/miio/powerstrip.py
+++ b/miio/powerstrip.py
@@ -6,7 +6,8 @@ from typing import Any, Dict, Optional
 import click
 
 from .click_common import EnumType, command, format_output
-from .device import Device, DeviceStatus, sensor
+from .device import Device
+from .devicestatus import DeviceStatus, sensor
 from .exceptions import DeviceException
 from .utils import deprecated
 

--- a/miio/powerstrip.py
+++ b/miio/powerstrip.py
@@ -72,13 +72,13 @@ class PowerStripStatus(DeviceStatus):
         return self.power == "on"
 
     @property
-    @sensor(name="Temperature", unit="C", icon="mdi:thermometer")
+    @sensor(name="Temperature", unit="C", device_class="temperature")
     def temperature(self) -> float:
         """Current temperature."""
         return self.data["temperature"]
 
     @property
-    @sensor(name="Current", unit="A", icon="mdi:current-ac")
+    @sensor(name="Current", unit="A", device_class="current")
     def current(self) -> Optional[float]:
         """Current, if available.
 
@@ -89,7 +89,7 @@ class PowerStripStatus(DeviceStatus):
         return None
 
     @property
-    @sensor(name="Load power", unit="W")
+    @sensor(name="Load power", unit="W", device_class="power")
     def load_power(self) -> Optional[float]:
         """Current power load, if available."""
         if self.data["power_consume_rate"] is not None:
@@ -125,7 +125,7 @@ class PowerStripStatus(DeviceStatus):
         return None
 
     @property
-    @sensor(name="Leakage current", unit="A")
+    @sensor(name="Leakage current", unit="A", device_class="current")
     def leakage_current(self) -> Optional[int]:
         """The leakage current, if available."""
         if "elec_leakage" in self.data and self.data["elec_leakage"] is not None:
@@ -133,7 +133,7 @@ class PowerStripStatus(DeviceStatus):
         return None
 
     @property
-    @sensor(name="Voltage", unit="V")
+    @sensor(name="Voltage", unit="V", device_class="voltage")
     def voltage(self) -> Optional[float]:
         """The voltage, if available."""
         if "voltage" in self.data and self.data["voltage"] is not None:
@@ -141,7 +141,7 @@ class PowerStripStatus(DeviceStatus):
         return None
 
     @property
-    @sensor(name="Power Factor", unit="%")
+    @sensor(name="Power Factor", unit="%", device_class="power_factor")
     def power_factor(self) -> Optional[float]:
         """The power factor, if available."""
         if "power_factor" in self.data and self.data["power_factor"] is not None:

--- a/miio/tests/test_devicestatus.py
+++ b/miio/tests/test_devicestatus.py
@@ -1,4 +1,5 @@
 from miio import DeviceStatus
+from miio.devicestatus import sensor
 
 
 def test_multiple():
@@ -64,3 +65,34 @@ def test_none():
             return None
 
     assert repr(NoneStatus()) == "<NoneStatus return_none=None>"
+
+
+def test_sensor_decorator():
+    class DecoratedProps(DeviceStatus):
+        @property
+        @sensor(name="Voltage", unit="V", icon="foo")
+        def all_kwargs(self):
+            pass
+
+        @property
+        @sensor(name="Only name")
+        def only_name(self):
+            pass
+
+        @property
+        @sensor(name="", unknown_kwarg="123")
+        def unknown(self):
+            pass
+
+    status = DecoratedProps()
+    sensors = status.sensors()
+    assert len(sensors) == 3
+
+    all_kwargs = sensors["all_kwargs"]
+    assert all_kwargs.name == "Voltage"
+    assert all_kwargs.unit == "V"
+    assert all_kwargs.icon == "foo"
+
+    assert sensors["only_name"].name == "Only name"
+
+    assert "unknown_kwarg" in sensors["unknown"].extras

--- a/miio/tests/test_devicestatus.py
+++ b/miio/tests/test_devicestatus.py
@@ -70,7 +70,7 @@ def test_none():
 def test_sensor_decorator():
     class DecoratedProps(DeviceStatus):
         @property
-        @sensor(name="Voltage", unit="V", icon="foo")
+        @sensor(name="Voltage", unit="V")
         def all_kwargs(self):
             pass
 
@@ -91,7 +91,6 @@ def test_sensor_decorator():
     all_kwargs = sensors["all_kwargs"]
     assert all_kwargs.name == "Voltage"
     assert all_kwargs.unit == "V"
-    assert all_kwargs.icon == "foo"
 
     assert sensors["only_name"].name == "Only name"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,8 +105,9 @@ exclude_lines = [
   "def __repr__"
 ]
 
-[tool.check-manifest]
-ignore = ["devtools/*"]
+[tool.mypy]
+# disables "Decorated property not supported", see https://github.com/python/mypy/issues/1362
+disable_error_code = "misc"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
This is the first PR to add support for introspectable integration interfaces to allow downstream users to query the device in order to obtain information about available sensors (e.g., "Voltage"), settings ("Wifi LED"), and actions (e.g., "Reset brush filter").
This will reduce the need to hard-code any details (e.g., inside homeassistant) about what exactly is supported by a device object.

The way this works is to have descriptor classes that define the information necessary to present the information to end users.
This PR adds all currently existing descriptors, but only the implementation for sensors. The rest of the types will follow soon in follow-up pull requests.

Integration developers can modify their `DeviceStatus` implementations to add `@sensor` decorators to expose properties that can be interesting for end-users:
```
class VacuumStatus(DeviceStatus):
    @property
    @sensor(name="Error Code", icon="mdi:alert-circle")
    def error_code(self) -> int:
        return -1

    @property
    @sensor(name="Battery", unit="%", icon="mdi:battery")
    def battery_level(self) -> int:
        return 10
```

The sensor descriptor objects will be available using `DeviceStatus.sensors()` and will contain the supplied information.
The decorator inspects the return type of the property to deliver information whether a sensor is a binary sensor or just a regular one, here's an example how it looks like in homeassistant:
![image](https://user-images.githubusercontent.com/3705853/184224647-93952650-b119-420f-ad43-c3edcaafce3b.png)


The API is currently provisional and will likely change in the near future, I'm currently looking for feedback from other developers using the library as well as those developing integrations. Ping @Kirmas @starkillerOG @syssi 

TBD:
* [x] Proper solution for "Decorated property not supported" error from mypy, see https://github.com/python/mypy/issues/1362 . Adding `# type: ignore` for all properties gets tiresome pretty fast.
* [x] Add some tests