### PR TITLE
Add descriptors for yeelight

### DIFF
--- a/miio/__init__.py
+++ b/miio/__init__.py
@@ -12,6 +12,7 @@ from miio.devicestatus import DeviceStatus
 from miio.exceptions import DeviceError, DeviceException, UnsupportedFeatureException
 from miio.miot_device import MiotDevice
 from miio.deviceinfo import DeviceInfo
+from miio.interfaces import VacuumInterface, LightInterface, ColorTemperatureRange
 
 # isort: on
 

--- a/miio/integrations/light/yeelight/spec_helper.py
+++ b/miio/integrations/light/yeelight/spec_helper.py
@@ -1,10 +1,12 @@
 import logging
 import os
 from enum import IntEnum
-from typing import Dict, NamedTuple
+from typing import Dict
 
 import attr
 import yaml
+
+from miio import ColorTemperatureRange
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -14,16 +16,9 @@ class YeelightSubLightType(IntEnum):
     Background = 1
 
 
-class ColorTempRange(NamedTuple):
-    """Color temperature range."""
-
-    min: int
-    max: int
-
-
 @attr.s(auto_attribs=True)
 class YeelightLampInfo:
-    color_temp: ColorTempRange
+    color_temp: ColorTemperatureRange
     supports_color: bool
 
 
@@ -48,14 +43,14 @@ class YeelightSpecHelper:
             for key, value in models.items():
                 lamps = {
                     YeelightSubLightType.Main: YeelightLampInfo(
-                        ColorTempRange(*value["color_temp"]),
+                        ColorTemperatureRange(*value["color_temp"]),
                         value["supports_color"],
                     )
                 }
 
                 if "background" in value:
                     lamps[YeelightSubLightType.Background] = YeelightLampInfo(
-                        ColorTempRange(*value["background"]["color_temp"]),
+                        ColorTemperatureRange(*value["background"]["color_temp"]),
                         value["background"]["supports_color"],
                     )
 

--- a/miio/integrations/light/yeelight/tests/test_yeelight_spec_helper.py
+++ b/miio/integrations/light/yeelight/tests/test_yeelight_spec_helper.py
@@ -1,4 +1,8 @@
-from ..spec_helper import ColorTempRange, YeelightSpecHelper, YeelightSubLightType
+from ..spec_helper import (
+    ColorTemperatureRange,
+    YeelightSpecHelper,
+    YeelightSubLightType,
+)
 
 
 def test_get_model_info():
@@ -6,9 +10,9 @@ def test_get_model_info():
     model_info = spec_helper.get_model_info("yeelink.light.bslamp1")
     assert model_info.model == "yeelink.light.bslamp1"
     assert model_info.night_light is False
-    assert model_info.lamps[YeelightSubLightType.Main].color_temp == ColorTempRange(
-        1700, 6500
-    )
+    assert model_info.lamps[
+        YeelightSubLightType.Main
+    ].color_temp == ColorTemperatureRange(1700, 6500)
     assert model_info.lamps[YeelightSubLightType.Main].supports_color is True
     assert YeelightSubLightType.Background not in model_info.lamps
 
@@ -18,8 +22,8 @@ def test_get_unknown_model_info():
     model_info = spec_helper.get_model_info("notreal")
     assert model_info.model == "yeelink.light.*"
     assert model_info.night_light is False
-    assert model_info.lamps[YeelightSubLightType.Main].color_temp == ColorTempRange(
-        1700, 6500
-    )
+    assert model_info.lamps[
+        YeelightSubLightType.Main
+    ].color_temp == ColorTemperatureRange(1700, 6500)
     assert model_info.lamps[YeelightSubLightType.Main].supports_color is False
     assert YeelightSubLightType.Background not in model_info.lamps

--- a/miio/integrations/light/yeelight/yeelight.py
+++ b/miio/integrations/light/yeelight/yeelight.py
@@ -7,7 +7,7 @@ import click
 from miio import ColorTemperatureRange, LightInterface
 from miio.click_common import command, format_output
 from miio.device import Device, DeviceStatus
-from miio.devicestatus import sensor, switch
+from miio.devicestatus import sensor, setting, switch
 from miio.utils import int_to_rgb, rgb_to_int
 
 from .spec_helper import YeelightSpecHelper, YeelightSubLightType
