### PR TITLE
Prefer newest, released release for miottemplate

### DIFF
--- a/devtools/miottemplate.py
+++ b/devtools/miottemplate.py
@@ -138,11 +138,12 @@ def download(ctx, urn, model):
             ctx.invoke(download_mapping)
 
         mapping = get_mapping()
-        urn = mapping.urn_for_model(model)
+        model = mapping.info_for_model(model)
 
-    url = f"https://miot-spec.org/miot-spec-v2/instance?type={urn}"
+    url = f"https://miot-spec.org/miot-spec-v2/instance?type={model.type}"
+    click.echo("Going to download %s" % url)
     content = requests.get(url)
-    save_to = f"{urn}.json"
+    save_to = model.filename
     click.echo(f"Saving data to {save_to}")
     with open(save_to, "w") as f:
         f.write(content.text)


### PR DESCRIPTION
Previously, miottemplate downloaded the first match when multiple were responded. This PR changes the behavior to download the newest, released (status=released) schema file.

This also fixes the previously broken download functionality.