### PR TITLE
Add support for dreame.vacuum.p2029

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ Supported devices
 -  Xiaomi Mijia 360 1080p
 -  Xiaomi Mijia STYJ02YM (Viomi)
 -  Xiaomi Mijia 1C STYTJ01ZHM (Dreame)
--  Dreame F9, D9, Z10 Pro
+-  Dreame F9, D9, L10 Pro, Z10 Pro
 -  Dreame Trouver Finder
 -  Xiaomi Mi Home (Mijia) G1 Robot Vacuum Mop MJSTG1
 -  Xiaomi Roidmi Eve

--- a/miio/integrations/vacuum/dreame/dreamevacuum_miot.py
+++ b/miio/integrations/vacuum/dreame/dreamevacuum_miot.py
@@ -21,6 +21,7 @@ DREAME_1C = "dreame.vacuum.mc1808"
 DREAME_F9 = "dreame.vacuum.p2008"
 DREAME_D9 = "dreame.vacuum.p2009"
 DREAME_Z10_PRO = "dreame.vacuum.p2028"
+DREAME_L10_PRO = "dreame.vacuum.p2029"
 DREAME_MOP_2_PRO_PLUS = "dreame.vacuum.p2041o"
 DREAME_MOP_2_ULTRA = "dreame.vacuum.p2150a"
 DREAME_MOP_2 = "dreame.vacuum.p2150o"
@@ -121,6 +122,7 @@ _DREAME_F9_MAPPING: MiotMapping = {
 }
 
 _DREAME_TROUVER_FINDER_MAPPING: MiotMapping = {
+    # https://home.miot-spec.com/spec/dreame.vacuum.p2029
     # https://home.miot-spec.com/spec/dreame.vacuum.p2036
     "battery_level": {"siid": 3, "piid": 1},
     "charging_state": {"siid": 3, "piid": 2},
@@ -167,6 +169,7 @@ MIOT_MAPPING: Dict[str, MiotMapping] = {
     DREAME_F9: _DREAME_F9_MAPPING,
     DREAME_D9: _DREAME_F9_MAPPING,
     DREAME_Z10_PRO: _DREAME_F9_MAPPING,
+    DREAME_L10_PRO: _DREAME_TROUVER_FINDER_MAPPING,
     DREAME_MOP_2_PRO_PLUS: _DREAME_F9_MAPPING,
     DREAME_MOP_2_ULTRA: _DREAME_F9_MAPPING,
     DREAME_MOP_2: _DREAME_F9_MAPPING,
@@ -244,6 +247,7 @@ def _get_cleaning_mode_enum_class(model):
         DREAME_F9,
         DREAME_D9,
         DREAME_Z10_PRO,
+        DREAME_L10_PRO,
         DREAME_MOP_2_PRO_PLUS,
         DREAME_MOP_2_ULTRA,
         DREAME_MOP_2,


### PR DESCRIPTION
Fixes #1052 

By the way:

The only difference between `_DREAME_F9_MAPPING` and `_DREAME_TROUVER_FINDER_MAPPING` is the ordering and this:

```python
_DREAME_F9_MAPPING: MiotMapping = {
    # https://home.miot-spec.com/spec/dreame.vacuum.p2008
    # https://home.miot-spec.com/spec/dreame.vacuum.p2009
    # https://home.miot-spec.com/spec/dreame.vacuum.p2028
    # https://home.miot-spec.com/spec/dreame.vacuum.p2041o
    # https://home.miot-spec.com/spec/dreame.vacuum.p2150a
    # https://home.miot-spec.com/spec/dreame.vacuum.p2150o
    ...
    "delete_timer": {"siid": 18, "piid": 8},
    ...
}

_DREAME_TROUVER_FINDER_MAPPING: MiotMapping = {
    # https://home.miot-spec.com/spec/dreame.vacuum.p2029
    # https://home.miot-spec.com/spec/dreame.vacuum.p2036
    ...
    "delete_timer": {"siid": 8, "aiid": 1},
    ...
}
```

But to be honest, not even one of the specs list siid 18 but all the ssid 8 with aiid 1 as `delete_timer`.