@@ -119,12 +119,15 @@ class YeelightStatus(DeviceStatus):
         return self.lights[0].is_on
 
     @property
-    @sensor("Brightness", unit="%")
+    @setting("Brightness", unit="%", setter_name="set_brightness", max_value=100)
     def brightness(self) -> int:
         """Return current brightness."""
         return self.lights[0].brightness
 
     @property
+    @sensor(
+        "RGB", setter_name="set_rgb"
+    )  # TODO: we need to extend @setting to support tuples to fix this
     def rgb(self) -> Optional[Tuple[int, int, int]]:
         """Return color in RGB if RGB mode is active."""
         return self.lights[0].rgb
@@ -136,12 +139,17 @@ class YeelightStatus(DeviceStatus):
         return self.lights[0].color_mode
 
     @property
+    @sensor(
+        "HSV", setter_name="set_hsv"
+    )  # TODO: we need to extend @setting to support tuples to fix this
     def hsv(self) -> Optional[Tuple[int, int, int]]:
         """Return current color in HSV if HSV mode is active."""
         return self.lights[0].hsv
 
     @property
-    @sensor("Color temperature")
+    @sensor(
+        "Color temperature", setter_name="set_color_temperature"
+    )  # TODO: we need to allow ranges by attribute to fix this
     def color_temp(self) -> Optional[int]:
         """Return current color temperature, if applicable."""
         return self.lights[0].color_temp
@@ -159,7 +167,7 @@ class YeelightStatus(DeviceStatus):
         return self.lights[0].color_flow_params
 
     @property
-    @sensor("Developer mode enabled", setter_name="set_developer_mode")
+    @switch("Developer mode enabled", setter_name="set_developer_mode")
     def developer_mode(self) -> Optional[bool]:
         """Return whether the developer mode is active."""
         lan_ctrl = self.data["lan_ctrl"]
@@ -186,7 +194,7 @@ class YeelightStatus(DeviceStatus):
         return int(self.data["delayoff"])
 
     @property
-    @switch("Music mode enabled", setter_name="set_music_mode")
+    @sensor("Music mode enabled")
     def music_mode(self) -> Optional[bool]:
         """Return whether the music mode is active."""
         music_on = self.data["music_on"]

--- a/miio/interfaces/__init__.py
+++ b/miio/interfaces/__init__.py
@@ -1,5 +1,11 @@
 """Interfaces API."""
 
+from .lightinterface import ColorTemperatureRange, LightInterface
 from .vacuuminterface import FanspeedPresets, VacuumInterface
 
-__all__ = ["FanspeedPresets", "VacuumInterface"]
+__all__ = [
+    "FanspeedPresets",
+    "VacuumInterface",
+    "LightInterface",
+    "ColorTemperatureRange",
+]

--- a/miio/interfaces/lightinterface.py
+++ b/miio/interfaces/lightinterface.py
@@ -1,0 +1,37 @@
+"""`LightInterface` is an interface (abstract class) for light devices."""
+from abc import abstractmethod
+from typing import NamedTuple, Optional, Tuple
+
+
+class ColorTemperatureRange(NamedTuple):
+    """Color temperature range."""
+
+    min: int
+    max: int
+
+
+class LightInterface:
+    """Light interface."""
+
+    @abstractmethod
+    def set_power(self, on: bool, **kwargs):
+        """Turn device on or off."""
+
+    @abstractmethod
+    def set_brightness(self, level: int, **kwargs):
+        """Set the light brightness [0,100]."""
+
+    @property
+    def color_temperature_range(self) -> Optional[ColorTemperatureRange]:
+        """Return the color temperature range, if supported."""
+        return None
+
+    def set_color_temperature(self, level: int, **kwargs):
+        """Set color temperature in kelvin."""
+        raise NotImplementedError(
+            "Called set_color_temperature on device that does not support it"
+        )
+
+    def set_rgb(self, rgb: Tuple[int, int, int], **kwargs):
+        """Set color in RGB."""
+        raise NotImplementedError("Called set_rgb on device that does not support it")


### PR DESCRIPTION
Adds descriptor decorators for the yeelight integration, so that they can be automatically detected by downstreams.
This also adds a minimal LightInterface, and converts Yeelight to use it.
This interface is expected to change, but this will enable development for the time being.

Related to #1495 - ping @Kirmas 