### PR TITLE
Make pushserver more generic

### DIFF
--- a/miio/push_server/test_serverprotocol.py
+++ b/miio/push_server/test_serverprotocol.py
@@ -1,0 +1,122 @@
+import pytest
+
+from miio import Message
+
+from .serverprotocol import ServerProtocol
+
+HOST = "127.0.0.1"
+PORT = 1234
+SERVER_ID = 4141
+DUMMY_TOKEN = bytes.fromhex("0" * 32)
+
+
+@pytest.fixture
+def protocol(mocker, event_loop) -> ServerProtocol:
+    server = mocker.Mock()
+
+    # Mock server id
+    type(server).server_id = mocker.PropertyMock(return_value=SERVER_ID)
+    socket = mocker.Mock()
+
+    proto = ServerProtocol(event_loop, socket, server)
+    proto.transport = mocker.Mock()
+
+    yield proto
+
+
+def test_send_ping_ack(protocol: ServerProtocol, mocker):
+    """Test that ping acks are send as expected."""
+    protocol.send_ping_ACK(HOST, PORT)
+    protocol.transport.sendto.assert_called()
+
+    cargs = protocol.transport.sendto.call_args[0]
+
+    m = Message.parse(cargs[0])
+    assert int.from_bytes(m.header.value.device_id, "big") == SERVER_ID
+    assert m.data.length == 0
+
+    assert cargs[1][0] == HOST
+    assert cargs[1][1] == PORT
+
+
+def test_send_response(protocol: ServerProtocol):
+    """Test that send_response sends valid messages."""
+    payload = {"foo": 1}
+    protocol.send_response(HOST, PORT, 1, DUMMY_TOKEN, payload)
+    protocol.transport.sendto.assert_called()
+
+    cargs = protocol.transport.sendto.call_args[0]
+    m = Message.parse(cargs[0], token=DUMMY_TOKEN)
+    payload = m.data.value
+    assert payload["id"] == 1
+    assert payload["foo"] == 1
+
+
+def test_send_error(protocol: ServerProtocol, mocker):
+    """Test that error payloads are created correctly."""
+    ERR_MSG = "example error"
+    ERR_CODE = -1
+    protocol.send_error(HOST, PORT, 1, DUMMY_TOKEN, code=ERR_CODE, message=ERR_MSG)
+    protocol.send_response = mocker.Mock()  # type: ignore[assignment]
+    protocol.transport.sendto.assert_called()
+
+    cargs = protocol.transport.sendto.call_args[0]
+    m = Message.parse(cargs[0], token=DUMMY_TOKEN)
+    payload = m.data.value
+
+    assert "error" in payload
+    assert payload["error"]["code"] == ERR_CODE
+    assert payload["error"]["error"] == ERR_MSG
+
+
+def test__handle_datagram_from_registered_device(protocol: ServerProtocol, mocker):
+    """Test that events from registered devices are handled correctly."""
+    protocol.server._registered_devices = {HOST: {}}
+    protocol.server._registered_devices[HOST]["token"] = DUMMY_TOKEN
+    dummy_callback = mocker.Mock()
+    protocol.server._registered_devices[HOST]["callback"] = dummy_callback
+
+    PARAMS = {"test_param": 1}
+    payload = {"id": 1, "method": "action:source_device", "params": PARAMS}
+    msg_from_device = protocol._create_message(payload, DUMMY_TOKEN, 4242)
+
+    protocol._handle_datagram_from_registered_device(HOST, PORT, msg_from_device)
+
+    # Assert that a response is sent back
+    protocol.transport.sendto.assert_called()
+
+    # Assert that the callback is called
+    dummy_callback.assert_called()
+    cargs = dummy_callback.call_args[0]
+    assert cargs[2] == PARAMS
+    assert cargs[0] == "source.device"
+    assert cargs[1] == "action"
+
+
+def test_datagram_with_known_method(protocol: ServerProtocol, mocker):
+    """Test that regular client messages are handled properly."""
+    protocol.send_response = mocker.Mock()  # type: ignore[assignment]
+
+    response_payload = {"result": "info response"}
+    protocol.server.methods = {"miIO.info": response_payload}
+
+    msg = protocol._create_message({"id": 1, "method": "miIO.info"}, DUMMY_TOKEN, 1234)
+    protocol._handle_datagram_from_client(HOST, PORT, msg)
+
+    protocol.send_response.assert_called()  # type: ignore
+    cargs = protocol.send_response.call_args[1]  # type: ignore
+    assert cargs["payload"] == response_payload
+
+
+def test_datagram_with_unknown_method(protocol: ServerProtocol, mocker):
+    """Test that regular client messages are handled properly."""
+    protocol.send_error = mocker.Mock()  # type: ignore[assignment]
+    protocol.server.methods = {}
+
+    msg = protocol._create_message({"id": 1, "method": "miIO.info"}, DUMMY_TOKEN, 1234)
+    protocol._handle_datagram_from_client(HOST, PORT, msg)
+
+    protocol.send_error.assert_called()  # type: ignore
+    cargs = protocol.send_error.call_args[0]  # type: ignore
+    assert cargs[4] == -1
+    assert cargs[5] == "unsupported method"

