### PR TITLE
Roborock timer: add find_next_schedule to replace next_schedule

### DIFF
--- a/miio/tests/test_vacuums.py
+++ b/miio/tests/test_vacuums.py
@@ -71,9 +71,15 @@ def test_vacuum_timer(mocker):
     assert t.id == "1488667794112"
     assert t.enabled is False
     assert t.cron == "49 22 * * 6"
-    assert t.next_schedule == datetime(
-        2000, 1, 1, 22, 49, tzinfo=UTC
+    with pytest.deprecated_call():
+        assert t.next_schedule == datetime(
+            2000, 1, 1, 22, 49, tzinfo=UTC
+        ), "should figure out the next run"
+    with pytest.deprecated_call():
+        assert t.next_schedule == datetime(
+            2000, 1, 1, 22, 49, tzinfo=UTC
+        ), "should return the same value twice"
+
+    assert t.find_next_schedule(after=datetime(2000, 2, 2)) == datetime(
+        2000, 2, 5, 22, 49, tzinfo=UTC
     ), "should figure out the next run"
-    assert t.next_schedule == datetime(
-        2000, 1, 1, 22, 49, tzinfo=UTC
-    ), "should return the same value twice"


### PR DESCRIPTION
This is a follow up for: https://github.com/rytilahti/python-miio/pull/1520#discussion_r970052935

In PR #1520 we discussed, if `next_schedule` should return the next schedule relative to (A) the time of access or (B) the time of object creation. While alternative B has the advantage of "fresh" data, even if a reference to a Timer is kept for an extended period, it may be surprising to a user that a property of an object can change over time (without any external influence). In other words: I would be surprised, if in a single threaded program the following assertion could ever fail `assert timer.next_schedule == timer.next_schedule`.
If an API behaves in a surprising way, it may lead to bugs as developers assume a certain behavior while using the API (see [principle of least surprise](https://en.wikipedia.org/wiki/Principle_of_least_astonishment)).

As an alternative I suggested deprecating the `next_schedule` property and replace it with a method `find_next_schedule`. A method returning a different value based on the current time is far less surprising (IMHO).

To be honest: I'm not sure if it's worth the change. Maybe programs just should not keep the Timer objects in memory anyhow, as they might get changed by the user or another program at any point in time.