### PR TITLE
Mark zhimi.airp.mb3a as supported for airpurifier_miot

### DIFF
--- a/miio/integrations/airpurifier/zhimi/airpurifier_miot.py
+++ b/miio/integrations/airpurifier/zhimi/airpurifier_miot.py
@@ -237,7 +237,8 @@ _MAPPING_ZA1 = {
 _MAPPINGS = {
     "zhimi.airpurifier.ma4": _MAPPING,  # airpurifier 3
     "zhimi.airpurifier.mb3": _MAPPING,  # airpurifier 3h
-    "zhimi.airpurifier.mb3a": _MAPPING,  # airpurifier 3h
+    "zhimi.airpurifier.mb3a": _MAPPING,  # airpurifier 3h, unsure if both models are used for this device
+    "zhimi.airp.mb3a": _MAPPING,  # airpurifier 3h
     "zhimi.airpurifier.va1": _MAPPING,  # airpurifier proh
     "zhimi.airpurifier.vb2": _MAPPING,  # airpurifier proh
     "zhimi.airpurifier.mb4": _MAPPING_MB4,  # airpurifier 3c


### PR DESCRIPTION
I'm not sure if the "long form" name is used by some device so I won't remove it for now, this adds the "short form" name supported as well.
Should finally fix the warning mentioned at https://github.com/home-assistant/core/issues/69458