### PR TITLE
Make embedded statuses directly accessible attributes

### DIFF
--- a/miio/devicestatus.py
+++ b/miio/devicestatus.py
@@ -119,6 +119,7 @@ class DeviceStatus(metaclass=_StatusMeta):
         other_name = str(other.__class__.__name__)
 
         self._embedded[other_name] = other
+        setattr(self, other_name, other)
 
         for name, sensor in other.sensors().items():
             final_name = f"{other_name}:{name}"
@@ -133,14 +134,6 @@ class DeviceStatus(metaclass=_StatusMeta):
         for name, setting in other.settings().items():
             final_name = f"{other_name}:{name}"
             self._settings[final_name] = attr.evolve(setting, property=final_name)
-
-    def __getattribute__(self, item):
-        """Overridden to lookup properties from embedded containers."""
-        if ":" not in item:
-            return super().__getattribute__(item)
-
-        embed, prop = item.split(":")
-        return getattr(self._embedded[embed], prop)
 
 
 def sensor(name: str, *, unit: str = "", **kwargs):

--- a/miio/devicestatus.py
+++ b/miio/devicestatus.py
@@ -135,6 +135,13 @@ class DeviceStatus(metaclass=_StatusMeta):
             final_name = f"{other_name}:{name}"
             self._settings[final_name] = attr.evolve(setting, property=final_name)
 
+    def __getattribute__(self, item):
+        """Overridden to lookup properties from embedded containers."""
+        if ":" not in item:
+            return super().__getattribute__(item)
+
+        embed, prop = item.split(":")
+        return getattr(self._embedded[embed], prop)
 
 def sensor(name: str, *, unit: str = "", **kwargs):
     """Syntactic sugar to create SensorDescriptor objects.

--- a/miio/devicestatus.py
+++ b/miio/devicestatus.py
@@ -143,6 +143,7 @@ class DeviceStatus(metaclass=_StatusMeta):
         embed, prop = item.split(":")
         return getattr(self._embedded[embed], prop)
 
+
 def sensor(name: str, *, unit: str = "", **kwargs):
     """Syntactic sugar to create SensorDescriptor objects.
 

--- a/miio/devicestatus.py
+++ b/miio/devicestatus.py
@@ -63,6 +63,9 @@ class DeviceStatus(metaclass=_StatusMeta):
       introspectable way. See :func:`@property`, :func:`switch`, and :func:`@setting`.
     * :func:`embed` allows embedding other status containers.
     * The __repr__ implementation returns all defined properties and their values.
+    * A `Property` of a embeded `ModuleStatus` container of the `MainStatus` container
+      can be accesed using `ModuleStatus.MainStatus.Property`
+      or `getattr(ModuleStatus, MainStatus:Property)`
     """
 
     def __repr__(self):

--- a/miio/integrations/vacuum/roborock/vacuum.py
+++ b/miio/integrations/vacuum/roborock/vacuum.py
@@ -403,10 +403,15 @@ class RoborockVacuum(Device, VacuumInterface):
     @command()
     def status(self) -> VacuumStatus:
         """Return status of the vacuum."""
-        status = VacuumStatus(self.send("get_status")[0])
+        status = self.vacuum_status()
         status.embed(self.consumable_status())
         status.embed(self.clean_history())
         return status
+
+    @command()
+    def vacuum_status(self) -> VacuumStatus:
+        """Return status of the vacuum."""
+        return VacuumStatus(self.send("get_status")[0])
 
     def enable_log_upload(self):
         raise NotImplementedError("unknown parameters")

--- a/miio/integrations/vacuum/roborock/vacuum.py
+++ b/miio/integrations/vacuum/roborock/vacuum.py
@@ -403,15 +403,10 @@ class RoborockVacuum(Device, VacuumInterface):
     @command()
     def status(self) -> VacuumStatus:
         """Return status of the vacuum."""
-        status = self.vacuum_status()
+        status = VacuumStatus(self.send("get_status")[0])
         status.embed(self.consumable_status())
         status.embed(self.clean_history())
         return status
-
-    @command()
-    def vacuum_status(self) -> VacuumStatus:
-        """Return status of the vacuum."""
-        return VacuumStatus(self.send("get_status")[0])
 
     def enable_log_upload(self):
         raise NotImplementedError("unknown parameters")


### PR DESCRIPTION
Consider this test script with a Roborock vacuum:
```
from miio import RoborockVacuum
r = RoborockVacuum(ip = "192.168.1.IP", token = "TokenTokenToken")
status = r.status()
```

`print(status["CleaningSummary:count"])`
Will give
`TypeError: 'VacuumStatus' object is not subscriptable`

`print(status.CleaningSummary:count)`
will give
`SyntaxError: invalid syntax`
This is a invalid syntax since variable names can only contain (A-Z, a-z), (0-9), and (_), see https://realpython.com/python-variables/#variable-names

~Therefore overwriding __getattribute__ will not work as intended.~
Alright so it does work when using getattr(status, "CleaningSummary:count") which is used inside HomeAssistant for conveniance. So lets keep it.

This PR will make the embeded classes a attribute of the main class, so you can acess the embedded classes using:

`print(status.CleaningSummary.count)`
Which will work

(This is still needed since using normal python scripts there needs to be an easy way to acces the embeded containers)