### PR TITLE
Allow custom methods for miio simulator

### DIFF
--- a/docs/simulator.rst
+++ b/docs/simulator.rst
@@ -120,6 +120,12 @@ You need to define several mappings for each property:
     * ``setter`` defines the method that allows changing the ``value``
     * ``models`` list, if the property is only available on some of the supported models
 
+.. note::
+
+    The schema might change in the future to accommodate other potential uses, e.g., allowing
+    definition of new files using pure YAML without a need for Python implementation.
+    Refer :ref:`example_desc` for a complete, working example.
+
 Alternatively, you can define *methods* with their responses by defining ``methods``, which is necessary to simulate
 devices that use other ways to obtain the status information (e.g., on Roborock vacuums).
 You can either use ``result`` or ``result_json`` to define the response for the given method:
@@ -134,18 +140,16 @@ You can either use ``result`` or ``result_json`` to define the response for the 
       - name: get_timezone
         result_json: '["UTC"]'
 
+Calling method ``get_status`` will return ``[{"some_variable": 1, "another_variable": "foo"}]``,
+the ``result_json`` will be parsed and serialized to ``["UTC"]`` when sent to the client.
 A full working example can be found in :ref:`example_desc_methods`.
 
-.. note::
-
-    The schema might change in the future to accommodate other potential uses, e.g., allowing
-    definition of new files using pure YAML without a need for Python implementation.
-    Refer :ref:`example_desc` for a complete, working example.
 
 Minimal Working Example
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-The following defining a very minimal device description having a single model with two properties:
+The following YAML file defines a very minimal device having a single model with two properties,
+and exposing also a custom method (``reboot``):
 
 .. code-block:: yaml
 
@@ -184,7 +188,7 @@ concrete example for a device using ``get_prop`` for accessing the properties (`
 Example Description File Using Methods
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following description file shows a complete,
+The following description file (``simulated_roborock.yaml``) shows a complete,
 concrete example for a device using custom method names for obtaining the status.
 
 .. literalinclude:: ../miio/integrations/vacuum/roborock/simulated_roborock.yaml

--- a/docs/simulator.rst
+++ b/docs/simulator.rst
@@ -111,7 +111,7 @@ The name is not required, but recommended.
 This information is currently used to set the model information for the simulated
 device when not overridden using the ``--model`` option.
 
-The description file needs to define a list of properties the device supports.
+The description file can define a list of *properties* the device supports for ``get_prop`` queries.
 You need to define several mappings for each property:
 
     * ``name`` defines the name used for fetching using the ``get_prop`` request
@@ -119,6 +119,22 @@ You need to define several mappings for each property:
     * ``value`` is the value which is returned for ``get_prop`` requests
     * ``setter`` defines the method that allows changing the ``value``
     * ``models`` list, if the property is only available on some of the supported models
+
+Alternatively, you can define *methods* with their responses by defining ``methods``, which is necessary to simulate
+devices that use other ways to obtain the status information (e.g., on Roborock vacuums).
+You can either use ``result`` or ``result_json`` to define the response for the given method:
+
+.. code-block:: yaml
+
+    methods:
+      - name: get_status
+        result:
+          - some_variable: 1
+            another_variable: "foo"
+      - name: get_timezone
+        result_json: '["UTC"]'
+
+A full working example can be found in :ref:`example_desc_methods`.
 
 .. note::
 
@@ -144,6 +160,9 @@ The following defining a very minimal device description having a single model w
       - name: is_on
         type: bool
         value: false
+    methods:
+      - name: reboot
+        result_json: '["ok"]'
 
 In this case, the ``get_prop`` method call with parameters ``['speed', 'is_on']`` will return ``[33, 0]``.
 The ``speed`` property can be changed by calling the ``set_speed`` method.
@@ -154,9 +173,21 @@ See :ref:`example_desc` for a more complete example.
 Example Description File
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following description file shows a complete, concrete example of a description file (``zhimi_fan.yaml``):
+The following description file shows a complete,
+concrete example for a device using ``get_prop`` for accessing the properties (``zhimi_fan.yaml``):
 
 .. literalinclude:: ../miio/integrations/fan/zhimi/zhimi_fan.yaml
+   :language: yaml
+
+.. _example_desc_methods:
+
+Example Description File Using Methods
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following description file shows a complete,
+concrete example for a device using custom method names for obtaining the status.
+
+.. literalinclude:: ../miio/integrations/vacuum/roborock/simulated_roborock.yaml
    :language: yaml
 
 

--- a/miio/integrations/vacuum/roborock/simulated_roborock.yaml
+++ b/miio/integrations/vacuum/roborock/simulated_roborock.yaml
@@ -1,0 +1,65 @@
+models:
+  - model: roborock.vacuum.a15
+type: vacuum
+methods:
+  - name: get_status
+    result:
+      - _model: roborock.vacuum.a15  # internal note where this status came from
+        adbumper_status:
+          - 0
+          - 0
+          - 0
+        auto_dust_collection: 1
+        battery: 87
+        clean_area: 35545000
+        clean_time: 2311
+        debug_mode: 0
+        dnd_enabled: 0
+        dock_type: 0
+        dust_collection_status: 0
+        error_code: 0
+        fan_power: 102
+        in_cleaning: 0
+        in_fresh_state: 1
+        in_returning: 0
+        is_locating: 0
+        lab_status: 3
+        lock_status: 0
+        map_present: 1
+        map_status: 3
+        mop_forbidden_enable: 0
+        mop_mode: 300
+        msg_seq: 1839
+        msg_ver: 2
+        state: 8
+        water_box_carriage_status: 0
+        water_box_mode: 202
+        water_box_status: 1
+        water_shortage_status: 0
+  - name: get_consumable
+    result:
+      - filter_work_time: 32454
+        sensor_dirty_time: 3798
+        side_brush_work_time: 32454
+        main_brush_work_time: 32454
+  - name: get_clean_summary
+    result_json: '[ 174145, 2410150000, 82, [ 1488240000, 1488153600, 1488067200, 1487980800, 1487894400, 1487808000, 1487548800 ] ]'
+  - name: get_timer
+    result_json: '[["1488667794112", "off", ["49 22 * * 6", ["start_clean", ""]], ["1488667777661", "off", ["49 21 * * 3,4,5,6", ["start_clean", ""]]]]]'
+  - name: get_timezone
+    result_json: '["UTC"]'
+  - name: get_dnd_timer
+    result:
+      - enabled: 1
+        start_minute: 0
+        end_minute: 0
+        start_hour: 22
+        end_hour: 8
+  - name: get_clean_record
+    result:
+      - begin: 1488347071
+        end: 1488347123
+        duration: 16
+        area: 0
+        error: 0
+        complete: 0


### PR DESCRIPTION
This will allow simulating devices that do use other methods besides "get_prop" for fetching the properties.

The result can be defined either as regular yaml object (`result`) or as json string (`result_json`).

Added simulated roborock s7 as an example case, looks like the status container embedding is working as expected (@starkillerOG):
![image](https://user-images.githubusercontent.com/3705853/192322662-82e53300-bce0-4fe8-912f-b7a2c9def6a7.png)
