### PR TITLE
Skip write-only properties for miot status requests

### DIFF
--- a/miio/miot_device.py
+++ b/miio/miot_device.py
@@ -27,6 +27,27 @@ class MiotValueType(Enum):
 MiotMapping = Dict[str, Dict[str, Any]]
 
 
+def _filter_request_fields(req):
+    """Return only the parts that belong to the request.."""
+    return {k: v for k, v in req.items() if k in ["did", "siid", "piid"]}
+
+
+def _is_readable_property(prop):
+    """Returns True if a property in the mapping can be read."""
+    # actions cannot be read
+    if "aiid" in prop:
+        _LOGGER.debug("Ignoring action %s for the request", prop)
+        return False
+
+    # if the mapping has access defined, check if the property is readable
+    access = getattr(prop, "access", None)
+    if access is not None and "read" not in access:
+        _LOGGER.debug("Ignoring %s as it has non-read access defined", prop)
+        return False
+
+    return True
+
+
 class MiotDevice(Device):
     """Main class representing a MIoT device.
 
@@ -64,10 +85,14 @@ class MiotDevice(Device):
 
     def get_properties_for_mapping(self, *, max_properties=15) -> list:
         """Retrieve raw properties based on mapping."""
+        mapping = self._get_mapping()
 
         # We send property key in "did" because it's sent back via response and we can identify the property.
-        mapping = self._get_mapping()
-        properties = [{"did": k, **v} for k, v in mapping.items() if "aiid" not in v]
+        properties = [
+            {"did": k, **_filter_request_fields(v)}
+            for k, v in mapping.items()
+            if _is_readable_property(v)
+        ]
 
         return self.get_properties(
             properties, property_getter="get_properties", max_properties=max_properties


### PR DESCRIPTION
This PR changes `get_properties_for_mapping` to ignore write-only properties for requests.
The requests will also now only contain only the expected keys (`did`, `siid`, `piid`) even if the mapping defines some extras.

Fixes #1376