### PR TITLE
Add basic miIO simulator

### DIFF
--- a/docs/discovery.rst
+++ b/docs/discovery.rst
@@ -1,6 +1,9 @@
 Getting started
 ***************
 
+.. contents:: Contents
+   :local:
+
 Installation
 ============
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,7 @@ who have helped to extend this to cover not only the vacuum cleaner.
     discovery
     troubleshooting
     contributing
+    simulator
     device_docs/index
     push_server
 

--- a/docs/push_server.rst
+++ b/docs/push_server.rst
@@ -6,6 +6,9 @@ such as those from Zigbee devices connected to a gateway device.
 The server itself acts as a miio device receiving the events it has :ref:`subscribed to receive<events_subscribe>`,
 and calling the registered callbacks accordingly.
 
+.. contents:: Contents
+   :local:
+
 .. note::
 
     While the eventing has been so far tested only on gateway devices, other devices that allow scene definitions on the

--- a/docs/simulator.rst
+++ b/docs/simulator.rst
@@ -1,0 +1,166 @@
+Device Simulators
+*****************
+
+This section describes how to use and develop device simulators that can be useful when
+developing either this library and its CLI tool, as well as when developing applications
+communicating with MiIO/MiOT devices, like the Home Assistant integration, even when you
+have no access to real devices.
+
+.. contents:: Contents
+   :local:
+
+
+MiIO Simulator
+--------------
+
+The ``miiocli devtools miio-simulator`` command can be used to simulate devices.
+You can command the simulated devices using the ``miiocli`` tool or any other implementation
+that talks the MiIO proocol, like `Home Assistant <https://www.home-assistant.io>`_.
+
+Behind the scenes, the simulator uses :class:`the push server <miio.push_server.server.PushServer>` to
+handle the low-level protocol handling.
+To make it easy to simulate devices, it uses YAML-based :ref:`device description files <miio_device_descriptions>`
+to describe information like models and exposed properties to simulate.
+
+.. note::
+
+    The simulator currently supports only devices whose properties are queried using ``get_prop`` method,
+    and whose properties are set using a single setter method (e.g., ``set_fan_speed``) accepting the new value.
+
+
+Usage
+"""""
+
+You start the simulator like this::
+
+    miiocli devtools miio-simulator --file miio/integrations/fan/zhimi/zhimi_fan.yaml
+
+The mandatory ``--file`` option takes a path to :ref:`a device description file <miio_device_descriptions>` file
+that defines information about the device to be simulated.
+
+.. note::
+
+    You can define ``--model`` to define which model string you want to expose to the clients.
+    The MAC address of the device is generated from the model string, making them unique for
+    downstream use cases, e.g., to make them distinguishable to Home Assistant.
+
+After the simulator has started, you can communicate with it using the ``miiocli``::
+
+    $ export MIIO_FAN_TOKEN=00000000000000000000000000000000
+
+    $ miiocli fan --host 127.0.0.1 info
+
+    Model: zhimi.fan.sa1
+    Hardware version: MW300
+    Firmware version: 1.2.4_16
+
+    $ miiocli fan --ip 127.0.0.1 status
+
+    Power: on
+    Battery: None %
+    AC power: True
+    Temperature: None °C
+    Humidity: None %
+    LED: None
+    LED brightness: LedBrightness.Bright
+    Buzzer: False
+    Child lock: False
+    Speed: 277
+    Natural speed: 2
+    Direct speed: 1
+    Oscillate: False
+    Power-off time: 12
+    Angle: 120
+
+
+.. note::
+
+    The default token is hardcoded to full of zeros (``00000000000000000000000000000000``).
+    We defined ``MIIO_FAN_TOKEN`` to avoid repeating ``--token`` for each command.
+
+.. note::
+
+    Although Home Assistant uses MAC address as a unique ID to identify the device, the model information
+    is stored in the configuration entry which is used to initialize the integration.
+
+    Therefore, if you are testing multiple simulated devices in Home Assistant, you want to disable other simulated
+    integrations inside Home Assistant to avoid them being updated against a wrong simulated device.
+
+.. _miio_device_descriptions:
+
+Device Descriptions
+"""""""""""""""""""
+
+The simulator uses YAML files that describe information about the device, including supported models
+and the available properties.
+
+Required Information
+~~~~~~~~~~~~~~~~~~~~
+
+The file begins with a definition of models supported by the file:
+
+.. code-block:: yaml
+
+    models:
+      - name: Name of the device, if known
+        model: model.string.v2
+      - model: model.string.v3
+
+You need to have ``model`` for each model the description file wants to support.
+The name is not required, but recommended.
+This information is currently used to set the model information for the simulated
+device when not overridden using the ``--model`` option.
+
+The description file needs to define a list of properties the device supports.
+You need to define several mappings for each property:
+
+    * ``name`` defines the name used for fetching using the ``get_prop`` request
+    * ``type`` defines the type of the property, e.g., ``bool``, ``int``, or ``str``
+    * ``value`` is the value which is returned for ``get_prop`` requests
+    * ``setter`` defines the method that allows changing the ``value``
+    * ``models`` list, if the property is only available on some of the supported models
+
+.. note::
+
+    The schema might change in the future to accommodate other potential uses, e.g., allowing
+    definition of new files using pure YAML without a need for Python implementation.
+    Refer :ref:`example_desc` for a complete, working example.
+
+Minimal Working Example
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The following defining a very minimal device description having a single model with two properties:
+
+.. code-block:: yaml
+
+    models:
+      - name: Some Fan
+        model: some.fan.model
+    properties:
+      - name: speed
+        type: int
+        value: 33
+        setter: set_speed
+      - name: is_on
+        type: bool
+        value: false
+
+In this case, the ``get_prop`` method call with parameters ``['speed', 'is_on']`` will return ``[33, 0]``.
+The ``speed`` property can be changed by calling the ``set_speed`` method.
+See :ref:`example_desc` for a more complete example.
+
+.. _example_desc:
+
+Example Description File
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following description file shows a complete, concrete example of a description file (``zhimi_fan.yaml``):
+
+.. literalinclude:: ../miio/integrations/fan/zhimi/zhimi_fan.yaml
+   :language: yaml
+
+
+MiOT Simulator
+--------------
+
+.. note:: TBD.

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -5,6 +5,10 @@ This page lists some known issues and potential solutions.
 If you are having problems with incorrectly working commands or missing features,
 please refer to :ref:`new_devices` for information how to analyze the device traffic.
 
+.. contents:: Contents
+   :local:
+
+
 Discover devices across subnets
 -------------------------------
 

--- a/miio/devtools/__init__.py
+++ b/miio/devtools/__init__.py
@@ -5,6 +5,9 @@ import click
 
 from .pcapparser import parse_pcap
 from .propertytester import test_properties
+from .simulators import miio_simulator
+
+# from .simulators import miot_simulator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -17,3 +20,5 @@ def devtools(ctx: click.Context):
 
 devtools.add_command(parse_pcap)
 devtools.add_command(test_properties)
+devtools.add_command(miio_simulator)
+# devtools.add_command(miot_simulator)

--- a/miio/devtools/simulators/__init__.py
+++ b/miio/devtools/simulators/__init__.py
@@ -1,0 +1,4 @@
+# from .miotsimulator import miot_simulator
+from .miiosimulator import miio_simulator
+
+__all__ = ["miio_simulator"]

--- a/miio/devtools/simulators/common.py
+++ b/miio/devtools/simulators/common.py
@@ -1,0 +1,40 @@
+"""Common functionalities for miio and miot simulators."""
+from hashlib import md5
+
+
+def create_info_response(model, mac):
+    """Create a response for miIO.info call using the given model and mac."""
+    INFO_RESPONSE = {
+        "ap": {"bssid": "FF:FF:FF:FF:FF:FF", "rssi": -68, "ssid": "network"},
+        "cfg_time": 0,
+        "fw_ver": "1.2.4_16",
+        "hw_ver": "MW300",
+        "life": 24,
+        "mac": mac,
+        "mmfree": 30312,
+        "model": model,
+        "netif": {
+            "gw": "192.168.xxx.x",
+            "localIp": "192.168.xxx.x",
+            "mask": "255.255.255.0",
+        },
+        "ot": "otu",
+        "ott_stat": [0, 0, 0, 0],
+        "otu_stat": [320, 267, 3, 0, 3, 742],
+        "token": 32 * "0",
+        "wifi_fw_ver": "SD878x-14.76.36.p84-702.1.0-WM",
+    }
+    return INFO_RESPONSE
+
+
+def mac_from_model(model):
+    """Creates a mac address based on the model name.
+
+    This allows simulating multiple different devices separately as the homeassistant
+    unique_id is based on the mac address.
+    """
+    m = md5()  # nosec
+    m.update(model.encode())
+    digest = m.hexdigest()[:12]
+    mac = ":".join([digest[i : i + 2] for i in range(0, len(digest), 2)])
+    return mac

--- a/miio/devtools/simulators/miiosimulator.py
+++ b/miio/devtools/simulators/miiosimulator.py
@@ -66,7 +66,7 @@ class SimulatedMiio(BaseModel):
     properties: List[MiioProperty]
     name: Optional[str] = Field(default="Unnamed integration")
     actions: Optional[List[MiioAction]] = Field(default=[])
-    _model: Optional[str] = PrivateAttr()
+    _model: Optional[str] = PrivateAttr(default=None)
 
     class Config:
         extra = "forbid"

--- a/miio/devtools/simulators/miiosimulator.py
+++ b/miio/devtools/simulators/miiosimulator.py
@@ -1,0 +1,138 @@
+"""Implementation of miio simulator."""
+import asyncio
+import logging
+from typing import List, Optional, Union
+
+import click
+from pydantic import BaseModel, Field, PrivateAttr
+from yaml import safe_load
+
+from miio import PushServer
+
+from .common import create_info_response, mac_from_model
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Format(type):
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.convert_type
+
+    @classmethod
+    def convert_type(cls, input: str):
+        type_map = {
+            "bool": bool,
+            "int": int,
+            "str_bool": str,
+            "str": str,
+            "float": float,
+        }
+        return type_map[input]
+
+
+class MiioProperty(BaseModel):
+    """Single miio property."""
+
+    name: str
+    type: Format
+    value: Optional[Union[str, bool, int]]
+    models: List[str] = Field(default=[])
+    setter: Optional[str] = None
+    description: Optional[str] = None
+    min: Optional[int] = None
+    max: Optional[int] = None
+
+    class Config:
+        extra = "forbid"
+
+
+class MiioAction(BaseModel):
+    """Simulated miio action."""
+
+
+class MiioModel(BaseModel):
+    """Model information."""
+
+    model: str
+    name: Optional[str] = "unknown name"
+
+
+class SimulatedMiio(BaseModel):
+    """Simulated device model for miio devices."""
+
+    models: List[MiioModel]
+    type: str
+    properties: List[MiioProperty]
+    name: Optional[str] = Field(default="Unnamed integration")
+    actions: Optional[List[MiioAction]] = Field(default=[])
+    _model: Optional[str] = PrivateAttr()
+
+    class Config:
+        extra = "forbid"
+
+
+class MiioSimulator:
+    """Simple miio device simulator."""
+
+    def __init__(self, dev: SimulatedMiio, server: PushServer):
+        self._dev = dev
+        self._setters = {}
+        self._server = server
+
+        # If no model is given, use one from the supported ones
+        if self._dev._model is None:
+            self._dev._model = next(iter(self._dev.models)).model
+
+        server.add_method("get_prop", self.get_prop)
+        # initialize setters
+        for prop in self._dev.properties:
+            if prop.models and self._dev._model not in prop.models:
+                continue
+            if prop.setter is not None:
+                self._setters[prop.setter] = prop
+                server.add_method(prop.setter, self.handle_set)
+
+    def get_prop(self, payload):
+        """Handle get_prop."""
+        params = payload["params"]
+
+        resp = []
+        current_state = {prop.name: prop for prop in self._dev.properties}
+        for param in params:
+            p = current_state[param]
+            resp.append(p.type(p.value))
+
+        return {"result": resp}
+
+    def handle_set(self, payload):
+        """Handle setter methods."""
+        _LOGGER.info("Got setter call with %s", payload)
+        self._setters[payload["method"]].value = payload["params"][0]
+
+        return {"result": ["ok"]}
+
+
+async def main(dev):
+    server = PushServer()
+
+    _ = MiioSimulator(dev=dev, server=server)
+    mac = mac_from_model(dev._model)
+    server.add_method("miIO.info", create_info_response(dev._model, mac))
+
+    transport, proto = await server.start()
+
+
+@click.command()
+@click.option("--file", type=click.File("r"), required=True)
+@click.option("--model", type=str, required=False)
+def miio_simulator(file, model):
+    """Simulate miio device."""
+    data = file.read()
+    dev = SimulatedMiio.parse_obj(safe_load(data))
+    _LOGGER.info("Available models: %s", dev.models)
+    if model is not None:
+        dev._model = model
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(main(dev))
+    loop.run_forever()

--- a/miio/integrations/fan/zhimi/zhimi_fan.yaml
+++ b/miio/integrations/fan/zhimi/zhimi_fan.yaml
@@ -1,0 +1,103 @@
+models:
+  - model: zhimi.fan.sa1
+  - model: zhimi.fan.za1
+  - model: zhimi.fan.za3
+  - model: zhimi.fan.za4
+  - model: zhimi.fan.v3
+  - model: zhimi.fan.v2
+type: fan
+properties:
+  - name: angle
+    value: 120
+    type: int
+    min: 0
+    max: 120
+    setter: set_angle
+  - name: speed
+    value: 277
+    type: int
+    setter: set_speed_level
+    min: 0
+    max: 100
+  - name: poweroff_time
+    value: 12
+    type: int
+    setter: set_poweroff_time
+  - name: power
+    value: 'on'
+    type: str_bool
+    setter: set_power
+  - name: ac_power
+    value: 'on'
+    type: str_bool
+  - name: angle_enable
+    value: 'off'
+    setter: set_angle_enable
+    type: str_bool
+  - name: speed_level
+    value: 1
+    type: int
+    min: 0
+    max: 100
+    setter: set_speed_level
+  - name: natural_level
+    value: 2
+    type: int
+    setter: set_natural_level
+  - name: child_lock
+    value: 'off'
+    type: str_bool
+    setter: set_child_lock
+  - name: buzzer
+    value: 0
+    type: int
+    setter: set_buzzer
+  - name: led_b
+    value: 0
+    type: int
+    setter: set_led_b
+  - name: use_time
+    value: 2318
+    type: int
+  # V2 & V3 only
+  - name: temp_dec
+    value: 232
+    type: float
+    models:
+      - zhimi.fan.v3
+      - zhimi.fan.v2
+  - name: humidity
+    value: 46
+    type: int
+    models:
+      - zhimi.fan.v3
+      - zhimi.fan.v2
+  - name: battery
+    type: int
+    value: 98
+    models:
+      - zhimi.fan.v3
+      - zhimi.fan.v2
+  - name: bat_charge
+    value: "complete"
+    type: str
+    models:
+      - zhimi.fan.v3
+      - zhimi.fan.v2
+  - name: button_pressed
+    type: str
+    value: speed
+    models:
+      - zhimi.fan.v3
+      - zhimi.fan.v2
+  # V2 only properties
+  - name: led
+    type: str
+    value: null
+    models:
+      - zhimi.fan.v2
+  - name: bat_state
+    type: str
+    value: "unknown state"
+    models:
+      - zhimi.fan.v2

--- a/poetry.lock
+++ b/poetry.lock
@@ -481,6 +481,21 @@ optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "pydantic"
+version = "1.10.2"
+description = "Data validation and settings management using python type hints"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+typing-extensions = ">=4.1.0"
+
+[package.extras]
+dotenv = ["python-dotenv (>=0.10.4)"]
+email = ["email-validator (>=1.0.3)"]
+
+[[package]]
 name = "Pygments"
 version = "2.13.0"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -876,7 +891,7 @@ telegram = ["requests"]
 name = "typing-extensions"
 version = "4.3.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -981,7 +996,7 @@ docs = ["sphinx", "sphinx_click", "sphinxcontrib-apidoc", "sphinx_rtd_theme"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "0367a3767c8d8b6d3b82b49cf730920109e9a59945ffab7ea5b7535e7642d9c8"
+content-hash = "6bb49788f567124d559ea3804d3d5b45224fdf5809912ddd16602470952bb019"
 
 [metadata.files]
 alabaster = [
@@ -1423,6 +1438,44 @@ pycryptodome = [
     {file = "pycryptodome-3.15.0-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:d2a39a66057ab191e5c27211a7daf8f0737f23acbf6b3562b25a62df65ffcb7b"},
     {file = "pycryptodome-3.15.0-pp36-pypy36_pp73-win32.whl", hash = "sha256:9c772c485b27967514d0df1458b56875f4b6d025566bf27399d0c239ff1b369f"},
     {file = "pycryptodome-3.15.0.tar.gz", hash = "sha256:9135dddad504592bcc18b0d2d95ce86c3a5ea87ec6447ef25cfedea12d6018b8"},
+]
+pydantic = [
+    {file = "pydantic-1.10.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bb6ad4489af1bac6955d38ebcb95079a836af31e4c4f74aba1ca05bb9f6027bd"},
+    {file = "pydantic-1.10.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a1f5a63a6dfe19d719b1b6e6106561869d2efaca6167f84f5ab9347887d78b98"},
+    {file = "pydantic-1.10.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:352aedb1d71b8b0736c6d56ad2bd34c6982720644b0624462059ab29bd6e5912"},
+    {file = "pydantic-1.10.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:19b3b9ccf97af2b7519c42032441a891a5e05c68368f40865a90eb88833c2559"},
+    {file = "pydantic-1.10.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:e9069e1b01525a96e6ff49e25876d90d5a563bc31c658289a8772ae186552236"},
+    {file = "pydantic-1.10.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:355639d9afc76bcb9b0c3000ddcd08472ae75318a6eb67a15866b87e2efa168c"},
+    {file = "pydantic-1.10.2-cp310-cp310-win_amd64.whl", hash = "sha256:ae544c47bec47a86bc7d350f965d8b15540e27e5aa4f55170ac6a75e5f73b644"},
+    {file = "pydantic-1.10.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a4c805731c33a8db4b6ace45ce440c4ef5336e712508b4d9e1aafa617dc9907f"},
+    {file = "pydantic-1.10.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d49f3db871575e0426b12e2f32fdb25e579dea16486a26e5a0474af87cb1ab0a"},
+    {file = "pydantic-1.10.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:37c90345ec7dd2f1bcef82ce49b6235b40f282b94d3eec47e801baf864d15525"},
+    {file = "pydantic-1.10.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b5ba54d026c2bd2cb769d3468885f23f43710f651688e91f5fb1edcf0ee9283"},
+    {file = "pydantic-1.10.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:05e00dbebbe810b33c7a7362f231893183bcc4251f3f2ff991c31d5c08240c42"},
+    {file = "pydantic-1.10.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:2d0567e60eb01bccda3a4df01df677adf6b437958d35c12a3ac3e0f078b0ee52"},
+    {file = "pydantic-1.10.2-cp311-cp311-win_amd64.whl", hash = "sha256:c6f981882aea41e021f72779ce2a4e87267458cc4d39ea990729e21ef18f0f8c"},
+    {file = "pydantic-1.10.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c4aac8e7103bf598373208f6299fa9a5cfd1fc571f2d40bf1dd1955a63d6eeb5"},
+    {file = "pydantic-1.10.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:81a7b66c3f499108b448f3f004801fcd7d7165fb4200acb03f1c2402da73ce4c"},
+    {file = "pydantic-1.10.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bedf309630209e78582ffacda64a21f96f3ed2e51fbf3962d4d488e503420254"},
+    {file = "pydantic-1.10.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:9300fcbebf85f6339a02c6994b2eb3ff1b9c8c14f502058b5bf349d42447dcf5"},
+    {file = "pydantic-1.10.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:216f3bcbf19c726b1cc22b099dd409aa371f55c08800bcea4c44c8f74b73478d"},
+    {file = "pydantic-1.10.2-cp37-cp37m-win_amd64.whl", hash = "sha256:dd3f9a40c16daf323cf913593083698caee97df2804aa36c4b3175d5ac1b92a2"},
+    {file = "pydantic-1.10.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b97890e56a694486f772d36efd2ba31612739bc6f3caeee50e9e7e3ebd2fdd13"},
+    {file = "pydantic-1.10.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:9cabf4a7f05a776e7793e72793cd92cc865ea0e83a819f9ae4ecccb1b8aa6116"},
+    {file = "pydantic-1.10.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06094d18dd5e6f2bbf93efa54991c3240964bb663b87729ac340eb5014310624"},
+    {file = "pydantic-1.10.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cc78cc83110d2f275ec1970e7a831f4e371ee92405332ebfe9860a715f8336e1"},
+    {file = "pydantic-1.10.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:1ee433e274268a4b0c8fde7ad9d58ecba12b069a033ecc4645bb6303c062d2e9"},
+    {file = "pydantic-1.10.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:7c2abc4393dea97a4ccbb4ec7d8658d4e22c4765b7b9b9445588f16c71ad9965"},
+    {file = "pydantic-1.10.2-cp38-cp38-win_amd64.whl", hash = "sha256:0b959f4d8211fc964772b595ebb25f7652da3f22322c007b6fed26846a40685e"},
+    {file = "pydantic-1.10.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c33602f93bfb67779f9c507e4d69451664524389546bacfe1bee13cae6dc7488"},
+    {file = "pydantic-1.10.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5760e164b807a48a8f25f8aa1a6d857e6ce62e7ec83ea5d5c5a802eac81bad41"},
+    {file = "pydantic-1.10.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6eb843dcc411b6a2237a694f5e1d649fc66c6064d02b204a7e9d194dff81eb4b"},
+    {file = "pydantic-1.10.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4b8795290deaae348c4eba0cebb196e1c6b98bdbe7f50b2d0d9a4a99716342fe"},
+    {file = "pydantic-1.10.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:e0bedafe4bc165ad0a56ac0bd7695df25c50f76961da29c050712596cf092d6d"},
+    {file = "pydantic-1.10.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:2e05aed07fa02231dbf03d0adb1be1d79cabb09025dd45aa094aa8b4e7b9dcda"},
+    {file = "pydantic-1.10.2-cp39-cp39-win_amd64.whl", hash = "sha256:c1ba1afb396148bbc70e9eaa8c06c1716fdddabaf86e7027c5988bae2a829ab6"},
+    {file = "pydantic-1.10.2-py3-none-any.whl", hash = "sha256:1b6ee725bd6e83ec78b1aa32c5b1fa67a3a65badddde3976bca5fe4568f27709"},
+    {file = "pydantic-1.10.2.tar.gz", hash = "sha256:91b8e218852ef6007c2b98cd861601c6a09f1aa32bbbb74fab5b1c33d4a1e410"},
 ]
 Pygments = [
     {file = "Pygments-2.13.0-py3-none-any.whl", hash = "sha256:f643f331ab57ba3c9d89212ee4a2dabc6e94f117cf4eefde99a0574720d14c42"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ android_backup = { version = "^0", optional = true }
 micloud = { version = "*", optional = true }
 croniter = ">=1"
 defusedxml = "^0"
+pydantic = "*"
 
 sphinx = { version = ">=4.2", optional = true }
 sphinx_click = { version = "*", optional = true }

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ deps=
   restructuredtext_lint
   sphinx-autodoc-typehints
   sphinx-click
+  pydantic
 commands=
   doc8 docs
   rst-lint README.rst docs/*.rst


### PR DESCRIPTION
This makes it easier for developers without a real test device to perform some development and testing on device integrations.

To use the simulator, one needs to create a definition file with available properties, their types, initial values and methods that can be used to change them.
Uses currently pydantic for file parsing, the imports should be guarded if a new dependency for non-developers is unwanted.
These files could be later on used for unit-testing the implementations without custom test files, and maybe more (creating list of supported models, ..).

At the moment, this basic implementation only allows simulating devices that use get_prop for getting the properties and a single setter to change their state.

The token is currently hardcoded to full of 0s.
The MAC address will be generated using the model name to allow make instances on the same host unique (e.g., for homeassistant testing).

Example usage: `miiocli devtools miio-simulator --file zhimi_fan.yaml  --model zhimi.fan.v2`

TBD:
- [x] Based on #1531 which should get merged first.
- [x] Add docs