### PR TITLE
Implement introspectable switches

### DIFF
--- a/miio/descriptors.py
+++ b/miio/descriptors.py
@@ -44,7 +44,9 @@ class SwitchDescriptor:
     id: str
     name: str
     property: str
-    setter: Callable
+    setter_name: str
+    setter: Optional[Callable] = None
+    extras: Optional[Dict] = None
 
 
 @dataclass

--- a/miio/device.py
+++ b/miio/device.py
@@ -340,14 +340,19 @@ class Device(metaclass=DeviceGroupMeta):
         return []
 
     def sensors(self) -> Dict[str, SensorDescriptor]:
-        """Return list of sensors."""
+        """Return sensors."""
         # TODO: the latest status should be cached and re-used by all meta information getters
         sensors = self.status().sensors()
         return sensors
 
-    def switches(self) -> List[SwitchDescriptor]:
-        """Return list of toggleable switches."""
-        return []
+    def switches(self) -> Dict[str, SwitchDescriptor]:
+        """Return toggleable switches."""
+        switches = self.status().switches()
+        for switch in switches.values():
+            # TODO: Bind setter methods, this should probably done only once during init.
+            switch.setter = getattr(self, switch.setter_name)
+
+        return switches
 
     def __repr__(self):
         return f"<{self.__class__.__name__ }: {self.ip} (token: {self.token})>"

--- a/miio/powerstrip.py
+++ b/miio/powerstrip.py
@@ -7,7 +7,7 @@ import click
 
 from .click_common import EnumType, command, format_output
 from .device import Device
-from .devicestatus import DeviceStatus, sensor
+from .devicestatus import DeviceStatus, sensor, switch
 from .exceptions import DeviceException
 from .utils import deprecated
 
@@ -66,7 +66,7 @@ class PowerStripStatus(DeviceStatus):
         return self.data["power"]
 
     @property
-    @sensor(name="Power")
+    @switch(name="Power", setter_name="set_power", device_class="outlet")
     def is_on(self) -> bool:
         """True if the device is turned on."""
         return self.power == "on"
@@ -110,7 +110,9 @@ class PowerStripStatus(DeviceStatus):
         return self.led
 
     @property
-    @sensor(name="LED", icon="mdi:led-outline")
+    @switch(
+        name="LED", icon="mdi:led-outline", setter_name="set_led", device_class="switch"
+    )
     def led(self) -> Optional[bool]:
         """True if the wifi led is turned on."""
         if "wifi_led" in self.data and self.data["wifi_led"] is not None:
@@ -177,6 +179,13 @@ class PowerStrip(Device):
         values = self.get_properties(properties)
 
         return PowerStripStatus(defaultdict(lambda: None, zip(properties, values)))
+
+    @command(click.argument("power", type=bool))
+    def set_power(self, power: bool):
+        """Set the power on or off."""
+        if power:
+            return self.on()
+        return self.off()
 
     @command(default_output=format_output("Powering on"))
     def on(self):


### PR DESCRIPTION
Continuing on adding more introspectable properties (follow-up to #1488), this PR adds support for toggleable switches and implements them for `PowerStrip`.
The home assistant using this information is available at https://github.com/rytilahti/home-assistant/tree/xiaomi_miio/feat/entities_from_upstream

Here is how the powerstrip looks currently in homeassistant:
![image](https://user-images.githubusercontent.com/3705853/184506948-32561125-0f8c-419c-b179-e6f0fc438533.png)

Next step is adding support for settings (`select` platform), but it may take a bit longer as I don't have devices to test on prior cleaning up the `vacuum` platform integration to use the common facilities.

Ping @syssi @Kirmas @starkillerOG - feel free to test and start adding switches to integrations. Let me know if you encounter any issues or think that something should be changed, we can still adjust the API as needed.