### PR TITLE
Implement embedding DeviceStatus containers

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -256,6 +256,18 @@ Furthermore, it allows defining meta information about properties that are espec
     In practice this means that neither the input nor the output values of functions decorated with
     the descriptors are enforced automatically by this library.
 
+Embedding Containers
+""""""""""""""""""""
+
+Sometimes your device requires multiple I/O requests to gather information you want to expose
+to downstream users. One example of such is Roborock vacuum integration, where the status request
+does not report on information about consumables.
+
+To make it easy for downstream users, you can *embed* other status container classes into a single
+one using :meth:`miio.devicestatus.DeviceStatus.embed`.
+This will create a copy of the exposed descriptors to the main container and act as a proxy to give
+access to the properties of embedded containers.
+
 
 Sensors
 """""""

--- a/miio/integrations/vacuum/roborock/tests/test_vacuum.py
+++ b/miio/integrations/vacuum/roborock/tests/test_vacuum.py
@@ -45,8 +45,34 @@ class DummyVacuum(DummyDevice, RoborockVacuum):
             "water_box_status": 1,
         }
 
+        self.dummies = {}
+        self.dummies["consumables"] = [
+            {
+                "filter_work_time": 32454,
+                "sensor_dirty_time": 3798,
+                "side_brush_work_time": 32454,
+                "main_brush_work_time": 32454,
+            }
+        ]
+        self.dummies["clean_summary"] = [
+            174145,
+            2410150000,
+            82,
+            [
+                1488240000,
+                1488153600,
+                1488067200,
+                1487980800,
+                1487894400,
+                1487808000,
+                1487548800,
+            ],
+        ]
+
         self.return_values = {
-            "get_status": self.vacuum_state,
+            "get_status": lambda x: [self.state],
+            "get_consumable": lambda x: self.dummies["consumables"],
+            "get_clean_summary": lambda x: self.dummies["clean_summary"],
             "app_start": lambda x: self.change_mode("start"),
             "app_stop": lambda x: self.change_mode("stop"),
             "app_pause": lambda x: self.change_mode("pause"),
@@ -76,9 +102,6 @@ class DummyVacuum(DummyDevice, RoborockVacuum):
             self.state["state"] = DummyVacuum.STATE_ZONED_CLEAN
         elif new_mode == "charge":
             self.state["state"] = DummyVacuum.STATE_CHARGING
-
-    def vacuum_state(self, _):
-        return [self.state]
 
 
 @pytest.fixture(scope="class")

--- a/miio/integrations/vacuum/roborock/vacuum.py
+++ b/miio/integrations/vacuum/roborock/vacuum.py
@@ -403,7 +403,10 @@ class RoborockVacuum(Device, VacuumInterface):
     @command()
     def status(self) -> VacuumStatus:
         """Return status of the vacuum."""
-        return VacuumStatus(self.send("get_status")[0])
+        status = VacuumStatus(self.send("get_status")[0])
+        status.embed(self.consumable_status())
+        status.embed(self.clean_history())
+        return status
 
     def enable_log_upload(self):
         raise NotImplementedError("unknown parameters")


### PR DESCRIPTION
Adds `DeviceStatus.embed(self, other: DeviceStatus)` method that allows embedding separate DeviceStatus containers into a single one. This will copy over the switch, setting, and sensor descriptors to the container and prefixing their names with the name of the other class.

Internally, `__getattribute__` is overridden to check if the property name contains ':' and if so, the attribute lookup is done in an embedded class named after the first part of the key.

This PR also converts roborock vacuum integration to expose cleaning summary and consumable statuses using this functionality.