--- a/poetry.lock
+++ b/poetry.lock
@@ -523,6 +523,20 @@ tomli = ">=1.0.0"
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
+name = "pytest-asyncio"
+version = "0.19.0"
+description = "Pytest support for asyncio"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+pytest = ">=6.1.0"
+
+[package.extras]
+testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
+
+[[package]]
 name = "pytest-cov"
 version = "2.12.1"
 description = "Pytest plugin for measuring coverage."
@@ -967,7 +981,7 @@ docs = ["sphinx", "sphinx_click", "sphinxcontrib-apidoc", "sphinx_rtd_theme"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "c9fcfce783eee7f667e48c0e01d96c4da3a999fd5a7d5fbf88b16960234d9e57"
+content-hash = "0367a3767c8d8b6d3b82b49cf730920109e9a59945ffab7ea5b7535e7642d9c8"
 
 [metadata.files]
 alabaster = [
@@ -1421,6 +1435,10 @@ pyparsing = [
 pytest = [
     {file = "pytest-7.1.3-py3-none-any.whl", hash = "sha256:1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7"},
     {file = "pytest-7.1.3.tar.gz", hash = "sha256:4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39"},
+]
+pytest-asyncio = [
+    {file = "pytest-asyncio-0.19.0.tar.gz", hash = "sha256:ac4ebf3b6207259750bc32f4c1d8fcd7e79739edbc67ad0c58dd150b1d072fed"},
+    {file = "pytest_asyncio-0.19.0-py3-none-any.whl", hash = "sha256:7a97e37cfe1ed296e2e84941384bdd37c376453912d397ed39293e0916f521fa"},
 ]
 pytest-cov = [
     {file = "pytest-cov-2.12.1.tar.gz", hash = "sha256:261ceeb8c227b726249b376b8526b600f38667ee314f910353fa318caa01f4d7"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ docs = ["sphinx", "sphinx_click", "sphinxcontrib-apidoc", "sphinx_rtd_theme"]
 pytest = ">=6.2.5"
 pytest-cov = "^2"
 pytest-mock = "^3"
+pytest-asyncio = "*"
 voluptuous = "^0"
 pre-commit = "^2"
 doc8 = "^0"


### PR DESCRIPTION
This generalizes the push server to allow using it for other uses besides event handling, e.g., to create device simulators.
When receiving a datagram from an unregistered device, the implementation will now try to decrypt the contents using a token full of 0s. If the decryption succeeds, the list of previously registered methods (using `add_method(name: str, response: Union[Dict, Callable)`) is used to obtain a response to be send back to the requester. An error is send to the client if no method with the given name is found.

The main motivation behind this change is to make it easier for developers to test miiocli & the library against devices they do not possess by providing easy-to-use device simulators for both miio and miot protocols. The simulator implementations will follow in separate PRs.

@starkillerOG could you please take a look at this PR to make sure I'm not breaking anything event related? I'll add some tests prior getting this merged so that we don't break it accidentally in the future.

TBD:
- [x] Add tests