### PR TITLE
Move test-properties to under devtools command

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -85,6 +85,10 @@ Whether adding support for a new device or improving an existing one,
 the journey begins by finding out the commands used to control the device.
 This usually involves capturing packet traces between the device and the official app,
 and analyzing those packet traces afterwards.
+
+Traffic Capturing
+~~~~~~~~~~~~~~~~~
+
 The process is as follows:
 
 1. Install Android emulator (`BlueStacks emulator <https://www.bluestacks.com>`_ has been reported to work on Windows).
@@ -97,6 +101,44 @@ The process is as follows:
 ::
 
     python devtools/parse_pcap.py <pcap file> --token <token>
+
+Testing Properties
+~~~~~~~~~~~~~~~~~~
+
+Another option for MiIO devices is to try to test which property accesses return a response.
+Some ideas about the naming of properties can be located from the existing integrations.
+
+The ``miiocli devtools test-properties`` command can be used to perform this testing:
+
+.. code-block::
+
+    $ miiocli devtools test-properties power temperature current mode power_consume_rate voltage power_factor elec_leakage
+
+    Testing properties ('power', 'temperature', 'current', 'mode', 'power_consume_rate', 'voltage', 'power_factor', 'elec_leakage') for zimi.powerstrip.v2
+    Testing power                'on' <class 'str'>
+    Testing temperature          49.13 <class 'float'>
+    Testing current              0.07 <class 'float'>
+    Testing mode                 None
+    Testing power_consume_rate   7.8 <class 'float'>
+    Testing voltage              None
+    Testing power_factor         0.0 <class 'float'>
+    Testing elec_leakage         None
+    Found 5 valid properties, testing max_properties..
+    Testing 5 properties at once (power temperature current power_consume_rate power_factor): OK for 5 properties
+
+    Please copy the results below to your report
+    ### Results ###
+    Model: zimi.powerstrip.v2
+    Total responsives: 5
+    Total non-empty: 5
+    All non-empty properties:
+    {'current': 0.07,
+     'power': 'on',
+     'power_consume_rate': 7.8,
+     'power_factor': 0.0,
+     'temperature': 49.13}
+    Max properties: 5
+
 
 
 .. _miot:

--- a/miio/cli.py
+++ b/miio/cli.py
@@ -12,6 +12,7 @@ from miio.click_common import (
 from miio.miioprotocol import MiIOProtocol
 
 from .cloud import cloud
+from .devtools import devtools
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -60,6 +61,7 @@ def discover(mdns, handshake, network, timeout):
 
 cli.add_command(discover)
 cli.add_command(cloud)
+cli.add_command(devtools)
 
 
 def create_cli():

--- a/miio/device.py
+++ b/miio/device.py
@@ -1,6 +1,5 @@
 import logging
 from enum import Enum
-from pprint import pformat as pf
 from typing import Any, Dict, List, Optional, Union  # noqa: F401
 
 import click
@@ -234,98 +233,6 @@ class Device(metaclass=DeviceGroupMeta):
             )
 
         return values
-
-    @command(
-        click.argument("properties", type=str, nargs=-1, required=True),
-    )
-    def test_properties(self, properties):
-        """Helper to test device properties."""
-
-        def ok(x):
-            click.echo(click.style(str(x), fg="green", bold=True))
-
-        def fail(x):
-            click.echo(click.style(str(x), fg="red", bold=True))
-
-        try:
-            model = self.info().model
-        except Exception as ex:
-            _LOGGER.warning("Unable to obtain device model: %s", ex)
-            model = "<unavailable>"
-
-        click.echo(f"Testing properties {properties} for {model}")
-        valid_properties = {}
-        max_property_len = max(len(p) for p in properties)
-        for property in properties:
-            try:
-                click.echo(f"Testing {property:{max_property_len+2}} ", nl=False)
-                value = self.get_properties([property])
-                # Handle list responses
-                if isinstance(value, list):
-                    # unwrap single-element lists
-                    if len(value) == 1:
-                        value = value.pop()
-                    # report on unexpected multi-element lists
-                    elif len(value) > 1:
-                        _LOGGER.error("Got an array as response: %s", value)
-                    # otherwise we received an empty list, which we consider here as None
-                    else:
-                        value = None
-
-                if value is None:
-                    fail("None")
-                else:
-                    valid_properties[property] = value
-                    ok(f"{repr(value)} {type(value)}")
-            except Exception as ex:
-                _LOGGER.warning("Unable to request %s: %s", property, ex)
-
-        click.echo(
-            f"Found {len(valid_properties)} valid properties, testing max_properties.."
-        )
-
-        props_to_test = list(valid_properties.keys())
-        max_properties = -1
-        while len(props_to_test) > 0:
-            try:
-                click.echo(
-                    f"Testing {len(props_to_test)} properties at once ({' '.join(props_to_test)}): ",
-                    nl=False,
-                )
-                resp = self.get_properties(props_to_test)
-
-                if len(resp) == len(props_to_test):
-                    max_properties = len(props_to_test)
-                    ok(f"OK for {max_properties} properties")
-                    break
-                else:
-                    removed_property = props_to_test.pop()
-                    fail(
-                        f"Got different amount of properties ({len(props_to_test)}) than requested ({len(resp)}), removing {removed_property}"
-                    )
-
-            except Exception as ex:
-                removed_property = props_to_test.pop()
-                msg = f"Unable to request properties: {ex} - removing {removed_property} for next try"
-                _LOGGER.warning(msg)
-                fail(ex)
-
-        non_empty_properties = {
-            k: v for k, v in valid_properties.items() if v is not None
-        }
-
-        click.echo(
-            click.style("\nPlease copy the results below to your report", bold=True)
-        )
-        click.echo("### Results ###")
-        click.echo(f"Model: {model}")
-        _LOGGER.debug(f"All responsive properties:\n{pf(valid_properties)}")
-        click.echo(f"Total responsives: {len(valid_properties)}")
-        click.echo(f"Total non-empty: {len(non_empty_properties)}")
-        click.echo(f"All non-empty properties:\n{pf(non_empty_properties)}")
-        click.echo(f"Max properties: {max_properties}")
-
-        return "Done"
 
     def status(self) -> DeviceStatus:
         """Return device status."""

