### PR TITLE
Fix supported angles for mapped fans

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -129,7 +129,7 @@ Supported devices
 -  Xiaomi Philips Zhirui Bedroom Smart Lamp
 -  Huayi Huizuo Lamps
 -  Xiaomi Universal IR Remote Controller (Chuangmi IR)
--  Xiaomi Mi Smart Pedestal Fan V2, V3, SA1, ZA1, ZA3, ZA4, ZA5 1C, P5, P9, P10, P11, P33
+-  Xiaomi Mi Smart Pedestal Fan V2, V3, SA1, ZA1, ZA3, ZA4, ZA5 1C, P5, P9, P10, P11, P15, P18, P33
 -  Xiaomi Rosou SS4 Ventilator (leshow.fan.ss4)
 -  Xiaomi Mi Air Humidifier V1, CA1, CA4, CB1, MJJSQ, JSQ, JSQ1, JSQ001
 -  Xiaomi Mi Water Purifier (Basic support: Turn on & off)

--- a/miio/integrations/fan/dmaker/fan_miot.py
+++ b/miio/integrations/fan/dmaker/fan_miot.py
@@ -101,8 +101,8 @@ SUPPORTED_ANGLES = {
     MODEL_FAN_P9: [30, 60, 90, 120, 150],
     MODEL_FAN_P10: [30, 60, 90, 120, 140],
     MODEL_FAN_P11: [30, 60, 90, 120, 140],
-    MODEL_FAN_P15: [30, 60, 90, 120, 140], # mapped to P11
-    MODEL_FAN_P18: [30, 60, 90, 120, 140], # mapped to P10
+    MODEL_FAN_P15: [30, 60, 90, 120, 140],  # mapped to P11
+    MODEL_FAN_P18: [30, 60, 90, 120, 140],  # mapped to P10
     MODEL_FAN_P33: [30, 60, 90, 120, 140],
 }
 

--- a/miio/integrations/fan/dmaker/fan_miot.py
+++ b/miio/integrations/fan/dmaker/fan_miot.py
@@ -101,6 +101,8 @@ SUPPORTED_ANGLES = {
     MODEL_FAN_P9: [30, 60, 90, 120, 150],
     MODEL_FAN_P10: [30, 60, 90, 120, 140],
     MODEL_FAN_P11: [30, 60, 90, 120, 140],
+    MODEL_FAN_P15: [30, 60, 90, 120, 140], # mapped to P11
+    MODEL_FAN_P18: [30, 60, 90, 120, 140], # mapped to P10
     MODEL_FAN_P33: [30, 60, 90, 120, 140],
 }
 


### PR DESCRIPTION
In https://github.com/rytilahti/python-miio/pull/1362, supported for P15 and P18 has been added. However, both devices support changing the oscillation angle, but don't have a key present in `SUPPORTED_ANGLES`.

This PR adds the model keys to SUPPORTED_ANGLES. In a follow-up PR, I am happy to see if we can add full blown support for the P15 to Home Assistant. (since currently it won't be automatically mapped from P15 to P11 and I had to figure this out myself by reading GitHub issues).

```
  File "/usr/local/lib/python3.10/site-packages/miio/integrations/fan/dmaker/fan_miot.py", line 321, in set_angle
    if angle not in SUPPORTED_ANGLES[self.model]:
KeyError: 'dmaker.fan.p15'
```