### PR TITLE
Allow defining callable setters for switches and settings

### DIFF
--- a/miio/device.py
+++ b/miio/device.py
@@ -340,13 +340,14 @@ class Device(metaclass=DeviceGroupMeta):
         settings = self.status().settings()
         for setting in settings.values():
             # TODO: Bind setter methods, this should probably done only once during init.
-            if setting.setter is None and setting.setter_name is not None:
-                setting.setter = getattr(self, setting.setter_name)
-            else:
+            if setting.setter is None:
                 # TODO: this is ugly, how to fix the issue where setter_name is optional and thus not acceptable for getattr?
-                raise Exception(
-                    f"Neither setter or setter_name was defined for {setting}"
-                )
+                if setting.setter_name is None:
+                    raise Exception(
+                        f"Neither setter or setter_name was defined for {setting}"
+                    )
+
+                setting.setter = getattr(self, setting.setter_name)
 
         return settings
 
@@ -361,13 +362,13 @@ class Device(metaclass=DeviceGroupMeta):
         switches = self.status().switches()
         for switch in switches.values():
             # TODO: Bind setter methods, this should probably done only once during init.
-            if switch.setter is None and switch.setter_name is not None:
+            if switch.setter is None:
+                if switch.setter_name is None:
+                    # TODO: this is ugly, how to fix the issue where setter_name is optional and thus not acceptable for getattr?
+                    raise Exception(
+                        f"Neither setter or setter_name was defined for {switch}"
+                    )
                 switch.setter = getattr(self, switch.setter_name)
-            else:
-                # TODO: this is ugly, how to fix the issue where setter_name is optional and thus not acceptable for getattr?
-                raise Exception(
-                    f"Neither setter or setter_name was defined for {switch}"
-                )
 
         return switches
 

--- a/miio/integrations/airpurifier/dmaker/airfresh_t2017.py
+++ b/miio/integrations/airpurifier/dmaker/airfresh_t2017.py
@@ -330,14 +330,17 @@ class AirFreshA1(Device):
 
     @command()
     def set_ptc_timer(self):
-        """
-        value = time.index + '-' +
-            time.hexSum + '-' +
-            time.startTime + '-' +
-            time.ptcTimer.endTime + '-' +
-            time.level + '-' +
-            time.status;
-        return self.send("set_ptc_timer", [value])
+        """Set PTC timer (not implemented)
+
+        Value construction::
+
+            value = time.index + '-' +
+                time.hexSum + '-' +
+                time.startTime + '-' +
+                time.ptcTimer.endTime + '-' +
+                time.level + '-' +
+                time.status;
+            return self.send("set_ptc_timer", [value])
         """
         raise NotImplementedError()
 

--- a/miio/integrations/vacuum/dreame/dreamevacuum_miot.py
+++ b/miio/integrations/vacuum/dreame/dreamevacuum_miot.py
@@ -646,8 +646,7 @@ class DreameVacuum(MiotDevice, VacuumInterface):
         :param str url: URL or path to language pack
         :param str md5sum: MD5 hash for file if URL used
         :param int size: File size in bytes if URL used
-        :param str voice_id: In original it is country code for the selected
-        voice pack. You can put here what you like, I guess it doesn't matter (default: CP - Custom Packet)
+        :param str voice_id: Country code for the selected voice pack. CP=Custom Packet
         """
         local_url = None
         server = None


### PR DESCRIPTION
This fixes a logic flaw that made it impossible to define a setter callable for switches and settings.

Includes a couple of unrelated doc fixes to get the tests pass.