--- a/miio/devtools.py
+++ b/miio/devtools.py
@@ -1,0 +1,106 @@
+"""Command-line interface for devtools."""
+import logging
+from pprint import pformat as pf
+
+import click
+
+from .device import Device
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@click.group(invoke_without_command=False)
+@click.pass_context
+def devtools(ctx: click.Context):
+    """Tools for developers and troubleshooting."""
+
+
+@devtools.command()
+@click.option("--host", required=True, prompt=True)
+@click.option("--token", required=True, prompt=True)
+@click.argument("properties", type=str, nargs=-1, required=True)
+def test_properties(host: str, token: str, properties):
+    """Helper to test device properties."""
+    dev = Device(host, token)
+
+    def ok(x):
+        click.echo(click.style(str(x), fg="green", bold=True))
+
+    def fail(x):
+        click.echo(click.style(str(x), fg="red", bold=True))
+
+    try:
+        model = dev.info().model
+    except Exception as ex:
+        _LOGGER.warning("Unable to obtain device model: %s", ex)
+        model = "<unavailable>"
+
+    click.echo(f"Testing properties {properties} for {model}")
+    valid_properties = {}
+    max_property_len = max(len(p) for p in properties)
+    for property in properties:
+        try:
+            click.echo(f"Testing {property:{max_property_len+2}} ", nl=False)
+            value = dev.get_properties([property])
+            # Handle list responses
+            if isinstance(value, list):
+                # unwrap single-element lists
+                if len(value) == 1:
+                    value = value.pop()
+                # report on unexpected multi-element lists
+                elif len(value) > 1:
+                    _LOGGER.error("Got an array as response: %s", value)
+                # otherwise we received an empty list, which we consider here as None
+                else:
+                    value = None
+
+            if value is None:
+                fail("None")
+            else:
+                valid_properties[property] = value
+                ok(f"{repr(value)} {type(value)}")
+        except Exception as ex:
+            _LOGGER.warning("Unable to request %s: %s", property, ex)
+
+    click.echo(
+        f"Found {len(valid_properties)} valid properties, testing max_properties.."
+    )
+
+    props_to_test = list(valid_properties.keys())
+    max_properties = -1
+    while len(props_to_test) > 0:
+        try:
+            click.echo(
+                f"Testing {len(props_to_test)} properties at once ({' '.join(props_to_test)}): ",
+                nl=False,
+            )
+            resp = dev.get_properties(props_to_test)
+
+            if len(resp) == len(props_to_test):
+                max_properties = len(props_to_test)
+                ok(f"OK for {max_properties} properties")
+                break
+            else:
+                removed_property = props_to_test.pop()
+                fail(
+                    f"Got different amount of properties ({len(props_to_test)}) than requested ({len(resp)}), removing {removed_property}"
+                )
+
+        except Exception as ex:
+            removed_property = props_to_test.pop()
+            msg = f"Unable to request properties: {ex} - removing {removed_property} for next try"
+            _LOGGER.warning(msg)
+            fail(ex)
+
+    non_empty_properties = {k: v for k, v in valid_properties.items() if v is not None}
+
+    click.echo(click.style("\nPlease copy the results below to your report", bold=True))
+    click.echo("### Results ###")
+    click.echo(f"Model: {model}")
+    _LOGGER.debug(f"All responsive properties:\n{pf(valid_properties)}")
+    click.echo(f"Total responsives: {len(valid_properties)}")
+    click.echo(f"Total non-empty: {len(non_empty_properties)}")
+    click.echo(f"All non-empty properties:\n{pf(non_empty_properties)}")
+    click.echo(f"Max properties: {max_properties}")
+
+    return "Done"


### PR DESCRIPTION
The `test-properties` should have never been a part of the main `Device` class, this PR rectifies this by creating a new click group `devtools` that can be furthermore extended with other tooling.