### PR TITLE
Fix roborock timers' next_schedule on repeated requests

### DIFF
--- a/miio/integrations/vacuum/roborock/vacuumcontainers.py
+++ b/miio/integrations/vacuum/roborock/vacuumcontainers.py
@@ -502,7 +502,10 @@ class Timer(DeviceStatus):
 
     @property
     def next_schedule(self) -> datetime:
-        """Next schedule for the timer."""
+        """Next schedule for the timer.
+
+        Note, this value will not be updated after the Timer object has been created.
+        """
         if self._next_schedule is None:
             self._next_schedule = self.croniter.get_next(ret_type=datetime)
         return self._next_schedule

--- a/miio/integrations/vacuum/roborock/vacuumcontainers.py
+++ b/miio/integrations/vacuum/roborock/vacuumcontainers.py
@@ -462,6 +462,7 @@ class Timer(DeviceStatus):
 
         # Initialize croniter to cause an exception on invalid entries (#847)
         self.croniter = croniter(self.cron, start_time=localized_ts)
+        self._next_schedule: Optional[datetime] = None
 
     @property
     def id(self) -> str:
@@ -502,7 +503,9 @@ class Timer(DeviceStatus):
     @property
     def next_schedule(self) -> datetime:
         """Next schedule for the timer."""
-        return self.croniter.get_next(ret_type=datetime)
+        if self._next_schedule is None:
+            self._next_schedule = self.croniter.get_next(ret_type=datetime)
+        return self._next_schedule
 
 
 class SoundStatus(DeviceStatus):


### PR DESCRIPTION
Every call to `get_next` of a `croniter` instance returns a different timestamp (because it's a **cron** **iter**ator).

```python3
from croniter import croniter
from datetime import datetime

cron = croniter("* * * * *", datetime(2022, 1, 1))

cron.get_next(ret_type=datetime) # returns datetime.datetime(2022, 1, 1, 0, 1)
cron.get_next(ret_type=datetime) # returns datetime.datetime(2022, 1, 1, 0, 2)
cron.get_next(ret_type=datetime) # returns datetime.datetime(2022, 1, 1, 0, 3)
```

Because of this `Timer.next_schedule` will return different values each time. I don't think this is intended.

This PR will fix this behavior.