### PR TITLE
Clean up raised library exceptions

### DIFF
--- a/miio/__init__.py
+++ b/miio/__init__.py
@@ -9,7 +9,7 @@ from importlib.metadata import version  # type: ignore
 
 from miio.device import Device
 from miio.devicestatus import DeviceStatus
-from miio.exceptions import DeviceError, DeviceException
+from miio.exceptions import DeviceError, DeviceException, UnsupportedFeatureException
 from miio.miot_device import MiotDevice
 from miio.deviceinfo import DeviceInfo
 
@@ -69,7 +69,6 @@ from miio.integrations.vacuum import (
     Pro2Vacuum,
     RoborockVacuum,
     RoidmiVacuumMiot,
-    VacuumException,
     ViomiVacuum,
 )
 from miio.integrations.vacuum.roborock.vacuumcontainers import (

--- a/miio/airconditioner_miot.py
+++ b/miio/airconditioner_miot.py
@@ -6,7 +6,6 @@ from typing import Any, Dict
 import click
 
 from .click_common import EnumType, command, format_output
-from .exceptions import DeviceException
 from .miot_device import DeviceStatus, MiotDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -57,10 +56,6 @@ CLEANING_STAGES = [
     "Defrosting the surface",
     "Drying",
 ]
-
-
-class AirConditionerMiotException(DeviceException):
-    pass
 
 
 class CleaningStatus(DeviceStatus):
@@ -349,9 +344,7 @@ class AirConditionerMiot(MiotDevice):
             or target_temperature > 31.0
             or target_temperature % 0.5 != 0
         ):
-            raise AirConditionerMiotException(
-                "Invalid target temperature: %s" % target_temperature
-            )
+            raise ValueError("Invalid target temperature: %s" % target_temperature)
         return self.set_property("target_temperature", target_temperature)
 
     @command(
@@ -443,9 +436,7 @@ class AirConditionerMiot(MiotDevice):
     def set_fan_speed_percent(self, fan_speed_percent):
         """Set fan speed in percent, should be  between 1 to 100 or 101(auto)."""
         if fan_speed_percent < 1 or fan_speed_percent > 101:
-            raise AirConditionerMiotException(
-                "Invalid fan percent: %s" % fan_speed_percent
-            )
+            raise ValueError("Invalid fan percent: %s" % fan_speed_percent)
         return self.set_property("fan_speed_percent", fan_speed_percent)
 
     @command(

--- a/miio/airconditioningcompanion.py
+++ b/miio/airconditioningcompanion.py
@@ -6,7 +6,6 @@ import click
 
 from .click_common import EnumType, command, format_output
 from .device import Device, DeviceStatus
-from .exceptions import DeviceException
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -15,10 +14,6 @@ MODEL_ACPARTNER_V2 = "lumi.acpartner.v2"
 MODEL_ACPARTNER_V3 = "lumi.acpartner.v3"
 
 MODELS_SUPPORTED = [MODEL_ACPARTNER_V1, MODEL_ACPARTNER_V2, MODEL_ACPARTNER_V3]
-
-
-class AirConditioningCompanionException(DeviceException):
-    pass
 
 
 class OperationMode(enum.Enum):
@@ -313,19 +308,15 @@ class AirConditioningCompanion(Device):
         try:
             model_bytes = bytes.fromhex(model)
         except ValueError:
-            raise AirConditioningCompanionException(
-                "Invalid model. A hexadecimal string must be provided"
-            )
+            raise ValueError("Invalid model. A hexadecimal string must be provided")
 
         try:
             code_bytes = bytes.fromhex(code)
         except ValueError:
-            raise AirConditioningCompanionException(
-                "Invalid code. A hexadecimal string must be provided"
-            )
+            raise ValueError("Invalid code. A hexadecimal string must be provided")
 
         if slot < 0 or slot > 134:
-            raise AirConditioningCompanionException("Invalid slot: %s" % slot)
+            raise ValueError("Invalid slot: %s" % slot)
 
         slot_bytes = bytes([121 + slot])
 

--- a/miio/airconditioningcompanionMCN.py
+++ b/miio/airconditioningcompanionMCN.py
@@ -5,15 +5,10 @@ from typing import Any, Optional
 
 from .click_common import command, format_output
 from .device import Device, DeviceStatus
-from .exceptions import DeviceException
 
 _LOGGER = logging.getLogger(__name__)
 
 MODEL_ACPARTNER_MCN02 = "lumi.acpartner.mcn02"
-
-
-class AirConditioningCompanionException(DeviceException):
-    pass
 
 
 class OperationMode(enum.Enum):

--- a/miio/airdehumidifier.py
+++ b/miio/airdehumidifier.py
@@ -33,10 +33,6 @@ AVAILABLE_PROPERTIES = {
 }
 
 
-class AirDehumidifierException(DeviceException):
-    pass
-
-
 class OperationMode(enum.Enum):
     On = "on"
     Auto = "auto"
@@ -227,7 +223,7 @@ class AirDehumidifier(Device):
             return self.send("set_fan_level", [fan_speed.value])
         except DeviceError as ex:
             if ex.code == -10000:
-                raise AirDehumidifierException(
+                raise DeviceException(
                     "Unable to set fan speed, this can happen if device is turned off."
                 ) from ex
 
@@ -279,8 +275,6 @@ class AirDehumidifier(Device):
     def set_target_humidity(self, humidity: int):
         """Set the auto target humidity."""
         if humidity not in [40, 50, 60]:
-            raise AirDehumidifierException(
-                "Invalid auto target humidity: %s" % humidity
-            )
+            raise ValueError("Invalid auto target humidity: %s" % humidity)
 
         return self.send("set_auto", [humidity])

--- a/miio/airqualitymonitor.py
+++ b/miio/airqualitymonitor.py
@@ -6,7 +6,6 @@ import click
 
 from .click_common import command, format_output
 from .device import Device, DeviceStatus
-from .exceptions import DeviceException
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,10 +34,6 @@ AVAILABLE_PROPERTIES = {
     MODEL_AIRQUALITYMONITOR_B1: AVAILABLE_PROPERTIES_B1,
     MODEL_AIRQUALITYMONITOR_S1: AVAILABLE_PROPERTIES_S1,
 }
-
-
-class AirQualityMonitorException(DeviceException):
-    pass
 
 
 class AirQualityMonitorStatus(DeviceStatus):
@@ -275,6 +270,6 @@ class AirQualityMonitor(Device):
         end = end_hour * 3600 + end_minute * 60
 
         if begin < 0 or begin > 86399 or end < 0 or end > 86399:
-            AirQualityMonitorException("Begin or/and end time invalid.")
+            ValueError("Begin or/and end time invalid.")
 
         self.send("set_night_time", [begin, end])

--- a/miio/airqualitymonitor_miot.py
+++ b/miio/airqualitymonitor_miot.py
@@ -4,7 +4,6 @@ import logging
 import click
 
 from .click_common import command, format_output
-from .exceptions import DeviceException
 from .miot_device import DeviceStatus, MiotDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -45,10 +44,6 @@ _MAPPINGS = {
         "temperature_unit": {"siid": 9, "piid": 7},
     }
 }
-
-
-class AirQualityMonitorMiotException(DeviceException):
-    pass
 
 
 class ChargingState(enum.Enum):
@@ -205,7 +200,7 @@ class AirQualityMonitorCGDN1(MiotDevice):
     def set_monitoring_frequency_duration(self, duration):
         """Set monitoring frequency."""
         if duration < 0 or duration > 600:
-            raise AirQualityMonitorMiotException(
+            raise ValueError(
                 "Invalid duration: %s. Must be between 0 and 600" % duration
             )
         return self.set_property("monitoring_frequency", duration)
@@ -217,7 +212,7 @@ class AirQualityMonitorCGDN1(MiotDevice):
     def set_device_off_duration(self, duration):
         """Set device off duration."""
         if duration < 0 or duration > 60:
-            raise AirQualityMonitorMiotException(
+            raise ValueError(
                 "Invalid duration: %s. Must be between 0 and 60" % duration
             )
         return self.set_property("device_off", duration)
@@ -229,7 +224,7 @@ class AirQualityMonitorCGDN1(MiotDevice):
     def set_screen_off_duration(self, duration):
         """Set screen off duration."""
         if duration < 0 or duration > 300:
-            raise AirQualityMonitorMiotException(
+            raise ValueError(
                 "Invalid duration: %s. Must be between 0 and 300" % duration
             )
         return self.set_property("screen_off", duration)

--- a/miio/aqaracamera.py
+++ b/miio/aqaracamera.py
@@ -16,13 +16,8 @@ import click
 
 from .click_common import command, format_output
 from .device import Device, DeviceStatus
-from .exceptions import DeviceException
 
 _LOGGER = logging.getLogger(__name__)
-
-
-class CameraException(DeviceException):
-    pass
 
 
 @attr.s
@@ -255,7 +250,7 @@ class AqaraCamera(Device):
     def pair(self, timeout: int):
         """Start (or stop with "0") pairing."""
         if timeout < 0:
-            raise CameraException("Invalid timeout: %s" % timeout)
+            raise ValueError("Invalid timeout: %s" % timeout)
 
         return self.send("start_zigbee_join", [timeout])
 
@@ -292,7 +287,7 @@ class AqaraCamera(Device):
     def set_alarm_volume(self, volume):
         """Set alarm volume."""
         if volume < 0 or volume > 100:
-            raise CameraException("Volume has to be [0,100], was %s" % volume)
+            raise ValueError("Volume has to be [0,100], was %s" % volume)
         return self.send("set_alarming_volume", [volume])[0] == "ok"
 
     @command(click.argument("sound_id", type=str, required=False, default=None))

--- a/miio/chuangmi_ir.py
+++ b/miio/chuangmi_ir.py
@@ -21,11 +21,6 @@ from construct import (
 
 from .click_common import command, format_output
 from .device import Device
-from .exceptions import DeviceException
-
-
-class ChuangmiIrException(DeviceException):
-    pass
 
 
 class ChuangmiIr(Device):
@@ -50,7 +45,7 @@ class ChuangmiIr(Device):
         """
 
         if key < 1 or key > 1000000:
-            raise ChuangmiIrException("Invalid storage slot.")
+            raise ValueError("Invalid storage slot.")
         return self.send("miIO.ir_learn", {"key": str(key)})
 
     @command(
@@ -73,7 +68,7 @@ class ChuangmiIr(Device):
         """
 
         if key < 1 or key > 1000000:
-            raise ChuangmiIrException("Invalid storage slot.")
+            raise ValueError("Invalid storage slot.")
         return self.send("miIO.ir_read", {"key": str(key)})
 
     def play_raw(self, command: str, frequency: int = 38400, length: int = -1):
@@ -110,12 +105,12 @@ class ChuangmiIr(Device):
         :param int repeats: Number of extra signal repeats.
         """
         if repeats < 0:
-            raise ChuangmiIrException("Invalid repeats value")
+            raise ValueError("Invalid repeats value")
 
         try:
             pronto_data = Pronto.parse(bytearray.fromhex(pronto))
         except Exception as ex:
-            raise ChuangmiIrException("Invalid Pronto command") from ex
+            raise ValueError("Invalid Pronto command") from ex
 
         if len(pronto_data.intro) == 0:
             repeats += 1
@@ -161,10 +156,10 @@ class ChuangmiIr(Device):
 
         arg_types = [int, int]
         if len(command_args) > len(arg_types):
-            raise ChuangmiIrException("Invalid command arguments count")
+            raise ValueError("Invalid command arguments count")
 
         if command_type not in ["raw", "pronto"]:
-            raise ChuangmiIrException("Invalid command type")
+            raise ValueError("Invalid command type")
 
         play_method: Callable
         if command_type == "raw":
@@ -176,7 +171,7 @@ class ChuangmiIr(Device):
         try:
             converted_command_args = [t(v) for v, t in zip(command_args, arg_types)]
         except Exception as ex:
-            raise ChuangmiIrException("Invalid command arguments") from ex
+            raise ValueError("Invalid command arguments") from ex
 
         return play_method(command, *converted_command_args)
 

--- a/miio/click_common.py
+++ b/miio/click_common.py
@@ -49,7 +49,7 @@ class ExceptionHandlerGroup(click.Group):
     def __call__(self, *args, **kwargs):
         try:
             return self.main(*args, **kwargs)
-        except miio.DeviceException as ex:
+        except (ValueError, miio.DeviceException) as ex:
             _LOGGER.debug("Exception: %s", ex, exc_info=True)
             click.echo(click.style("Error: %s" % ex, fg="red", bold=True))
 

--- a/miio/cloud.py
+++ b/miio/cloud.py
@@ -5,16 +5,14 @@ from typing import TYPE_CHECKING, Dict, List, Optional
 import attr
 import click
 
+from miio.exceptions import CloudException
+
 _LOGGER = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from micloud import MiCloud  # noqa: F401
 
 AVAILABLE_LOCALES = ["cn", "de", "i2", "ru", "sg", "us"]
-
-
-class CloudException(Exception):
-    """Exception raised for cloud connectivity issues."""
 
 
 @attr.s(auto_attribs=True)

--- a/miio/cooker.py
+++ b/miio/cooker.py
@@ -9,7 +9,6 @@ import click
 
 from .click_common import command, format_output
 from .device import Device, DeviceStatus
-from .exceptions import DeviceException
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -69,10 +68,6 @@ COOKING_STAGES = {
     },
     16: {"name": "Cooking finished", "description": ""},
 }
-
-
-class CookerException(DeviceException):
-    pass
 
 
 class OperationMode(enum.Enum):
@@ -644,7 +639,7 @@ class Cooker(Device):
     def start(self, profile: str):
         """Start cooking a profile."""
         if not self._validate_profile(profile):
-            raise CookerException("Invalid cooking profile: %s" % profile)
+            raise ValueError("Invalid cooking profile: %s" % profile)
 
         self.send("set_start", [profile])
 
@@ -691,7 +686,7 @@ class Cooker(Device):
     def set_menu(self, profile: str):
         """Select one of the default(?) cooking profiles."""
         if not self._validate_profile(profile):
-            raise CookerException("Invalid cooking profile: %s" % profile)
+            raise ValueError("Invalid cooking profile: %s" % profile)
 
         self.send("set_menu", [profile])
 

--- a/miio/exceptions.py
+++ b/miio/exceptions.py
@@ -31,4 +31,12 @@ class DeviceError(DeviceException):
 
 
 class RecoverableError(DeviceError):
-    """Exception communicating an recoverable error delivered by the target device."""
+    """Exception communicating a recoverable error delivered by the target device."""
+
+
+class UnsupportedFeatureException(DeviceException):
+    """Exception communicating that the device does not support the wanted feature."""
+
+
+class CloudException(Exception):
+    """Exception raised for cloud connectivity issues."""

--- a/miio/fan_common.py
+++ b/miio/fan_common.py
@@ -1,11 +1,5 @@
 import enum
 
-from .exceptions import DeviceException
-
-
-class FanException(DeviceException):
-    pass
-
 
 class OperationMode(enum.Enum):
     Normal = "normal"

--- a/miio/gateway/devices/subdevice.py
+++ b/miio/gateway/devices/subdevice.py
@@ -9,12 +9,7 @@ import click
 from ...click_common import command
 from ...exceptions import DeviceException
 from ...push_server import EventInfo
-from ..gateway import (
-    GATEWAY_MODEL_EU,
-    GATEWAY_MODEL_ZIG3,
-    GatewayCallback,
-    GatewayException,
-)
+from ..gateway import GATEWAY_MODEL_EU, GATEWAY_MODEL_ZIG3, GatewayCallback
 
 _LOGGER = logging.getLogger(__name__)
 if TYPE_CHECKING:
@@ -138,7 +133,7 @@ class SubDevice:
                     self._props[prop_name] = result
                     i = i + 1
             except Exception as ex:
-                raise GatewayException(
+                raise DeviceException(
                     "One or more unexpected results while "
                     "fetching properties %s: %s on model %s"
                     % (self.get_prop_exp_dict, values, self.model)
@@ -150,7 +145,7 @@ class SubDevice:
         try:
             return self._gw.send(command, [self.sid])
         except Exception as ex:
-            raise GatewayException(
+            raise DeviceException(
                 "Got an exception while sending command %s on model %s"
                 % (command, self.model)
             ) from ex
@@ -161,7 +156,7 @@ class SubDevice:
         try:
             return self._gw.send(command, arguments, extra_parameters={"sid": self.sid})
         except Exception as ex:
-            raise GatewayException(
+            raise DeviceException(
                 "Got an exception while sending "
                 "command '%s' with arguments '%s' on model %s"
                 % (command, str(arguments), self.model)
@@ -173,13 +168,13 @@ class SubDevice:
         try:
             response = self._gw.send("get_device_prop", [self.sid, property])
         except Exception as ex:
-            raise GatewayException(
+            raise DeviceException(
                 "Got an exception while fetching property %s on model %s"
                 % (property, self.model)
             ) from ex
 
         if not response:
-            raise GatewayException(
+            raise DeviceException(
                 f"Empty response while fetching property '{property}': {response} on model {self.model}"
             )
 
@@ -193,13 +188,13 @@ class SubDevice:
                 "get_device_prop_exp", [[self.sid] + list(properties)]
             ).pop()
         except Exception as ex:
-            raise GatewayException(
+            raise DeviceException(
                 "Got an exception while fetching properties %s on model %s"
                 % (properties, self.model)
             ) from ex
 
         if len(list(properties)) != len(response):
-            raise GatewayException(
+            raise DeviceException(
                 "unexpected result while fetching properties %s: %s on model %s"
                 % (properties, response, self.model)
             )
@@ -212,7 +207,7 @@ class SubDevice:
         try:
             return self._gw.send("set_device_prop", {"sid": self.sid, property: value})
         except Exception as ex:
-            raise GatewayException(
+            raise DeviceException(
                 "Got an exception while setting propertie %s to value %s on model %s"
                 % (property, str(value), self.model)
             ) from ex

--- a/miio/gateway/gateway.py
+++ b/miio/gateway/gateway.py
@@ -39,11 +39,6 @@ SUPPORTED_MODELS = [
 
 GatewayCallback = Callable[[str, str], None]
 
-
-class GatewayException(DeviceException):
-    """Exception for the Xioami Gateway communication."""
-
-
 from .devices import SubDevice, SubDeviceInfo  # noqa: E402 isort:skip
 
 
@@ -407,7 +402,7 @@ class Gateway(Device):
         try:
             return self.send("get_illumination").pop()
         except Exception as ex:
-            raise GatewayException(
+            raise DeviceException(
                 "Got an exception while getting gateway illumination"
             ) from ex
 

--- a/miio/heater.py
+++ b/miio/heater.py
@@ -6,7 +6,6 @@ import click
 
 from .click_common import EnumType, command, format_output
 from .device import Device, DeviceStatus
-from .exceptions import DeviceException
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,10 +36,6 @@ SUPPORTED_MODELS: Dict[str, Dict[str, Any]] = {
         "delay_off_range": (0, 5 * 3600),
     },
 }
-
-
-class HeaterException(DeviceException):
-    pass
 
 
 class Brightness(enum.Enum):
@@ -182,7 +177,7 @@ class Heater(Device):
             self.model, SUPPORTED_MODELS[MODEL_HEATER_ZA1]
         )["temperature_range"]
         if not min_temp <= temperature <= max_temp:
-            raise HeaterException("Invalid target temperature: %s" % temperature)
+            raise ValueError("Invalid target temperature: %s" % temperature)
 
         return self.send("set_target_temperature", [temperature])
 
@@ -232,7 +227,7 @@ class Heater(Device):
             self.model, SUPPORTED_MODELS[MODEL_HEATER_ZA1]
         )["delay_off_range"]
         if not min_delay <= seconds <= max_delay:
-            raise HeaterException("Invalid delay time: %s" % seconds)
+            raise ValueError("Invalid delay time: %s" % seconds)
 
         if self.model == MODEL_HEATER_ZA1:
             return self.send("set_poweroff_time", [seconds])

--- a/miio/heater_miot.py
+++ b/miio/heater_miot.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, Optional
 import click
 
 from .click_common import EnumType, command, format_output
-from .exceptions import DeviceException
 from .miot_device import DeviceStatus, MiotDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -63,10 +62,6 @@ class LedBrightness(enum.Enum):
     On = 0
     Off = 1
     Dim = 2
-
-
-class HeaterMiotException(DeviceException):
-    pass
 
 
 class HeaterMiotStatus(DeviceStatus):
@@ -189,7 +184,7 @@ class HeaterMiot(MiotDevice):
             self.model, {"temperature_range": (18, 28)}
         )["temperature_range"]
         if target_temperature < min_temp or target_temperature > max_temp:
-            raise HeaterMiotException(
+            raise ValueError(
                 "Invalid temperature: %s. Must be between %s and %s."
                 % (target_temperature, min_temp, max_temp)
             )
@@ -240,7 +235,7 @@ class HeaterMiot(MiotDevice):
             self.model, {"delay_off_range": (0, 12 * 3600)}
         )["delay_off_range"]
         if seconds < min_delay or seconds > max_delay:
-            raise HeaterMiotException(
+            raise ValueError(
                 "Invalid scheduled turn off: %s. Must be between %s and %s"
                 % (seconds, min_delay, max_delay)
             )

--- a/miio/huizuo.py
+++ b/miio/huizuo.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Optional
 import click
 
 from .click_common import command, format_output
-from .exceptions import DeviceException
+from .exceptions import UnsupportedFeatureException
 from .miot_device import DeviceStatus, MiotDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -111,10 +111,6 @@ _ADDITIONAL_MAPPING_SCENE = {  # Only for write, send "0" to activate
     "on_or_increase_brightness": {"siid": 3, "piid": 8},
     "on_or_increase_colortemp": {"siid": 3, "piid": 9},
 }
-
-
-class HuizuoException(DeviceException):
-    pass
 
 
 class HuizuoStatus(DeviceStatus):
@@ -283,7 +279,7 @@ class Huizuo(MiotDevice):
     def set_brightness(self, level):
         """Set brightness."""
         if level < 0 or level > 100:
-            raise HuizuoException("Invalid brightness: %s" % level)
+            raise ValueError("Invalid brightness: %s" % level)
 
         return self.set_property("brightness", level)
 
@@ -302,7 +298,7 @@ class Huizuo(MiotDevice):
             max_color_temp = 6400
 
         if color_temp < 3000 or color_temp > max_color_temp:
-            raise HuizuoException("Invalid color temperature: %s" % color_temp)
+            raise ValueError("Invalid color temperature: %s" % color_temp)
 
         return self.set_property("color_temp", color_temp)
 
@@ -323,7 +319,9 @@ class HuizuoLampFan(Huizuo):
         if self.model in MODELS_WITH_FAN_WY or self.model in MODELS_WITH_FAN_WY2:
             return self.set_property("fan_power", True)
 
-        raise HuizuoException("Your device doesn't support a fan management")
+        raise UnsupportedFeatureException(
+            "Your device doesn't support a fan management"
+        )
 
     @command(
         default_output=format_output("Fan powering off"),
@@ -333,7 +331,9 @@ class HuizuoLampFan(Huizuo):
         if self.model in MODELS_WITH_FAN_WY or self.model in MODELS_WITH_FAN_WY2:
             return self.set_property("fan_power", False)
 
-        raise HuizuoException("Your device doesn't support a fan management")
+        raise UnsupportedFeatureException(
+            "Your device doesn't support a fan management"
+        )
 
     @command(
         click.argument("fan_level", type=int),
@@ -342,12 +342,14 @@ class HuizuoLampFan(Huizuo):
     def set_fan_level(self, fan_level):
         """Set fan speed level (only for models with fan)"""
         if fan_level < 0 or fan_level > 100:
-            raise HuizuoException("Invalid fan speed level: %s" % fan_level)
+            raise ValueError("Invalid fan speed level: %s" % fan_level)
 
         if self.model in MODELS_WITH_FAN_WY or self.model in MODELS_WITH_FAN_WY2:
             return self.set_property("fan_level", fan_level)
 
-        raise HuizuoException("Your device doesn't support a fan management")
+        raise UnsupportedFeatureException(
+            "Your device doesn't support a fan management"
+        )
 
     @command(
         default_output=format_output("Setting fan mode to 'Basic'"),
@@ -357,7 +359,9 @@ class HuizuoLampFan(Huizuo):
         if self.model in MODELS_WITH_FAN_WY or self.model in MODELS_WITH_FAN_WY2:
             return self.set_property("fan_mode", 0)
 
-        raise HuizuoException("Your device doesn't support a fan management")
+        raise UnsupportedFeatureException(
+            "Your device doesn't support a fan management"
+        )
 
     @command(
         default_output=format_output("Setting fan mode to 'Natural wind'"),
@@ -367,7 +371,9 @@ class HuizuoLampFan(Huizuo):
         if self.model in MODELS_WITH_FAN_WY or self.model in MODELS_WITH_FAN_WY2:
             return self.set_property("fan_mode", 1)
 
-        raise HuizuoException("Your device doesn't support a fan management")
+        raise UnsupportedFeatureException(
+            "Your device doesn't support a fan management"
+        )
 
     @command(
         default_output=format_output(
@@ -404,7 +410,9 @@ class HuizuoLampFan(Huizuo):
         if self.model in MODELS_WITH_FAN_WY:
             return self.set_property("fan_motor_reverse", True)
 
-        raise HuizuoException("Your device doesn't support a fan management")
+        raise UnsupportedFeatureException(
+            "Your device doesn't support a fan management"
+        )
 
     @command(
         default_output=format_output("Disable fan reverse"),
@@ -414,7 +422,9 @@ class HuizuoLampFan(Huizuo):
         if self.model in MODELS_WITH_FAN_WY:
             return self.set_property("fan_motor_reverse", False)
 
-        raise HuizuoException("Your device doesn't support a fan management")
+        raise UnsupportedFeatureException(
+            "Your device doesn't support a fan management"
+        )
 
 
 class HuizuoLampHeater(Huizuo):
@@ -433,7 +443,9 @@ class HuizuoLampHeater(Huizuo):
         if self.model in MODELS_WITH_HEATER:
             return self.set_property("heater_power", True)
 
-        raise HuizuoException("Your device doesn't support a heater management")
+        raise UnsupportedFeatureException(
+            "Your device doesn't support a heater management"
+        )
 
     @command(
         default_output=format_output("Heater powering off"),
@@ -443,7 +455,9 @@ class HuizuoLampHeater(Huizuo):
         if self.model in MODELS_WITH_HEATER:
             return self.set_property("heater_power", False)
 
-        raise HuizuoException("Your device doesn't support a heater management")
+        raise UnsupportedFeatureException(
+            "Your device doesn't support a heater management"
+        )
 
     @command(
         click.argument("heat_level", type=int),
@@ -452,12 +466,14 @@ class HuizuoLampHeater(Huizuo):
     def set_heat_level(self, heat_level):
         """Set heat level (only for models with heater)"""
         if heat_level not in [1, 2, 3]:
-            raise HuizuoException("Invalid heat level: %s" % heat_level)
+            raise ValueError("Invalid heat level: %s" % heat_level)
 
         if self.model in MODELS_WITH_HEATER:
             return self.set_property("heat_level", heat_level)
 
-        raise HuizuoException("Your device doesn't support a heat management")
+        raise UnsupportedFeatureException(
+            "Your device doesn't support a heat management"
+        )
 
     @command(
         default_output=format_output(
@@ -500,7 +516,7 @@ class HuizuoLampScene(Huizuo):
         if self.model in MODELS_WITH_SCENES:
             return self.set_property("on_off", 0)
 
-        raise HuizuoException("Your device doesn't support scenes")
+        raise UnsupportedFeatureException("Your device doesn't support scenes")
 
     @command(
         default_output=format_output("Increase the brightness"),
@@ -510,7 +526,7 @@ class HuizuoLampScene(Huizuo):
         if self.model in MODELS_WITH_SCENES:
             return self.set_property("brightness_increase", 0)
 
-        raise HuizuoException("Your device doesn't support scenes")
+        raise UnsupportedFeatureException("Your device doesn't support scenes")
 
     @command(
         default_output=format_output("Decrease the brightness"),
@@ -520,7 +536,7 @@ class HuizuoLampScene(Huizuo):
         if self.model in MODELS_WITH_SCENES:
             return self.set_property("brightness_decrease", 0)
 
-        raise HuizuoException("Your device doesn't support scenes")
+        raise UnsupportedFeatureException("Your device doesn't support scenes")
 
     @command(
         default_output=format_output("Switch between the brightnesses"),
@@ -530,7 +546,7 @@ class HuizuoLampScene(Huizuo):
         if self.model in MODELS_WITH_SCENES:
             return self.set_property("brightness_switch", 0)
 
-        raise HuizuoException("Your device doesn't support scenes")
+        raise UnsupportedFeatureException("Your device doesn't support scenes")
 
     @command(
         default_output=format_output("Increase the color temperature"),
@@ -540,7 +556,7 @@ class HuizuoLampScene(Huizuo):
         if self.model in MODELS_WITH_SCENES:
             return self.set_property("colortemp_increase", 0)
 
-        raise HuizuoException("Your device doesn't support scenes")
+        raise UnsupportedFeatureException("Your device doesn't support scenes")
 
     @command(
         default_output=format_output("Decrease the color temperature"),
@@ -550,7 +566,7 @@ class HuizuoLampScene(Huizuo):
         if self.model in MODELS_WITH_SCENES:
             return self.set_property("colortemp_decrease", 0)
 
-        raise HuizuoException("Your device doesn't support scenes")
+        raise UnsupportedFeatureException("Your device doesn't support scenes")
 
     @command(
         default_output=format_output("Switch between the color temperatures"),
@@ -561,7 +577,7 @@ class HuizuoLampScene(Huizuo):
         if self.model in MODELS_WITH_SCENES:
             return self.set_property("colortemp_switch", 0)
 
-        raise HuizuoException("Your device doesn't support scenes")
+        raise UnsupportedFeatureException("Your device doesn't support scenes")
 
     @command(
         default_output=format_output("Switch on or increase brightness"),
@@ -571,7 +587,7 @@ class HuizuoLampScene(Huizuo):
         if self.model in MODELS_WITH_SCENES:
             return self.set_property("on_or_increase_brightness", 0)
 
-        raise HuizuoException("Your device doesn't support scenes")
+        raise UnsupportedFeatureException("Your device doesn't support scenes")
 
     @command(
         default_output=format_output("Switch on or increase color temperature"),
@@ -582,4 +598,4 @@ class HuizuoLampScene(Huizuo):
         if self.model in MODELS_WITH_SCENES:
             return self.set_property("on_or_increase_colortemp", 0)
 
-        raise HuizuoException("Your device doesn't support scenes")
+        raise UnsupportedFeatureException("Your device doesn't support scenes")

--- a/miio/integrations/airpurifier/airdog/airpurifier_airdog.py
+++ b/miio/integrations/airpurifier/airdog/airpurifier_airdog.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional
 
 import click
 
-from miio import Device, DeviceException, DeviceStatus
+from miio import Device, DeviceStatus
 from miio.click_common import EnumType, command, format_output
 
 _LOGGER = logging.getLogger(__name__)
@@ -21,10 +21,6 @@ AVAILABLE_PROPERTIES = {
     MODEL_AIRDOG_X5: MODEL_AIRDOG_COMMON,
     MODEL_AIRDOG_X7SM: MODEL_AIRDOG_COMMON + ["hcho"],
 }
-
-
-class AirDogException(DeviceException):
-    pass
 
 
 class OperationMode(enum.Enum):
@@ -145,7 +141,7 @@ class AirDogX3(Device):
     def set_mode_and_speed(self, mode: OperationMode, speed: int = 1):
         """Set mode and speed."""
         if mode.value not in (om.value for om in OperationMode):
-            raise AirDogException(f"{mode.value} is not a valid OperationMode value")
+            raise ValueError(f"{mode.value} is not a valid OperationMode value")
 
         if mode in [OperationMode.Auto, OperationMode.Idle]:
             speed = 1
@@ -157,7 +153,7 @@ class AirDogX3(Device):
             max_speed = 5
 
         if speed < 1 or speed > max_speed:
-            raise AirDogException("Invalid speed: %s" % speed)
+            raise ValueError("Invalid speed: %s" % speed)
 
         return self.send("set_wind", [OperationModeMapping[mode.name].value, speed])
 

--- a/miio/integrations/airpurifier/airdog/tests/test_airpurifier_airdog.py
+++ b/miio/integrations/airpurifier/airdog/tests/test_airpurifier_airdog.py
@@ -9,7 +9,6 @@ from ..airpurifier_airdog import (
     MODEL_AIRDOG_X3,
     MODEL_AIRDOG_X5,
     MODEL_AIRDOG_X7SM,
-    AirDogException,
     AirDogStatus,
     OperationMode,
     OperationModeMapping,
@@ -113,10 +112,10 @@ class TestAirDogX3(TestCase):
         assert mode() == OperationMode.Manual
         assert speed() == 4
 
-        with pytest.raises(AirDogException):
+        with pytest.raises(ValueError):
             self.device.set_mode_and_speed(OperationMode.Manual, 0)
 
-        with pytest.raises(AirDogException):
+        with pytest.raises(ValueError):
             self.device.set_mode_and_speed(OperationMode.Manual, 5)
 
         self.device.set_mode_and_speed(OperationMode.Idle)
@@ -194,5 +193,5 @@ class TestAirDogX5AndX7SM(TestCase):
         assert mode() == OperationMode.Manual
         assert speed() == 5
 
-        with pytest.raises(AirDogException):
+        with pytest.raises(ValueError):
             self.device.set_mode_and_speed(OperationMode.Manual, 6)

--- a/miio/integrations/airpurifier/dmaker/airfresh_t2017.py
+++ b/miio/integrations/airpurifier/dmaker/airfresh_t2017.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional
 
 import click
 
-from miio import Device, DeviceException, DeviceStatus
+from miio import Device, DeviceStatus
 from miio.click_common import EnumType, command, format_output
 
 _LOGGER = logging.getLogger(__name__)
@@ -44,10 +44,6 @@ AVAILABLE_PROPERTIES = {
         "filter_day",
     ],
 }
-
-
-class AirFreshException(DeviceException):
-    pass
 
 
 class OperationMode(enum.Enum):
@@ -324,7 +320,7 @@ class AirFreshA1(Device):
     def set_favorite_speed(self, speed: int):
         """Sets the fan speed in favorite mode."""
         if speed < 0 or speed > 150:
-            raise AirFreshException("Invalid favorite speed: %s" % speed)
+            raise ValueError("Invalid favorite speed: %s" % speed)
 
         return self.send("set_favourite_speed", [speed])
 
@@ -391,7 +387,7 @@ class AirFreshT2017(AirFreshA1):
     def set_favorite_speed(self, speed: int):
         """Sets the fan speed in favorite mode."""
         if speed < 60 or speed > 300:
-            raise AirFreshException("Invalid favorite speed: %s" % speed)
+            raise ValueError("Invalid favorite speed: %s" % speed)
 
         return self.send("set_favourite_speed", [speed])
 

--- a/miio/integrations/airpurifier/dmaker/tests/test_airfresh_t2017.py
+++ b/miio/integrations/airpurifier/dmaker/tests/test_airfresh_t2017.py
@@ -8,7 +8,6 @@ from .. import AirFreshA1, AirFreshT2017
 from ..airfresh_t2017 import (
     MODEL_AIRFRESH_A1,
     MODEL_AIRFRESH_T2017,
-    AirFreshException,
     AirFreshStatus,
     DisplayOrientation,
     OperationMode,
@@ -166,10 +165,10 @@ class TestAirFreshA1(TestCase):
         self.device.set_favorite_speed(150)
         assert favorite_speed() == 150
 
-        with pytest.raises(AirFreshException):
+        with pytest.raises(ValueError):
             self.device.set_favorite_speed(-1)
 
-        with pytest.raises(AirFreshException):
+        with pytest.raises(ValueError):
             self.device.set_favorite_speed(151)
 
     def test_set_ptc(self):
@@ -361,13 +360,13 @@ class TestAirFreshT2017(TestCase):
         self.device.set_favorite_speed(300)
         assert favorite_speed() == 300
 
-        with pytest.raises(AirFreshException):
+        with pytest.raises(ValueError):
             self.device.set_favorite_speed(-1)
 
-        with pytest.raises(AirFreshException):
+        with pytest.raises(ValueError):
             self.device.set_favorite_speed(59)
 
-        with pytest.raises(AirFreshException):
+        with pytest.raises(ValueError):
             self.device.set_favorite_speed(301)
 
     def test_set_ptc(self):

--- a/miio/integrations/airpurifier/zhimi/airfresh.py
+++ b/miio/integrations/airpurifier/zhimi/airfresh.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional
 
 import click
 
-from miio import Device, DeviceException, DeviceStatus
+from miio import Device, DeviceStatus
 from miio.click_common import EnumType, command, format_output
 
 _LOGGER = logging.getLogger(__name__)
@@ -39,10 +39,6 @@ AVAILABLE_PROPERTIES = {
     MODEL_AIRFRESH_VA2: AVAILABLE_PROPERTIES_COMMON,
     MODEL_AIRFRESH_VA4: AVAILABLE_PROPERTIES_COMMON + ["ptc_state"],
 }
-
-
-class AirFreshException(DeviceException):
-    pass
 
 
 class OperationMode(enum.Enum):
@@ -325,7 +321,7 @@ class AirFresh(Device):
     def set_extra_features(self, value: int):
         """Storage register to enable extra features at the app."""
         if value < 0:
-            raise AirFreshException("Invalid app extra value: %s" % value)
+            raise ValueError("Invalid app extra value: %s" % value)
 
         return self.send("set_app_extra", [value])
 

--- a/miio/integrations/airpurifier/zhimi/airpurifier.py
+++ b/miio/integrations/airpurifier/zhimi/airpurifier.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional
 
 import click
 
-from miio import Device, DeviceException, DeviceStatus
+from miio import Device, DeviceStatus
 from miio.click_common import EnumType, command, format_output
 
 from .airfilter_util import FilterType, FilterTypeUtil
@@ -29,10 +29,6 @@ SUPPORTED_MODELS = [
     "zhimi.airpurifier.mc1",
     "zhimi.airpurifier.mc2",
 ]
-
-
-class AirPurifierException(DeviceException):
-    pass
 
 
 class OperationMode(enum.Enum):
@@ -417,7 +413,7 @@ class AirPurifier(Device):
     def set_favorite_level(self, level: int):
         """Set favorite level."""
         if level < 0 or level > 17:
-            raise AirPurifierException("Invalid favorite level: %s" % level)
+            raise ValueError("Invalid favorite level: %s" % level)
 
         # Possible alternative property: set_speed_favorite
 
@@ -479,7 +475,7 @@ class AirPurifier(Device):
     def set_volume(self, volume: int):
         """Set volume of sound notifications [0-100]."""
         if volume < 0 or volume > 100:
-            raise AirPurifierException("Invalid volume: %s" % volume)
+            raise ValueError("Invalid volume: %s" % volume)
 
         return self.send("set_volume", [volume])
 
@@ -526,7 +522,7 @@ class AirPurifier(Device):
         app_extra=1 unlocks a turbo mode supported feature
         """
         if value < 0:
-            raise AirPurifierException("Invalid app extra value: %s" % value)
+            raise ValueError("Invalid app extra value: %s" % value)
 
         return self.send("set_app_extra", [value])
 

--- a/miio/integrations/airpurifier/zhimi/airpurifier_miot.py
+++ b/miio/integrations/airpurifier/zhimi/airpurifier_miot.py
@@ -4,8 +4,9 @@ from typing import Any, Dict, Optional
 
 import click
 
-from miio import DeviceException, DeviceStatus, MiotDevice
+from miio import DeviceStatus, MiotDevice
 from miio.click_common import EnumType, command, format_output
+from miio.exceptions import UnsupportedFeatureException
 
 from .airfilter_util import FilterType, FilterTypeUtil
 
@@ -260,10 +261,6 @@ REVERSED_LED_BRIGHTNESS = [
     "zhimi.airp.vb4",
     "zhimi.airp.rmb1",
 ]
-
-
-class AirPurifierMiotException(DeviceException):
-    pass
 
 
 class OperationMode(enum.Enum):
@@ -551,13 +548,13 @@ class AirPurifierMiot(MiotDevice):
     def set_favorite_rpm(self, rpm: int):
         """Set favorite motor speed."""
         if "favorite_rpm" not in self._get_mapping():
-            raise AirPurifierMiotException(
+            raise UnsupportedFeatureException(
                 "Unsupported favorite rpm for model '%s'" % self.model
             )
 
         # Note: documentation says the maximum is 2300, however, the purifier may return an error for rpm over 2200.
         if rpm < 300 or rpm > 2300 or rpm % 10 != 0:
-            raise AirPurifierMiotException(
+            raise ValueError(
                 "Invalid favorite motor speed: %s. Must be between 300 and 2300 and divisible by 10"
                 % rpm
             )
@@ -580,7 +577,7 @@ class AirPurifierMiot(MiotDevice):
     def set_anion(self, anion: bool):
         """Set anion on/off."""
         if "anion" not in self._get_mapping():
-            raise AirPurifierMiotException(
+            raise UnsupportedFeatureException(
                 "Unsupported anion for model '%s'" % self.model
             )
         return self.set_property("anion", anion)
@@ -594,7 +591,7 @@ class AirPurifierMiot(MiotDevice):
     def set_buzzer(self, buzzer: bool):
         """Set buzzer on/off."""
         if "buzzer" not in self._get_mapping():
-            raise AirPurifierMiotException(
+            raise UnsupportedFeatureException(
                 "Unsupported buzzer for model '%s'" % self.model
             )
 
@@ -611,7 +608,7 @@ class AirPurifierMiot(MiotDevice):
     def set_gestures(self, gestures: bool):
         """Set gestures on/off."""
         if "gestures" not in self._get_mapping():
-            raise AirPurifierMiotException(
+            raise UnsupportedFeatureException(
                 "Gestures not support for model '%s'" % self.model
             )
 
@@ -626,7 +623,7 @@ class AirPurifierMiot(MiotDevice):
     def set_child_lock(self, lock: bool):
         """Set child lock on/off."""
         if "child_lock" not in self._get_mapping():
-            raise AirPurifierMiotException(
+            raise UnsupportedFeatureException(
                 "Unsupported child lock for model '%s'" % self.model
             )
         return self.set_property("child_lock", lock)
@@ -638,12 +635,12 @@ class AirPurifierMiot(MiotDevice):
     def set_fan_level(self, level: int):
         """Set fan level."""
         if "fan_level" not in self._get_mapping():
-            raise AirPurifierMiotException(
+            raise UnsupportedFeatureException(
                 "Unsupported fan level for model '%s'" % self.model
             )
 
         if level < 1 or level > 3:
-            raise AirPurifierMiotException("Invalid fan level: %s" % level)
+            raise ValueError("Invalid fan level: %s" % level)
         return self.set_property("fan_level", level)
 
     @command(
@@ -653,14 +650,12 @@ class AirPurifierMiot(MiotDevice):
     def set_volume(self, volume: int):
         """Set buzzer volume."""
         if "volume" not in self._get_mapping():
-            raise AirPurifierMiotException(
+            raise UnsupportedFeatureException(
                 "Unsupported volume for model '%s'" % self.model
             )
 
         if volume < 0 or volume > 100:
-            raise AirPurifierMiotException(
-                "Invalid volume: %s. Must be between 0 and 100" % volume
-            )
+            raise ValueError("Invalid volume: %s. Must be between 0 and 100" % volume)
         return self.set_property("buzzer_volume", volume)
 
     @command(
@@ -673,12 +668,12 @@ class AirPurifierMiot(MiotDevice):
         Needs to be between 0 and 14.
         """
         if "favorite_level" not in self._get_mapping():
-            raise AirPurifierMiotException(
+            raise UnsupportedFeatureException(
                 "Unsupported favorite level for model '%s'" % self.model
             )
 
         if level < 0 or level > 14:
-            raise AirPurifierMiotException("Invalid favorite level: %s" % level)
+            raise ValueError("Invalid favorite level: %s" % level)
 
         return self.set_property("favorite_level", level)
 
@@ -689,7 +684,7 @@ class AirPurifierMiot(MiotDevice):
     def set_led_brightness(self, brightness: LedBrightness):
         """Set led brightness."""
         if "led_brightness" not in self._get_mapping():
-            raise AirPurifierMiotException(
+            raise UnsupportedFeatureException(
                 "Unsupported led brightness for model '%s'" % self.model
             )
 
@@ -707,7 +702,7 @@ class AirPurifierMiot(MiotDevice):
     def set_led(self, led: bool):
         """Turn led on/off."""
         if "led" not in self._get_mapping():
-            raise AirPurifierMiotException(
+            raise UnsupportedFeatureException(
                 "Unsupported led for model '%s'" % self.model
             )
         return self.set_property("led", led)
@@ -719,10 +714,10 @@ class AirPurifierMiot(MiotDevice):
     def set_led_brightness_level(self, level: int):
         """Set led brightness level (0..8)."""
         if "led_brightness_level" not in self._get_mapping():
-            raise AirPurifierMiotException(
+            raise UnsupportedFeatureException(
                 "Unsupported led brightness level for model '%s'" % self.model
             )
         if level < 0 or level > 8:
-            raise AirPurifierMiotException("Invalid brightness level: %s" % level)
+            raise ValueError("Invalid brightness level: %s" % level)
 
         return self.set_property("led_brightness_level", level)

--- a/miio/integrations/airpurifier/zhimi/tests/test_airfresh.py
+++ b/miio/integrations/airpurifier/zhimi/tests/test_airfresh.py
@@ -8,7 +8,6 @@ from .. import AirFresh
 from ..airfresh import (
     MODEL_AIRFRESH_VA2,
     MODEL_AIRFRESH_VA4,
-    AirFreshException,
     AirFreshStatus,
     LedBrightness,
     OperationMode,
@@ -193,7 +192,7 @@ class TestAirFresh(TestCase):
         self.device.set_extra_features(2)
         assert extra_features() == 2
 
-        with pytest.raises(AirFreshException):
+        with pytest.raises(ValueError):
             self.device.set_extra_features(-1)
 
     def test_reset_filter(self):

--- a/miio/integrations/airpurifier/zhimi/tests/test_airpurifier.py
+++ b/miio/integrations/airpurifier/zhimi/tests/test_airpurifier.py
@@ -6,7 +6,6 @@ from miio.tests.dummies import DummyDevice
 
 from .. import AirPurifier
 from ..airpurifier import (
-    AirPurifierException,
     AirPurifierStatus,
     FilterType,
     LedBrightness,
@@ -175,10 +174,10 @@ class TestAirPurifier(TestCase):
         self.device.set_favorite_level(10)
         assert favorite_level() == 10
 
-        with pytest.raises(AirPurifierException):
+        with pytest.raises(ValueError):
             self.device.set_favorite_level(-1)
 
-        with pytest.raises(AirPurifierException):
+        with pytest.raises(ValueError):
             self.device.set_favorite_level(18)
 
     def test_set_led_brightness(self):
@@ -235,10 +234,10 @@ class TestAirPurifier(TestCase):
         self.device.set_volume(100)
         assert volume() == 100
 
-        with pytest.raises(AirPurifierException):
+        with pytest.raises(ValueError):
             self.device.set_volume(-1)
 
-        with pytest.raises(AirPurifierException):
+        with pytest.raises(ValueError):
             self.device.set_volume(101)
 
     def test_set_learn_mode(self):
@@ -272,7 +271,7 @@ class TestAirPurifier(TestCase):
         self.device.set_extra_features(2)
         assert extra_features() == 2
 
-        with pytest.raises(AirPurifierException):
+        with pytest.raises(ValueError):
             self.device.set_extra_features(-1)
 
     def test_reset_filter(self):

--- a/miio/integrations/airpurifier/zhimi/tests/test_airpurifier_miot.py
+++ b/miio/integrations/airpurifier/zhimi/tests/test_airpurifier_miot.py
@@ -2,11 +2,12 @@ from unittest import TestCase
 
 import pytest
 
+from miio.exceptions import UnsupportedFeatureException
 from miio.tests.dummies import DummyMiotDevice
 
 from .. import AirPurifierMiot
 from ..airfilter_util import FilterType
-from ..airpurifier_miot import AirPurifierMiotException, LedBrightness, OperationMode
+from ..airpurifier_miot import LedBrightness, OperationMode
 
 _INITIAL_STATE = {
     "power": True,
@@ -148,10 +149,10 @@ class TestAirPurifier(TestCase):
         self.device.set_fan_level(3)
         assert fan_level() == 3
 
-        with pytest.raises(AirPurifierMiotException):
+        with pytest.raises(ValueError):
             self.device.set_fan_level(0)
 
-        with pytest.raises(AirPurifierMiotException):
+        with pytest.raises(ValueError):
             self.device.set_fan_level(4)
 
     def test_set_mode(self):
@@ -181,10 +182,10 @@ class TestAirPurifier(TestCase):
         self.device.set_favorite_level(14)
         assert favorite_level() == 14
 
-        with pytest.raises(AirPurifierMiotException):
+        with pytest.raises(ValueError):
             self.device.set_favorite_level(-1)
 
-        with pytest.raises(AirPurifierMiotException):
+        with pytest.raises(ValueError):
             self.device.set_favorite_level(15)
 
     def test_set_led_brightness(self):
@@ -231,7 +232,7 @@ class TestAirPurifier(TestCase):
         assert child_lock() is False
 
     def test_set_anion(self):
-        with pytest.raises(AirPurifierMiotException):
+        with pytest.raises(UnsupportedFeatureException):
             self.device.set_anion(True)
 
 
@@ -282,19 +283,19 @@ class TestAirPurifierMB4(TestCase):
         assert led_brightness_level() == 2
 
     def test_set_fan_level(self):
-        with pytest.raises(AirPurifierMiotException):
+        with pytest.raises(UnsupportedFeatureException):
             self.device.set_fan_level(0)
 
     def test_set_favorite_level(self):
-        with pytest.raises(AirPurifierMiotException):
+        with pytest.raises(UnsupportedFeatureException):
             self.device.set_favorite_level(0)
 
     def test_set_led_brightness(self):
-        with pytest.raises(AirPurifierMiotException):
+        with pytest.raises(UnsupportedFeatureException):
             self.device.set_led_brightness(LedBrightness.Bright)
 
     def test_set_led(self):
-        with pytest.raises(AirPurifierMiotException):
+        with pytest.raises(UnsupportedFeatureException):
             self.device.set_led(True)
 
 

--- a/miio/integrations/fan/dmaker/fan.py
+++ b/miio/integrations/fan/dmaker/fan.py
@@ -4,7 +4,7 @@ import click
 
 from miio import Device, DeviceStatus
 from miio.click_common import EnumType, command, format_output
-from miio.fan_common import FanException, MoveDirection, OperationMode
+from miio.fan_common import MoveDirection, OperationMode
 
 MODEL_FAN_P5 = "dmaker.fan.p5"
 
@@ -150,7 +150,7 @@ class FanP5(Device):
     def set_speed(self, speed: int):
         """Set speed."""
         if speed < 0 or speed > 100:
-            raise FanException("Invalid speed: %s" % speed)
+            raise ValueError("Invalid speed: %s" % speed)
 
         return self.send("s_speed", [speed])
 
@@ -161,7 +161,7 @@ class FanP5(Device):
     def set_angle(self, angle: int):
         """Set the oscillation angle."""
         if angle not in [30, 60, 90, 120, 140]:
-            raise FanException(
+            raise ValueError(
                 "Unsupported angle. Supported values: 30, 60, 90, 120, 140"
             )
 
@@ -229,7 +229,7 @@ class FanP5(Device):
         """Set delay off minutes."""
 
         if minutes < 0:
-            raise FanException("Invalid value for a delayed turn off: %s" % minutes)
+            raise ValueError("Invalid value for a delayed turn off: %s" % minutes)
 
         return self.send("s_t_off", [minutes])
 

--- a/miio/integrations/fan/dmaker/fan_miot.py
+++ b/miio/integrations/fan/dmaker/fan_miot.py
@@ -5,7 +5,7 @@ import click
 
 from miio import DeviceStatus, MiotDevice
 from miio.click_common import EnumType, command, format_output
-from miio.fan_common import FanException, MoveDirection, OperationMode
+from miio.fan_common import MoveDirection, OperationMode
 
 MODEL_FAN_P9 = "dmaker.fan.p9"
 MODEL_FAN_P10 = "dmaker.fan.p10"
@@ -310,7 +310,7 @@ class FanMiot(MiotDevice):
     def set_speed(self, speed: int):
         """Set speed."""
         if speed < 0 or speed > 100:
-            raise FanException("Invalid speed: %s" % speed)
+            raise ValueError("Invalid speed: %s" % speed)
 
         return self.set_property("fan_speed", speed)
 
@@ -321,7 +321,7 @@ class FanMiot(MiotDevice):
     def set_angle(self, angle: int):
         """Set the oscillation angle."""
         if angle not in SUPPORTED_ANGLES[self.model]:
-            raise FanException(
+            raise ValueError(
                 "Unsupported angle. Supported values: "
                 + ", ".join(f"{i}" for i in SUPPORTED_ANGLES[self.model])
             )
@@ -378,7 +378,7 @@ class FanMiot(MiotDevice):
         """Set delay off minutes."""
 
         if minutes < 0 or minutes > 480:
-            raise FanException("Invalid value for a delayed turn off: %s" % minutes)
+            raise ValueError("Invalid value for a delayed turn off: %s" % minutes)
 
         return self.set_property("power_off_time", minutes)
 
@@ -462,7 +462,7 @@ class Fan1C(MiotDevice):
     def set_speed(self, speed: int):
         """Set speed."""
         if speed not in (1, 2, 3):
-            raise FanException("Invalid speed: %s" % speed)
+            raise ValueError("Invalid speed: %s" % speed)
 
         return self.set_property("fan_level", speed)
 
@@ -516,6 +516,6 @@ class Fan1C(MiotDevice):
         """Set delay off minutes."""
 
         if minutes < 0 or minutes > 480:
-            raise FanException("Invalid value for a delayed turn off: %s" % minutes)
+            raise ValueError("Invalid value for a delayed turn off: %s" % minutes)
 
         return self.set_property("power_off_time", minutes)

--- a/miio/integrations/fan/dmaker/test_fan.py
+++ b/miio/integrations/fan/dmaker/test_fan.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 import pytest
 
-from miio.fan_common import FanException, OperationMode
+from miio.fan_common import OperationMode
 from miio.tests.dummies import DummyDevice
 
 from .fan import MODEL_FAN_P5, FanP5, FanStatusP5
@@ -102,10 +102,10 @@ class TestFanP5(TestCase):
         self.device.set_speed(100)
         assert speed() == 100
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_speed(-1)
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_speed(101)
 
     def test_set_angle(self):
@@ -123,16 +123,16 @@ class TestFanP5(TestCase):
         self.device.set_angle(140)
         assert angle() == 140
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_angle(-1)
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_angle(1)
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_angle(31)
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_angle(141)
 
     def test_set_oscillate(self):
@@ -186,5 +186,5 @@ class TestFanP5(TestCase):
         self.device.delay_off(0)
         assert delay_off_countdown() == 0
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.delay_off(-1)

--- a/miio/integrations/fan/dmaker/test_fan_miot.py
+++ b/miio/integrations/fan/dmaker/test_fan_miot.py
@@ -10,7 +10,6 @@ from .fan_miot import (
     MODEL_FAN_P10,
     MODEL_FAN_P11,
     Fan1C,
-    FanException,
     FanMiot,
     OperationMode,
 )
@@ -81,10 +80,10 @@ class TestFanMiot(TestCase):
         self.device.set_speed(100)
         assert speed() == 100
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_speed(-1)
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_speed(101)
 
     def test_set_angle(self):
@@ -102,19 +101,19 @@ class TestFanMiot(TestCase):
         self.device.set_angle(150)
         assert angle() == 150
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_angle(-1)
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_angle(1)
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_angle(31)
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_angle(140)
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_angle(151)
 
     def test_set_oscillate(self):
@@ -168,9 +167,9 @@ class TestFanMiot(TestCase):
         self.device.delay_off(480)
         assert delay_off_countdown() == 480
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.delay_off(-1)
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.delay_off(481)
 
 
@@ -202,19 +201,19 @@ class TestFanMiotP10(TestCase):
         self.device.set_angle(140)
         assert angle() == 140
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_angle(-1)
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_angle(1)
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_angle(31)
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_angle(150)
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_angle(141)
 
 
@@ -298,10 +297,10 @@ class TestFan1C(TestCase):
         self.device.set_speed(3)
         assert speed() == 3
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_speed(0)
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_speed(4)
 
     def test_set_oscillate(self):
@@ -355,7 +354,7 @@ class TestFan1C(TestCase):
         self.device.delay_off(480)
         assert delay_off_countdown() == 480
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.delay_off(-1)
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.delay_off(481)

--- a/miio/integrations/fan/leshow/fan_leshow.py
+++ b/miio/integrations/fan/leshow/fan_leshow.py
@@ -4,7 +4,7 @@ from typing import Any, Dict
 
 import click
 
-from miio import Device, DeviceException, DeviceStatus
+from miio import Device, DeviceStatus
 from miio.click_common import EnumType, command, format_output
 
 _LOGGER = logging.getLogger(__name__)
@@ -24,10 +24,6 @@ AVAILABLE_PROPERTIES_COMMON = [
 AVAILABLE_PROPERTIES = {
     MODEL_FAN_LESHOW_SS4: AVAILABLE_PROPERTIES_COMMON,
 }
-
-
-class FanLeshowException(DeviceException):
-    pass
 
 
 class OperationMode(enum.Enum):
@@ -140,7 +136,7 @@ class FanLeshow(Device):
     def set_speed(self, speed: int):
         """Set a speed level between 0 and 100."""
         if speed < 0 or speed > 100:
-            raise FanLeshowException("Invalid speed: %s" % speed)
+            raise ValueError("Invalid speed: %s" % speed)
 
         return self.send("set_blow", [speed])
 
@@ -174,8 +170,6 @@ class FanLeshow(Device):
         """Set delay off minutes."""
 
         if minutes < 0 or minutes > 540:
-            raise FanLeshowException(
-                "Invalid value for a delayed turn off: %s" % minutes
-            )
+            raise ValueError("Invalid value for a delayed turn off: %s" % minutes)
 
         return self.send("set_timer", [minutes])

--- a/miio/integrations/fan/leshow/tests/test_fan_leshow.py
+++ b/miio/integrations/fan/leshow/tests/test_fan_leshow.py
@@ -4,13 +4,7 @@ import pytest
 
 from miio.tests.dummies import DummyDevice
 
-from ..fan_leshow import (
-    MODEL_FAN_LESHOW_SS4,
-    FanLeshow,
-    FanLeshowException,
-    FanLeshowStatus,
-    OperationMode,
-)
+from ..fan_leshow import MODEL_FAN_LESHOW_SS4, FanLeshow, FanLeshowStatus, OperationMode
 
 
 class DummyFanLeshow(DummyDevice, FanLeshow):
@@ -89,10 +83,10 @@ class TestFanLeshow(TestCase):
         self.device.set_speed(100)
         assert speed() == 100
 
-        with pytest.raises(FanLeshowException):
+        with pytest.raises(ValueError):
             self.device.set_speed(-1)
 
-        with pytest.raises(FanLeshowException):
+        with pytest.raises(ValueError):
             self.device.set_speed(101)
 
     def test_set_oscillate(self):
@@ -126,8 +120,8 @@ class TestFanLeshow(TestCase):
         self.device.delay_off(0)
         assert delay_off_countdown() == 0
 
-        with pytest.raises(FanLeshowException):
+        with pytest.raises(ValueError):
             self.device.delay_off(-1)
 
-        with pytest.raises(FanLeshowException):
+        with pytest.raises(ValueError):
             self.device.delay_off(541)

--- a/miio/integrations/fan/zhimi/fan.py
+++ b/miio/integrations/fan/zhimi/fan.py
@@ -6,7 +6,7 @@ import click
 from miio import Device, DeviceStatus
 from miio.click_common import EnumType, command, format_output
 from miio.devicestatus import sensor, setting, switch
-from miio.fan_common import FanException, LedBrightness, MoveDirection
+from miio.fan_common import LedBrightness, MoveDirection
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -282,7 +282,7 @@ class Fan(Device):
     def set_natural_speed(self, speed: int):
         """Set natural level."""
         if speed < 0 or speed > 100:
-            raise FanException("Invalid speed: %s" % speed)
+            raise ValueError("Invalid speed: %s" % speed)
 
         return self.send("set_natural_level", [speed])
 
@@ -293,7 +293,7 @@ class Fan(Device):
     def set_direct_speed(self, speed: int):
         """Set speed of the direct mode."""
         if speed < 0 or speed > 100:
-            raise FanException("Invalid speed: %s" % speed)
+            raise ValueError("Invalid speed: %s" % speed)
 
         return self.send("set_speed_level", [speed])
 
@@ -312,7 +312,7 @@ class Fan(Device):
     def set_angle(self, angle: int):
         """Set the oscillation angle."""
         if angle < 0 or angle > 120:
-            raise FanException("Invalid angle: %s" % angle)
+            raise ValueError("Invalid angle: %s" % angle)
 
         return self.send("set_angle", [angle])
 
@@ -395,6 +395,6 @@ class Fan(Device):
         """Set delay off seconds."""
 
         if seconds < 0:
-            raise FanException("Invalid value for a delayed turn off: %s" % seconds)
+            raise ValueError("Invalid value for a delayed turn off: %s" % seconds)
 
         return self.send("set_poweroff_time", [seconds])

--- a/miio/integrations/fan/zhimi/test_fan.py
+++ b/miio/integrations/fan/zhimi/test_fan.py
@@ -9,7 +9,6 @@ from .fan import (
     MODEL_FAN_V2,
     MODEL_FAN_V3,
     Fan,
-    FanException,
     FanStatus,
     LedBrightness,
     MoveDirection,
@@ -165,10 +164,10 @@ class TestFanV2(TestCase):
         self.device.set_direct_speed(100)
         assert direct_speed() == 100
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_direct_speed(-1)
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_direct_speed(101)
 
     def test_set_rotate(self):
@@ -202,10 +201,10 @@ class TestFanV2(TestCase):
         self.device.set_angle(120)
         assert angle() == 120
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_angle(-1)
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_angle(121)
 
     def test_set_oscillate(self):
@@ -262,7 +261,7 @@ class TestFanV2(TestCase):
         self.device.delay_off(0)
         assert delay_off_countdown() == 0
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.delay_off(-1)
 
 
@@ -404,10 +403,10 @@ class TestFanV3(TestCase):
         self.device.set_direct_speed(100)
         assert direct_speed() == 100
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_direct_speed(-1)
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_direct_speed(101)
 
     def test_set_natural_speed(self):
@@ -421,10 +420,10 @@ class TestFanV3(TestCase):
         self.device.set_natural_speed(100)
         assert natural_speed() == 100
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_natural_speed(-1)
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_natural_speed(101)
 
     def test_set_rotate(self):
@@ -458,10 +457,10 @@ class TestFanV3(TestCase):
         self.device.set_angle(120)
         assert angle() == 120
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_angle(-1)
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_angle(121)
 
     def test_set_oscillate(self):
@@ -518,7 +517,7 @@ class TestFanV3(TestCase):
         self.device.delay_off(0)
         assert delay_off_countdown() == 0
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.delay_off(-1)
 
 
@@ -622,10 +621,10 @@ class TestFanSA1(TestCase):
         self.device.set_direct_speed(100)
         assert direct_speed() == 100
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_direct_speed(-1)
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_direct_speed(101)
 
     def test_set_natural_speed(self):
@@ -639,10 +638,10 @@ class TestFanSA1(TestCase):
         self.device.set_natural_speed(100)
         assert natural_speed() == 100
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_natural_speed(-1)
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_natural_speed(101)
 
     def test_set_rotate(self):
@@ -676,10 +675,10 @@ class TestFanSA1(TestCase):
         self.device.set_angle(120)
         assert angle() == 120
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_angle(-1)
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.set_angle(121)
 
     def test_set_oscillate(self):
@@ -736,5 +735,5 @@ class TestFanSA1(TestCase):
         self.device.delay_off(0)
         assert delay_off_countdown() == 0
 
-        with pytest.raises(FanException):
+        with pytest.raises(ValueError):
             self.device.delay_off(-1)

--- a/miio/integrations/fan/zhimi/test_zhimi_miot.py
+++ b/miio/integrations/fan/zhimi/test_zhimi_miot.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 import pytest
 
-from miio.fan_common import FanException, OperationMode
+from miio.fan_common import OperationMode
 from miio.tests.dummies import DummyMiotDevice
 
 from . import FanZA5
@@ -86,7 +86,7 @@ class TestFanZA5(TestCase):
             assert speed() == s
 
         for s in (-1, 0, 101):
-            with pytest.raises(FanException):
+            with pytest.raises(ValueError):
                 self.device.set_speed(s)
 
     def test_fan_speed_deprecation(self):
@@ -102,7 +102,7 @@ class TestFanZA5(TestCase):
             assert angle() == a
 
         for a in (0, 45, 140):
-            with pytest.raises(FanException):
+            with pytest.raises(ValueError):
                 self.device.set_angle(a)
 
     def test_set_oscillate(self):
@@ -144,7 +144,7 @@ class TestFanZA5(TestCase):
             assert led_brightness() == brightness
 
         for brightness in (-1, 101):
-            with pytest.raises(FanException):
+            with pytest.raises(ValueError):
                 self.device.set_led_brightness(brightness)
 
     def test_delay_off(self):
@@ -156,5 +156,5 @@ class TestFanZA5(TestCase):
             assert delay_off_countdown() == delay
 
         for delay in (-1, 36001):
-            with pytest.raises(FanException):
+            with pytest.raises(ValueError):
                 self.device.delay_off(delay)

--- a/miio/integrations/fan/zhimi/zhimi_miot.py
+++ b/miio/integrations/fan/zhimi/zhimi_miot.py
@@ -3,9 +3,9 @@ from typing import Any, Dict
 
 import click
 
-from miio import DeviceStatus, MiotDevice
+from miio import DeviceException, DeviceStatus, MiotDevice
 from miio.click_common import EnumType, command, format_output
-from miio.fan_common import FanException, MoveDirection, OperationMode
+from miio.fan_common import MoveDirection, OperationMode
 from miio.utils import deprecated
 
 MODEL_FAN_ZA5 = "zhimi.fan.za5"
@@ -236,7 +236,7 @@ class FanZA5(MiotDevice):
     def set_speed(self, speed: int):
         """Set fan speed."""
         if speed < 1 or speed > 100:
-            raise FanException("Invalid speed: %s" % speed)
+            raise ValueError("Invalid speed: %s" % speed)
 
         return self.set_property("fan_speed", speed)
 
@@ -247,7 +247,7 @@ class FanZA5(MiotDevice):
     def set_angle(self, angle: int):
         """Set the oscillation angle."""
         if angle not in SUPPORTED_ANGLES[self.model]:
-            raise FanException(
+            raise ValueError(
                 "Unsupported angle. Supported values: "
                 + ", ".join(f"{i}" for i in SUPPORTED_ANGLES[self.model])
             )
@@ -293,7 +293,7 @@ class FanZA5(MiotDevice):
     def set_led_brightness(self, brightness: int):
         """Set LED brightness."""
         if brightness < 0 or brightness > 100:
-            raise FanException("Invalid brightness: %s" % brightness)
+            raise ValueError("Invalid brightness: %s" % brightness)
 
         return self.set_property("light", brightness)
 
@@ -313,7 +313,7 @@ class FanZA5(MiotDevice):
         """Set delay off seconds."""
 
         if seconds < 0 or seconds > 10 * 60 * 60:
-            raise FanException("Invalid value for a delayed turn off: %s" % seconds)
+            raise ValueError("Invalid value for a delayed turn off: %s" % seconds)
 
         return self.set_property("power_off_time", seconds)
 
@@ -325,7 +325,7 @@ class FanZA5(MiotDevice):
         """Rotate fan 7.5 degrees horizontally to given direction."""
         status = self.status()
         if status.oscillate:
-            raise FanException(
+            raise DeviceException(
                 "Rotation requires oscillation to be turned off to function."
             )
         return self.set_property("set_move", direction.name.lower())

--- a/miio/integrations/humidifier/deerma/airhumidifier_jsqs.py
+++ b/miio/integrations/humidifier/deerma/airhumidifier_jsqs.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, Optional
 import click
 
 from miio.click_common import EnumType, command, format_output
-from miio.exceptions import DeviceException
 from miio.miot_device import DeviceStatus, MiotDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -31,10 +30,6 @@ _MAPPING = {
 
 SUPPORTED_MODELS = ["deerma.humidifier.jsqs", "deerma.humidifier.jsq5"]
 MIOT_MAPPING = {model: _MAPPING for model in SUPPORTED_MODELS}
-
-
-class AirHumidifierJsqsException(DeviceException):
-    pass
 
 
 class OperationMode(enum.Enum):
@@ -192,7 +187,7 @@ class AirHumidifierJsqs(MiotDevice):
     def set_target_humidity(self, humidity: int):
         """Set target humidity."""
         if humidity < 40 or humidity > 80:
-            raise AirHumidifierJsqsException(
+            raise ValueError(
                 "Invalid target humidity: %s. Must be between 40 and 80" % humidity
             )
         return self.set_property("target_humidity", humidity)

--- a/miio/integrations/humidifier/deerma/airhumidifier_mjjsq.py
+++ b/miio/integrations/humidifier/deerma/airhumidifier_mjjsq.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional
 
 import click
 
-from miio import Device, DeviceException, DeviceStatus
+from miio import Device, DeviceStatus
 from miio.click_common import EnumType, command, format_output
 
 _LOGGER = logging.getLogger(__name__)
@@ -31,10 +31,6 @@ AVAILABLE_PROPERTIES = {
     MODEL_HUMIDIFIER_JSQ: MODEL_HUMIDIFIER_JSQ_COMMON,
     MODEL_HUMIDIFIER_JSQ1: MODEL_HUMIDIFIER_JSQ_COMMON + ["wet_and_protect"],
 }
-
-
-class AirHumidifierException(DeviceException):
-    pass
 
 
 class OperationMode(enum.Enum):
@@ -203,7 +199,7 @@ class AirHumidifierMjjsq(Device):
     def set_target_humidity(self, humidity: int):
         """Set the target humidity in percent."""
         if humidity < 0 or humidity > 99:
-            raise AirHumidifierException("Invalid target humidity: %s" % humidity)
+            raise ValueError("Invalid target humidity: %s" % humidity)
 
         return self.send("Set_HumiValue", [humidity])
 

--- a/miio/integrations/humidifier/deerma/tests/test_airhumidifier_jsqs.py
+++ b/miio/integrations/humidifier/deerma/tests/test_airhumidifier_jsqs.py
@@ -3,7 +3,7 @@ import pytest
 from miio import AirHumidifierJsqs
 from miio.tests.dummies import DummyMiotDevice
 
-from ..airhumidifier_jsqs import AirHumidifierJsqsException, OperationMode
+from ..airhumidifier_jsqs import OperationMode
 
 _INITIAL_STATE = {
     "power": True,
@@ -80,10 +80,10 @@ def test_set_target_humidity(dev):
     dev.set_target_humidity(80)
     assert target_humidity() == 80
 
-    with pytest.raises(AirHumidifierJsqsException):
+    with pytest.raises(ValueError):
         dev.set_target_humidity(39)
 
-    with pytest.raises(AirHumidifierJsqsException):
+    with pytest.raises(ValueError):
         dev.set_target_humidity(81)
 
 

--- a/miio/integrations/humidifier/deerma/tests/test_airhumidifier_mjjsq.py
+++ b/miio/integrations/humidifier/deerma/tests/test_airhumidifier_mjjsq.py
@@ -7,7 +7,6 @@ from miio.tests.dummies import DummyDevice
 from .. import AirHumidifierMjjsq
 from ..airhumidifier_mjjsq import (
     MODEL_HUMIDIFIER_JSQ1,
-    AirHumidifierException,
     AirHumidifierStatus,
     OperationMode,
 )
@@ -133,13 +132,13 @@ class TestAirHumidifierMjjsq(TestCase):
         self.device.set_target_humidity(99)
         assert target_humidity() == 99
 
-        with pytest.raises(AirHumidifierException):
+        with pytest.raises(ValueError):
             self.device.set_target_humidity(-1)
 
-        with pytest.raises(AirHumidifierException):
+        with pytest.raises(ValueError):
             self.device.set_target_humidity(100)
 
-        with pytest.raises(AirHumidifierException):
+        with pytest.raises(ValueError):
             self.device.set_target_humidity(101)
 
     def test_set_wet_protection(self):

--- a/miio/integrations/humidifier/shuii/airhumidifier_jsq.py
+++ b/miio/integrations/humidifier/shuii/airhumidifier_jsq.py
@@ -4,14 +4,10 @@ from typing import Any, Dict, Optional
 
 import click
 
-from miio import Device, DeviceException, DeviceStatus
+from miio import Device, DeviceStatus
 from miio.click_common import EnumType, command, format_output
 
 _LOGGER = logging.getLogger(__name__)
-
-
-class AirHumidifierException(DeviceException):
-    pass
 
 
 # Xiaomi Zero Fog Humidifier
@@ -212,7 +208,7 @@ class AirHumidifierJsq(Device):
         """Set mode."""
         value = mode.value
         if value not in (om.value for om in OperationMode):
-            raise AirHumidifierException(f"{value} is not a valid OperationMode value")
+            raise ValueError(f"{value} is not a valid OperationMode value")
 
         return self.send("set_mode", [value])
 
@@ -224,7 +220,7 @@ class AirHumidifierJsq(Device):
         """Set led brightness."""
         value = brightness.value
         if value not in (lb.value for lb in LedBrightness):
-            raise AirHumidifierException(f"{value} is not a valid LedBrightness value")
+            raise ValueError(f"{value} is not a valid LedBrightness value")
 
         return self.send("set_brightness", [value])
 

--- a/miio/integrations/humidifier/shuii/tests/test_airhumidifier_jsq.py
+++ b/miio/integrations/humidifier/shuii/tests/test_airhumidifier_jsq.py
@@ -8,7 +8,6 @@ from miio.tests.dummies import DummyDevice
 from .. import AirHumidifierJsq
 from ..airhumidifier_jsq import (
     MODEL_HUMIDIFIER_JSQ001,
-    AirHumidifierException,
     AirHumidifierStatus,
     LedBrightness,
     OperationMode,
@@ -167,17 +166,17 @@ class TestAirHumidifierJsq(TestCase):
         self.device.set_mode(OperationMode.Level3)
         assert mode() == OperationMode.Level3
 
-        with pytest.raises(AirHumidifierException) as excinfo:
+        with pytest.raises(ValueError) as excinfo:
             self.device.set_mode(Bunch(value=10))
         assert str(excinfo.value) == "10 is not a valid OperationMode value"
         assert mode() == OperationMode.Level3
 
-        with pytest.raises(AirHumidifierException) as excinfo:
+        with pytest.raises(ValueError) as excinfo:
             self.device.set_mode(Bunch(value=-1))
         assert str(excinfo.value) == "-1 is not a valid OperationMode value"
         assert mode() == OperationMode.Level3
 
-        with pytest.raises(AirHumidifierException) as excinfo:
+        with pytest.raises(ValueError) as excinfo:
             self.device.set_mode(Bunch(value="smth"))
         assert str(excinfo.value) == "smth is not a valid OperationMode value"
         assert mode() == OperationMode.Level3
@@ -202,17 +201,17 @@ class TestAirHumidifierJsq(TestCase):
         self.device.set_led_brightness(LedBrightness.Low)
         assert led_brightness() == LedBrightness.Low
 
-        with pytest.raises(AirHumidifierException) as excinfo:
+        with pytest.raises(ValueError) as excinfo:
             self.device.set_led_brightness(Bunch(value=10))
         assert str(excinfo.value) == "10 is not a valid LedBrightness value"
         assert led_brightness() == LedBrightness.Low
 
-        with pytest.raises(AirHumidifierException) as excinfo:
+        with pytest.raises(ValueError) as excinfo:
             self.device.set_led_brightness(Bunch(value=-10))
         assert str(excinfo.value) == "-10 is not a valid LedBrightness value"
         assert led_brightness() == LedBrightness.Low
 
-        with pytest.raises(AirHumidifierException) as excinfo:
+        with pytest.raises(ValueError) as excinfo:
             self.device.set_led_brightness(Bunch(value="smth"))
         assert str(excinfo.value) == "smth is not a valid LedBrightness value"
         assert led_brightness() == LedBrightness.Low

--- a/miio/integrations/humidifier/zhimi/airhumidifier.py
+++ b/miio/integrations/humidifier/zhimi/airhumidifier.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional
 
 import click
 
-from miio import Device, DeviceError, DeviceException, DeviceInfo, DeviceStatus
+from miio import Device, DeviceError, DeviceInfo, DeviceStatus
 from miio.click_common import EnumType, command, format_output
 from miio.devicestatus import sensor, setting, switch
 
@@ -45,10 +45,6 @@ AVAILABLE_PROPERTIES = {
     MODEL_HUMIDIFIER_CB2: AVAILABLE_PROPERTIES_COMMON
     + ["temperature", "speed", "depth", "dry"],
 }
-
-
-class AirHumidifierException(DeviceException):
-    pass
 
 
 class OperationMode(enum.Enum):
@@ -189,7 +185,7 @@ class AirHumidifierStatus(DeviceStatus):
         For example 1.2.9_5033.
         """
         if self.device_info.firmware_version is None:
-            raise AirHumidifierException("Missing firmware information")
+            return "missing fw version"
 
         return self.device_info.firmware_version
 
@@ -459,7 +455,7 @@ class AirHumidifier(Device):
     def set_target_humidity(self, humidity: int):
         """Set the target humidity."""
         if humidity not in [30, 40, 50, 60, 70, 80]:
-            raise AirHumidifierException("Invalid target humidity: %s" % humidity)
+            raise ValueError("Invalid target humidity: %s" % humidity)
 
         return self.send("set_limit_hum", [humidity])
 

--- a/miio/integrations/humidifier/zhimi/airhumidifier_miot.py
+++ b/miio/integrations/humidifier/zhimi/airhumidifier_miot.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional
 
 import click
 
-from miio import DeviceException, DeviceStatus, MiotDevice
+from miio import DeviceStatus, MiotDevice
 from miio.click_common import EnumType, command, format_output
 
 _LOGGER = logging.getLogger(__name__)
@@ -42,10 +42,6 @@ _MAPPINGS = {
         "clean_mode": {"siid": 7, "piid": 5},  # bool
     }
 }
-
-
-class AirHumidifierMiotException(DeviceException):
-    pass
 
 
 class OperationMode(enum.Enum):
@@ -310,7 +306,7 @@ class AirHumidifierMiot(MiotDevice):
     def set_speed(self, rpm: int):
         """Set motor speed."""
         if rpm < 200 or rpm > 2000 or rpm % 10 != 0:
-            raise AirHumidifierMiotException(
+            raise ValueError(
                 "Invalid motor speed: %s. Must be between 200 and 2000 and divisible by 10"
                 % rpm
             )
@@ -323,7 +319,7 @@ class AirHumidifierMiot(MiotDevice):
     def set_target_humidity(self, humidity: int):
         """Set target humidity."""
         if humidity < 30 or humidity > 80:
-            raise AirHumidifierMiotException(
+            raise ValueError(
                 "Invalid target humidity: %s. Must be between 30 and 80" % humidity
             )
         return self.set_property("target_humidity", humidity)

--- a/miio/integrations/humidifier/zhimi/tests/test_airhumidifier.py
+++ b/miio/integrations/humidifier/zhimi/tests/test_airhumidifier.py
@@ -8,7 +8,6 @@ from ..airhumidifier import (
     MODEL_HUMIDIFIER_CA1,
     MODEL_HUMIDIFIER_CB1,
     MODEL_HUMIDIFIER_V1,
-    AirHumidifierException,
     LedBrightness,
     OperationMode,
 )
@@ -183,16 +182,16 @@ def test_set_target_humidity(dev):
     dev.set_target_humidity(80)
     assert target_humidity() == 80
 
-    with pytest.raises(AirHumidifierException):
+    with pytest.raises(ValueError):
         dev.set_target_humidity(-1)
 
-    with pytest.raises(AirHumidifierException):
+    with pytest.raises(ValueError):
         dev.set_target_humidity(20)
 
-    with pytest.raises(AirHumidifierException):
+    with pytest.raises(ValueError):
         dev.set_target_humidity(90)
 
-    with pytest.raises(AirHumidifierException):
+    with pytest.raises(ValueError):
         dev.set_target_humidity(110)
 
 

--- a/miio/integrations/humidifier/zhimi/tests/test_airhumidifier_miot.py
+++ b/miio/integrations/humidifier/zhimi/tests/test_airhumidifier_miot.py
@@ -3,12 +3,7 @@ import pytest
 from miio.tests.dummies import DummyMiotDevice
 
 from .. import AirHumidifierMiot
-from ..airhumidifier_miot import (
-    AirHumidifierMiotException,
-    LedBrightness,
-    OperationMode,
-    PressedButton,
-)
+from ..airhumidifier_miot import LedBrightness, OperationMode, PressedButton
 
 _INITIAL_STATE = {
     "power": True,
@@ -103,10 +98,10 @@ def test_set_speed(dev):
     dev.set_speed(2000)
     assert speed_level() == 2000
 
-    with pytest.raises(AirHumidifierMiotException):
+    with pytest.raises(ValueError):
         dev.set_speed(199)
 
-    with pytest.raises(AirHumidifierMiotException):
+    with pytest.raises(ValueError):
         dev.set_speed(2001)
 
 
@@ -119,10 +114,10 @@ def test_set_target_humidity(dev):
     dev.set_target_humidity(80)
     assert target_humidity() == 80
 
-    with pytest.raises(AirHumidifierMiotException):
+    with pytest.raises(ValueError):
         dev.set_target_humidity(29)
 
-    with pytest.raises(AirHumidifierMiotException):
+    with pytest.raises(ValueError):
         dev.set_target_humidity(81)
 
 

--- a/miio/integrations/light/philips/ceil.py
+++ b/miio/integrations/light/philips/ceil.py
@@ -4,17 +4,13 @@ from typing import Any, Dict
 
 import click
 
-from miio import Device, DeviceException, DeviceStatus
+from miio import Device, DeviceStatus
 from miio.click_common import command, format_output
 
 _LOGGER = logging.getLogger(__name__)
 
 
 SUPPORTED_MODELS = ["philips.light.ceiling", "philips.light.zyceiling"]
-
-
-class CeilException(DeviceException):
-    pass
 
 
 class CeilStatus(DeviceStatus):
@@ -113,7 +109,7 @@ class Ceil(Device):
     def set_brightness(self, level: int):
         """Set brightness level."""
         if level < 1 or level > 100:
-            raise CeilException("Invalid brightness: %s" % level)
+            raise ValueError("Invalid brightness: %s" % level)
 
         return self.send("set_bright", [level])
 
@@ -124,7 +120,7 @@ class Ceil(Device):
     def set_color_temperature(self, level: int):
         """Set Correlated Color Temperature."""
         if level < 1 or level > 100:
-            raise CeilException("Invalid color temperature: %s" % level)
+            raise ValueError("Invalid color temperature: %s" % level)
 
         return self.send("set_cct", [level])
 
@@ -138,10 +134,10 @@ class Ceil(Device):
     def set_brightness_and_color_temperature(self, brightness: int, cct: int):
         """Set brightness level and the correlated color temperature."""
         if brightness < 1 or brightness > 100:
-            raise CeilException("Invalid brightness: %s" % brightness)
+            raise ValueError("Invalid brightness: %s" % brightness)
 
         if cct < 1 or cct > 100:
-            raise CeilException("Invalid color temperature: %s" % cct)
+            raise ValueError("Invalid color temperature: %s" % cct)
 
         return self.send("set_bricct", [brightness, cct])
 
@@ -153,7 +149,7 @@ class Ceil(Device):
         """Turn off delay in seconds."""
 
         if seconds < 1:
-            raise CeilException("Invalid value for a delayed turn off: %s" % seconds)
+            raise ValueError("Invalid value for a delayed turn off: %s" % seconds)
 
         return self.send("delay_off", [seconds])
 
@@ -164,7 +160,7 @@ class Ceil(Device):
     def set_scene(self, number: int):
         """Set a fixed scene (1-4)."""
         if number < 1 or number > 4:
-            raise CeilException("Invalid fixed scene number: %s" % number)
+            raise ValueError("Invalid fixed scene number: %s" % number)
 
         return self.send("apply_fixed_scene", [number])
 

--- a/miio/integrations/light/philips/philips_bulb.py
+++ b/miio/integrations/light/philips/philips_bulb.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional
 
 import click
 
-from miio import Device, DeviceException, DeviceStatus
+from miio import Device, DeviceStatus
 from miio.click_common import command, format_output
 
 _LOGGER = logging.getLogger(__name__)
@@ -25,10 +25,6 @@ AVAILABLE_PROPERTIES = {
     MODEL_PHILIPS_CANDLE: AVAILABLE_PROPERTIES_COLORTEMP,
     MODEL_PHILIPS_CANDLE2: AVAILABLE_PROPERTIES_COLORTEMP,
 }
-
-
-class PhilipsBulbException(DeviceException):
-    pass
 
 
 class PhilipsBulbStatus(DeviceStatus):
@@ -113,7 +109,7 @@ class PhilipsWhiteBulb(Device):
     def set_brightness(self, level: int):
         """Set brightness level."""
         if level < 1 or level > 100:
-            raise PhilipsBulbException("Invalid brightness: %s" % level)
+            raise ValueError("Invalid brightness: %s" % level)
 
         return self.send("set_bright", [level])
 
@@ -125,9 +121,7 @@ class PhilipsWhiteBulb(Device):
         """Set delay off seconds."""
 
         if seconds < 1:
-            raise PhilipsBulbException(
-                "Invalid value for a delayed turn off: %s" % seconds
-            )
+            raise ValueError("Invalid value for a delayed turn off: %s" % seconds)
 
         return self.send("delay_off", [seconds])
 
@@ -144,7 +138,7 @@ class PhilipsBulb(PhilipsWhiteBulb):
     def set_color_temperature(self, level: int):
         """Set Correlated Color Temperature."""
         if level < 1 or level > 100:
-            raise PhilipsBulbException("Invalid color temperature: %s" % level)
+            raise ValueError("Invalid color temperature: %s" % level)
 
         return self.send("set_cct", [level])
 
@@ -158,10 +152,10 @@ class PhilipsBulb(PhilipsWhiteBulb):
     def set_brightness_and_color_temperature(self, brightness: int, cct: int):
         """Set brightness level and the correlated color temperature."""
         if brightness < 1 or brightness > 100:
-            raise PhilipsBulbException("Invalid brightness: %s" % brightness)
+            raise ValueError("Invalid brightness: %s" % brightness)
 
         if cct < 1 or cct > 100:
-            raise PhilipsBulbException("Invalid color temperature: %s" % cct)
+            raise ValueError("Invalid color temperature: %s" % cct)
 
         return self.send("set_bricct", [brightness, cct])
 
@@ -172,6 +166,6 @@ class PhilipsBulb(PhilipsWhiteBulb):
     def set_scene(self, number: int):
         """Set scene number."""
         if number < 1 or number > 4:
-            raise PhilipsBulbException("Invalid fixed scene number: %s" % number)
+            raise ValueError("Invalid fixed scene number: %s" % number)
 
         return self.send("apply_fixed_scene", [number])

--- a/miio/integrations/light/philips/philips_eyecare.py
+++ b/miio/integrations/light/philips/philips_eyecare.py
@@ -4,14 +4,10 @@ from typing import Any, Dict
 
 import click
 
-from miio import Device, DeviceException, DeviceStatus
+from miio import Device, DeviceStatus
 from miio.click_common import command, format_output
 
 _LOGGER = logging.getLogger(__name__)
-
-
-class PhilipsEyecareException(DeviceException):
-    pass
 
 
 class PhilipsEyecareStatus(DeviceStatus):
@@ -137,7 +133,7 @@ class PhilipsEyecare(Device):
     def set_brightness(self, level: int):
         """Set brightness level of the primary light."""
         if level < 1 or level > 100:
-            raise PhilipsEyecareException("Invalid brightness: %s" % level)
+            raise ValueError("Invalid brightness: %s" % level)
 
         return self.send("set_bright", [level])
 
@@ -148,7 +144,7 @@ class PhilipsEyecare(Device):
     def set_scene(self, number: int):
         """Set one of the fixed eyecare user scenes."""
         if number < 1 or number > 4:
-            raise PhilipsEyecareException("Invalid fixed scene number: %s" % number)
+            raise ValueError("Invalid fixed scene number: %s" % number)
 
         return self.send("set_user_scene", [number])
 
@@ -160,9 +156,7 @@ class PhilipsEyecare(Device):
         """Set delay off minutes."""
 
         if minutes < 0:
-            raise PhilipsEyecareException(
-                "Invalid value for a delayed turn off: %s" % minutes
-            )
+            raise ValueError("Invalid value for a delayed turn off: %s" % minutes)
 
         return self.send("delay_off", [minutes])
 
@@ -203,6 +197,6 @@ class PhilipsEyecare(Device):
     def set_ambient_brightness(self, level: int):
         """Set the brightness of the ambient light."""
         if level < 1 or level > 100:
-            raise PhilipsEyecareException("Invalid ambient brightness: %s" % level)
+            raise ValueError("Invalid ambient brightness: %s" % level)
 
         return self.send("set_amb_bright", [level])

--- a/miio/integrations/light/philips/philips_moonlight.py
+++ b/miio/integrations/light/philips/philips_moonlight.py
@@ -4,15 +4,11 @@ from typing import Any, Dict, List, Tuple
 
 import click
 
-from miio import Device, DeviceException, DeviceStatus
+from miio import Device, DeviceStatus
 from miio.click_common import command, format_output
 from miio.utils import int_to_rgb
 
 _LOGGER = logging.getLogger(__name__)
-
-
-class PhilipsMoonlightException(DeviceException):
-    pass
 
 
 class PhilipsMoonlightStatus(DeviceStatus):
@@ -166,7 +162,7 @@ class PhilipsMoonlight(Device):
         """Set color in RGB."""
         for color in rgb:
             if color < 0 or color > 255:
-                raise PhilipsMoonlightException("Invalid color: %s" % color)
+                raise ValueError("Invalid color: %s" % color)
 
         return self.send("set_rgb", [*rgb])
 
@@ -177,7 +173,7 @@ class PhilipsMoonlight(Device):
     def set_brightness(self, level: int):
         """Set brightness level."""
         if level < 1 or level > 100:
-            raise PhilipsMoonlightException("Invalid brightness: %s" % level)
+            raise ValueError("Invalid brightness: %s" % level)
 
         return self.send("set_bright", [level])
 
@@ -188,7 +184,7 @@ class PhilipsMoonlight(Device):
     def set_color_temperature(self, level: int):
         """Set Correlated Color Temperature."""
         if level < 1 or level > 100:
-            raise PhilipsMoonlightException("Invalid color temperature: %s" % level)
+            raise ValueError("Invalid color temperature: %s" % level)
 
         return self.send("set_cct", [level])
 
@@ -202,10 +198,10 @@ class PhilipsMoonlight(Device):
     def set_brightness_and_color_temperature(self, brightness: int, cct: int):
         """Set brightness level and the correlated color temperature."""
         if brightness < 1 or brightness > 100:
-            raise PhilipsMoonlightException("Invalid brightness: %s" % brightness)
+            raise ValueError("Invalid brightness: %s" % brightness)
 
         if cct < 1 or cct > 100:
-            raise PhilipsMoonlightException("Invalid color temperature: %s" % cct)
+            raise ValueError("Invalid color temperature: %s" % cct)
 
         return self.send("set_bricct", [brightness, cct])
 
@@ -219,11 +215,11 @@ class PhilipsMoonlight(Device):
     def set_brightness_and_rgb(self, brightness: int, rgb: Tuple[int, int, int]):
         """Set brightness level and the color."""
         if brightness < 1 or brightness > 100:
-            raise PhilipsMoonlightException("Invalid brightness: %s" % brightness)
+            raise ValueError("Invalid brightness: %s" % brightness)
 
         for color in rgb:
             if color < 0 or color > 255:
-                raise PhilipsMoonlightException("Invalid color: %s" % color)
+                raise ValueError("Invalid color: %s" % color)
 
         return self.send("set_brirgb", [*rgb, brightness])
 
@@ -234,7 +230,7 @@ class PhilipsMoonlight(Device):
     def set_scene(self, number: int):
         """Set scene number."""
         if number < 1 or number > 6:
-            raise PhilipsMoonlightException("Invalid fixed scene number: %s" % number)
+            raise ValueError("Invalid fixed scene number: %s" % number)
 
         if number == 6:
             return self.send("go_night")

--- a/miio/integrations/light/philips/philips_rwread.py
+++ b/miio/integrations/light/philips/philips_rwread.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 
 import click
 
-from miio import Device, DeviceException, DeviceStatus
+from miio import Device, DeviceStatus
 from miio.click_common import EnumType, command, format_output
 
 _LOGGER = logging.getLogger(__name__)
@@ -15,10 +15,6 @@ MODEL_PHILIPS_LIGHT_RWREAD = "philips.light.rwread"
 AVAILABLE_PROPERTIES = {
     MODEL_PHILIPS_LIGHT_RWREAD: ["power", "bright", "dv", "snm", "flm", "chl", "flmv"]
 }
-
-
-class PhilipsRwreadException(DeviceException):
-    pass
 
 
 class MotionDetectionSensitivity(enum.Enum):
@@ -122,7 +118,7 @@ class PhilipsRwread(Device):
     def set_brightness(self, level: int):
         """Set brightness level of the primary light."""
         if level < 1 or level > 100:
-            raise PhilipsRwreadException("Invalid brightness: %s" % level)
+            raise ValueError("Invalid brightness: %s" % level)
 
         return self.send("set_bright", [level])
 
@@ -133,7 +129,7 @@ class PhilipsRwread(Device):
     def set_scene(self, number: int):
         """Set one of the fixed eyecare user scenes."""
         if number < 1 or number > 4:
-            raise PhilipsRwreadException("Invalid fixed scene number: %s" % number)
+            raise ValueError("Invalid fixed scene number: %s" % number)
 
         return self.send("apply_fixed_scene", [number])
 
@@ -145,9 +141,7 @@ class PhilipsRwread(Device):
         """Set delay off in seconds."""
 
         if seconds < 0:
-            raise PhilipsRwreadException(
-                "Invalid value for a delayed turn off: %s" % seconds
-            )
+            raise ValueError("Invalid value for a delayed turn off: %s" % seconds)
 
         return self.send("delay_off", [seconds])
 

--- a/miio/integrations/light/philips/tests/test_ceil.py
+++ b/miio/integrations/light/philips/tests/test_ceil.py
@@ -4,7 +4,7 @@ import pytest
 
 from miio.tests.dummies import DummyDevice
 
-from ..ceil import Ceil, CeilException, CeilStatus
+from ..ceil import Ceil, CeilStatus
 
 
 class DummyCeil(DummyDevice, Ceil):
@@ -90,10 +90,10 @@ class TestCeil(TestCase):
         self.device.set_brightness(20)
         assert brightness() == 20
 
-        with pytest.raises(CeilException):
+        with pytest.raises(ValueError):
             self.device.set_brightness(-1)
 
-        with pytest.raises(CeilException):
+        with pytest.raises(ValueError):
             self.device.set_brightness(101)
 
     def test_set_color_temperature(self):
@@ -105,10 +105,10 @@ class TestCeil(TestCase):
         self.device.set_color_temperature(20)
         assert color_temperature() == 20
 
-        with pytest.raises(CeilException):
+        with pytest.raises(ValueError):
             self.device.set_color_temperature(-1)
 
-        with pytest.raises(CeilException):
+        with pytest.raises(ValueError):
             self.device.set_color_temperature(101)
 
     def test_set_brightness_and_color_temperature(self):
@@ -128,22 +128,22 @@ class TestCeil(TestCase):
         assert brightness() == 10
         assert color_temperature() == 11
 
-        with pytest.raises(CeilException):
+        with pytest.raises(ValueError):
             self.device.set_brightness_and_color_temperature(-1, 10)
 
-        with pytest.raises(CeilException):
+        with pytest.raises(ValueError):
             self.device.set_brightness_and_color_temperature(10, -1)
 
-        with pytest.raises(CeilException):
+        with pytest.raises(ValueError):
             self.device.set_brightness_and_color_temperature(0, 10)
 
-        with pytest.raises(CeilException):
+        with pytest.raises(ValueError):
             self.device.set_brightness_and_color_temperature(10, 0)
 
-        with pytest.raises(CeilException):
+        with pytest.raises(ValueError):
             self.device.set_brightness_and_color_temperature(101, 10)
 
-        with pytest.raises(CeilException):
+        with pytest.raises(ValueError):
             self.device.set_brightness_and_color_temperature(10, 101)
 
     def test_delay_off(self):
@@ -155,10 +155,10 @@ class TestCeil(TestCase):
         self.device.delay_off(200)
         assert delay_off_countdown() == 200
 
-        with pytest.raises(CeilException):
+        with pytest.raises(ValueError):
             self.device.delay_off(0)
 
-        with pytest.raises(CeilException):
+        with pytest.raises(ValueError):
             self.device.delay_off(-1)
 
     def test_set_scene(self):
@@ -170,10 +170,10 @@ class TestCeil(TestCase):
         self.device.set_scene(4)
         assert scene() == 4
 
-        with pytest.raises(CeilException):
+        with pytest.raises(ValueError):
             self.device.set_scene(0)
 
-        with pytest.raises(CeilException):
+        with pytest.raises(ValueError):
             self.device.set_scene(5)
 
     def test_smart_night_light_on(self):

--- a/miio/integrations/light/philips/tests/test_philips_bulb.py
+++ b/miio/integrations/light/philips/tests/test_philips_bulb.py
@@ -8,7 +8,6 @@ from ..philips_bulb import (
     MODEL_PHILIPS_LIGHT_BULB,
     MODEL_PHILIPS_LIGHT_HBULB,
     PhilipsBulb,
-    PhilipsBulbException,
     PhilipsBulbStatus,
     PhilipsWhiteBulb,
 )
@@ -82,13 +81,13 @@ class TestPhilipsBulb(TestCase):
         assert brightness() == 50
         self.device.set_brightness(100)
 
-        with pytest.raises(PhilipsBulbException):
+        with pytest.raises(ValueError):
             self.device.set_brightness(-1)
 
-        with pytest.raises(PhilipsBulbException):
+        with pytest.raises(ValueError):
             self.device.set_brightness(0)
 
-        with pytest.raises(PhilipsBulbException):
+        with pytest.raises(ValueError):
             self.device.set_brightness(101)
 
     def test_set_color_temperature(self):
@@ -101,13 +100,13 @@ class TestPhilipsBulb(TestCase):
         assert color_temperature() == 30
         self.device.set_color_temperature(10)
 
-        with pytest.raises(PhilipsBulbException):
+        with pytest.raises(ValueError):
             self.device.set_color_temperature(-1)
 
-        with pytest.raises(PhilipsBulbException):
+        with pytest.raises(ValueError):
             self.device.set_color_temperature(0)
 
-        with pytest.raises(PhilipsBulbException):
+        with pytest.raises(ValueError):
             self.device.set_color_temperature(101)
 
     def test_set_brightness_and_color_temperature(self):
@@ -127,22 +126,22 @@ class TestPhilipsBulb(TestCase):
         assert brightness() == 10
         assert color_temperature() == 11
 
-        with pytest.raises(PhilipsBulbException):
+        with pytest.raises(ValueError):
             self.device.set_brightness_and_color_temperature(-1, 10)
 
-        with pytest.raises(PhilipsBulbException):
+        with pytest.raises(ValueError):
             self.device.set_brightness_and_color_temperature(10, -1)
 
-        with pytest.raises(PhilipsBulbException):
+        with pytest.raises(ValueError):
             self.device.set_brightness_and_color_temperature(0, 10)
 
-        with pytest.raises(PhilipsBulbException):
+        with pytest.raises(ValueError):
             self.device.set_brightness_and_color_temperature(10, 0)
 
-        with pytest.raises(PhilipsBulbException):
+        with pytest.raises(ValueError):
             self.device.set_brightness_and_color_temperature(101, 10)
 
-        with pytest.raises(PhilipsBulbException):
+        with pytest.raises(ValueError):
             self.device.set_brightness_and_color_temperature(10, 101)
 
     def test_delay_off(self):
@@ -154,10 +153,10 @@ class TestPhilipsBulb(TestCase):
         self.device.delay_off(200)
         assert delay_off_countdown() == 200
 
-        with pytest.raises(PhilipsBulbException):
+        with pytest.raises(ValueError):
             self.device.delay_off(-1)
 
-        with pytest.raises(PhilipsBulbException):
+        with pytest.raises(ValueError):
             self.device.delay_off(0)
 
     def test_set_scene(self):
@@ -169,13 +168,13 @@ class TestPhilipsBulb(TestCase):
         self.device.set_scene(2)
         assert scene() == 2
 
-        with pytest.raises(PhilipsBulbException):
+        with pytest.raises(ValueError):
             self.device.set_scene(-1)
 
-        with pytest.raises(PhilipsBulbException):
+        with pytest.raises(ValueError):
             self.device.set_scene(0)
 
-        with pytest.raises(PhilipsBulbException):
+        with pytest.raises(ValueError):
             self.device.set_scene(5)
 
 
@@ -241,13 +240,13 @@ class TestPhilipsWhiteBulb(TestCase):
         assert brightness() == 50
         self.device.set_brightness(100)
 
-        with pytest.raises(PhilipsBulbException):
+        with pytest.raises(ValueError):
             self.device.set_brightness(-1)
 
-        with pytest.raises(PhilipsBulbException):
+        with pytest.raises(ValueError):
             self.device.set_brightness(0)
 
-        with pytest.raises(PhilipsBulbException):
+        with pytest.raises(ValueError):
             self.device.set_brightness(101)
 
     def test_delay_off(self):
@@ -259,8 +258,8 @@ class TestPhilipsWhiteBulb(TestCase):
         self.device.delay_off(200)
         assert delay_off_countdown() == 200
 
-        with pytest.raises(PhilipsBulbException):
+        with pytest.raises(ValueError):
             self.device.delay_off(-1)
 
-        with pytest.raises(PhilipsBulbException):
+        with pytest.raises(ValueError):
             self.device.delay_off(0)

--- a/miio/integrations/light/philips/tests/test_philips_eyecare.py
+++ b/miio/integrations/light/philips/tests/test_philips_eyecare.py
@@ -4,11 +4,7 @@ import pytest
 
 from miio.tests.dummies import DummyDevice
 
-from ..philips_eyecare import (
-    PhilipsEyecare,
-    PhilipsEyecareException,
-    PhilipsEyecareStatus,
-)
+from ..philips_eyecare import PhilipsEyecare, PhilipsEyecareStatus
 
 
 class DummyPhilipsEyecare(DummyDevice, PhilipsEyecare):
@@ -105,13 +101,13 @@ class TestPhilipsEyecare(TestCase):
         assert brightness() == 50
         self.device.set_brightness(100)
 
-        with pytest.raises(PhilipsEyecareException):
+        with pytest.raises(ValueError):
             self.device.set_brightness(-1)
 
-        with pytest.raises(PhilipsEyecareException):
+        with pytest.raises(ValueError):
             self.device.set_brightness(0)
 
-        with pytest.raises(PhilipsEyecareException):
+        with pytest.raises(ValueError):
             self.device.set_brightness(101)
 
     def test_set_scene(self):
@@ -123,13 +119,13 @@ class TestPhilipsEyecare(TestCase):
         self.device.set_scene(2)
         assert scene() == 2
 
-        with pytest.raises(PhilipsEyecareException):
+        with pytest.raises(ValueError):
             self.device.set_scene(-1)
 
-        with pytest.raises(PhilipsEyecareException):
+        with pytest.raises(ValueError):
             self.device.set_scene(0)
 
-        with pytest.raises(PhilipsEyecareException):
+        with pytest.raises(ValueError):
             self.device.set_scene(5)
 
     def test_delay_off(self):
@@ -143,7 +139,7 @@ class TestPhilipsEyecare(TestCase):
         self.device.delay_off(200)
         assert delay_off_countdown() == 200
 
-        with pytest.raises(PhilipsEyecareException):
+        with pytest.raises(ValueError):
             self.device.delay_off(-1)
 
     def test_smart_night_light(self):
@@ -183,11 +179,11 @@ class TestPhilipsEyecare(TestCase):
         assert ambient_brightness() == 50
         self.device.set_ambient_brightness(100)
 
-        with pytest.raises(PhilipsEyecareException):
+        with pytest.raises(ValueError):
             self.device.set_ambient_brightness(-1)
 
-        with pytest.raises(PhilipsEyecareException):
+        with pytest.raises(ValueError):
             self.device.set_ambient_brightness(0)
 
-        with pytest.raises(PhilipsEyecareException):
+        with pytest.raises(ValueError):
             self.device.set_ambient_brightness(101)

--- a/miio/integrations/light/philips/tests/test_philips_moonlight.py
+++ b/miio/integrations/light/philips/tests/test_philips_moonlight.py
@@ -5,11 +5,7 @@ import pytest
 from miio.tests.dummies import DummyDevice
 from miio.utils import int_to_rgb, rgb_to_int
 
-from ..philips_moonlight import (
-    PhilipsMoonlight,
-    PhilipsMoonlightException,
-    PhilipsMoonlightStatus,
-)
+from ..philips_moonlight import PhilipsMoonlight, PhilipsMoonlightStatus
 
 
 class DummyPhilipsMoonlight(DummyDevice, PhilipsMoonlight):
@@ -100,13 +96,13 @@ class TestPhilipsMoonlight(TestCase):
         assert brightness() == 50
         self.device.set_brightness(100)
 
-        with pytest.raises(PhilipsMoonlightException):
+        with pytest.raises(ValueError):
             self.device.set_brightness(-1)
 
-        with pytest.raises(PhilipsMoonlightException):
+        with pytest.raises(ValueError):
             self.device.set_brightness(0)
 
-        with pytest.raises(PhilipsMoonlightException):
+        with pytest.raises(ValueError):
             self.device.set_brightness(101)
 
     def test_set_rgb(self):
@@ -120,22 +116,22 @@ class TestPhilipsMoonlight(TestCase):
         self.device.set_rgb((255, 255, 255))
         assert rgb() == (255, 255, 255)
 
-        with pytest.raises(PhilipsMoonlightException):
+        with pytest.raises(ValueError):
             self.device.set_rgb((-1, 0, 0))
 
-        with pytest.raises(PhilipsMoonlightException):
+        with pytest.raises(ValueError):
             self.device.set_rgb((256, 0, 0))
 
-        with pytest.raises(PhilipsMoonlightException):
+        with pytest.raises(ValueError):
             self.device.set_rgb((0, -1, 0))
 
-        with pytest.raises(PhilipsMoonlightException):
+        with pytest.raises(ValueError):
             self.device.set_rgb((0, 256, 0))
 
-        with pytest.raises(PhilipsMoonlightException):
+        with pytest.raises(ValueError):
             self.device.set_rgb((0, 0, -1))
 
-        with pytest.raises(PhilipsMoonlightException):
+        with pytest.raises(ValueError):
             self.device.set_rgb((0, 0, 256))
 
     def test_set_color_temperature(self):
@@ -148,13 +144,13 @@ class TestPhilipsMoonlight(TestCase):
         assert color_temperature() == 30
         self.device.set_color_temperature(10)
 
-        with pytest.raises(PhilipsMoonlightException):
+        with pytest.raises(ValueError):
             self.device.set_color_temperature(-1)
 
-        with pytest.raises(PhilipsMoonlightException):
+        with pytest.raises(ValueError):
             self.device.set_color_temperature(0)
 
-        with pytest.raises(PhilipsMoonlightException):
+        with pytest.raises(ValueError):
             self.device.set_color_temperature(101)
 
     def test_set_brightness_and_color_temperature(self):
@@ -174,22 +170,22 @@ class TestPhilipsMoonlight(TestCase):
         assert brightness() == 10
         assert color_temperature() == 11
 
-        with pytest.raises(PhilipsMoonlightException):
+        with pytest.raises(ValueError):
             self.device.set_brightness_and_color_temperature(-1, 10)
 
-        with pytest.raises(PhilipsMoonlightException):
+        with pytest.raises(ValueError):
             self.device.set_brightness_and_color_temperature(10, -1)
 
-        with pytest.raises(PhilipsMoonlightException):
+        with pytest.raises(ValueError):
             self.device.set_brightness_and_color_temperature(0, 10)
 
-        with pytest.raises(PhilipsMoonlightException):
+        with pytest.raises(ValueError):
             self.device.set_brightness_and_color_temperature(10, 0)
 
-        with pytest.raises(PhilipsMoonlightException):
+        with pytest.raises(ValueError):
             self.device.set_brightness_and_color_temperature(101, 10)
 
-        with pytest.raises(PhilipsMoonlightException):
+        with pytest.raises(ValueError):
             self.device.set_brightness_and_color_temperature(10, 101)
 
     def test_set_brightness_and_rgb(self):
@@ -209,31 +205,31 @@ class TestPhilipsMoonlight(TestCase):
         assert brightness() == 100
         assert rgb() == (255, 255, 255)
 
-        with pytest.raises(PhilipsMoonlightException):
+        with pytest.raises(ValueError):
             self.device.set_brightness_and_rgb(-1, 10)
 
-        with pytest.raises(PhilipsMoonlightException):
+        with pytest.raises(ValueError):
             self.device.set_brightness_and_rgb(0, 10)
 
-        with pytest.raises(PhilipsMoonlightException):
+        with pytest.raises(ValueError):
             self.device.set_brightness_and_rgb(101, 10)
 
-        with pytest.raises(PhilipsMoonlightException):
+        with pytest.raises(ValueError):
             self.device.set_brightness_and_rgb(10, (-1, 0, 0))
 
-        with pytest.raises(PhilipsMoonlightException):
+        with pytest.raises(ValueError):
             self.device.set_brightness_and_rgb(10, (256, 0, 0))
 
-        with pytest.raises(PhilipsMoonlightException):
+        with pytest.raises(ValueError):
             self.device.set_brightness_and_rgb(10, (0, -1, 0))
 
-        with pytest.raises(PhilipsMoonlightException):
+        with pytest.raises(ValueError):
             self.device.set_brightness_and_rgb(10, (0, 256, 0))
 
-        with pytest.raises(PhilipsMoonlightException):
+        with pytest.raises(ValueError):
             self.device.set_brightness_and_rgb(10, (0, 0, -1))
 
-        with pytest.raises(PhilipsMoonlightException):
+        with pytest.raises(ValueError):
             self.device.set_brightness_and_rgb(10, (0, 0, 256))
 
     def test_set_scene(self):
@@ -245,11 +241,11 @@ class TestPhilipsMoonlight(TestCase):
         self.device.set_scene(6)
         assert scene() == 6
 
-        with pytest.raises(PhilipsMoonlightException):
+        with pytest.raises(ValueError):
             self.device.set_scene(-1)
 
-        with pytest.raises(PhilipsMoonlightException):
+        with pytest.raises(ValueError):
             self.device.set_scene(0)
 
-        with pytest.raises(PhilipsMoonlightException):
+        with pytest.raises(ValueError):
             self.device.set_scene(7)

--- a/miio/integrations/light/philips/tests/test_philips_rwread.py
+++ b/miio/integrations/light/philips/tests/test_philips_rwread.py
@@ -8,7 +8,6 @@ from ..philips_rwread import (
     MODEL_PHILIPS_LIGHT_RWREAD,
     MotionDetectionSensitivity,
     PhilipsRwread,
-    PhilipsRwreadException,
     PhilipsRwreadStatus,
 )
 
@@ -92,13 +91,13 @@ class TestPhilipsRwread(TestCase):
         assert brightness() == 50
         self.device.set_brightness(100)
 
-        with pytest.raises(PhilipsRwreadException):
+        with pytest.raises(ValueError):
             self.device.set_brightness(-1)
 
-        with pytest.raises(PhilipsRwreadException):
+        with pytest.raises(ValueError):
             self.device.set_brightness(0)
 
-        with pytest.raises(PhilipsRwreadException):
+        with pytest.raises(ValueError):
             self.device.set_brightness(101)
 
     def test_set_scene(self):
@@ -110,13 +109,13 @@ class TestPhilipsRwread(TestCase):
         self.device.set_scene(2)
         assert scene() == 2
 
-        with pytest.raises(PhilipsRwreadException):
+        with pytest.raises(ValueError):
             self.device.set_scene(-1)
 
-        with pytest.raises(PhilipsRwreadException):
+        with pytest.raises(ValueError):
             self.device.set_scene(0)
 
-        with pytest.raises(PhilipsRwreadException):
+        with pytest.raises(ValueError):
             self.device.set_scene(5)
 
     def test_delay_off(self):
@@ -130,7 +129,7 @@ class TestPhilipsRwread(TestCase):
         self.device.delay_off(200)
         assert delay_off_countdown() == 200
 
-        with pytest.raises(PhilipsRwreadException):
+        with pytest.raises(ValueError):
             self.device.delay_off(-1)
 
     def test_set_motion_detection(self):

--- a/miio/integrations/light/yeelight/__init__.py
+++ b/miio/integrations/light/yeelight/__init__.py
@@ -1,2 +1,2 @@
 # flake8: noqa
-from .yeelight import Yeelight, YeelightException, YeelightMode, YeelightStatus
+from .yeelight import Yeelight, YeelightMode, YeelightStatus

--- a/miio/integrations/light/yeelight/tests/test_yeelight.py
+++ b/miio/integrations/light/yeelight/tests/test_yeelight.py
@@ -4,7 +4,7 @@ import pytest
 
 from miio.tests.dummies import DummyDevice
 
-from .. import Yeelight, YeelightException, YeelightMode, YeelightStatus
+from .. import Yeelight, YeelightMode, YeelightStatus
 from ..spec_helper import YeelightSpecHelper, YeelightSubLightType
 
 
@@ -112,10 +112,10 @@ class TestYeelightCommon(TestCase):
         assert brightness() == 0
         self.device.set_brightness(100)
 
-        with pytest.raises(YeelightException):
+        with pytest.raises(ValueError):
             self.device.set_brightness(-100)
 
-        with pytest.raises(YeelightException):
+        with pytest.raises(ValueError):
             self.device.set_brightness(200)
 
     def test_set_color_temp(self):
@@ -127,10 +127,10 @@ class TestYeelightCommon(TestCase):
         self.device.set_color_temp(6500)
         assert color_temp() == 6500
 
-        with pytest.raises(YeelightException):
+        with pytest.raises(ValueError):
             self.device.set_color_temp(1000)
 
-        with pytest.raises(YeelightException):
+        with pytest.raises(ValueError):
             self.device.set_color_temp(7000)
 
     def test_set_developer_mode(self):
@@ -285,22 +285,22 @@ class TestYeelightLightColor(TestCase):
         self.device.set_rgb((255, 255, 255))
         assert rgb() == (255, 255, 255)
 
-        with pytest.raises(YeelightException):
+        with pytest.raises(ValueError):
             self.device.set_rgb((-1, 0, 0))
 
-        with pytest.raises(YeelightException):
+        with pytest.raises(ValueError):
             self.device.set_rgb((256, 0, 0))
 
-        with pytest.raises(YeelightException):
+        with pytest.raises(ValueError):
             self.device.set_rgb((0, -1, 0))
 
-        with pytest.raises(YeelightException):
+        with pytest.raises(ValueError):
             self.device.set_rgb((0, 256, 0))
 
-        with pytest.raises(YeelightException):
+        with pytest.raises(ValueError):
             self.device.set_rgb((0, 0, -1))
 
-        with pytest.raises(YeelightException):
+        with pytest.raises(ValueError):
             self.device.set_rgb((0, 0, 256))
 
     @pytest.mark.skip("hsv is not properly implemented")

--- a/miio/integrations/light/yeelight/yeelight.py
+++ b/miio/integrations/light/yeelight/yeelight.py
@@ -5,15 +5,9 @@ import click
 
 from miio.click_common import command, format_output
 from miio.device import Device, DeviceStatus
-from miio.exceptions import DeviceException
 from miio.utils import int_to_rgb, rgb_to_int
 
 from .spec_helper import ColorTempRange, YeelightSpecHelper, YeelightSubLightType
-
-
-class YeelightException(DeviceException):
-    pass
-
 
 SUBLIGHT_PROP_PREFIX = {
     YeelightSubLightType.Main: "",
@@ -355,7 +349,7 @@ class Yeelight(Device):
     def set_brightness(self, level, transition=0):
         """Set brightness."""
         if level < 0 or level > 100:
-            raise YeelightException("Invalid brightness: %s" % level)
+            raise ValueError("Invalid brightness: %s" % level)
         if transition > 0:
             return self.send("set_bright", [level, "smooth", transition])
         return self.send("set_bright", [level])
@@ -371,7 +365,7 @@ class Yeelight(Device):
             level > self.valid_temperature_range.max
             or level < self.valid_temperature_range.min
         ):
-            raise YeelightException("Invalid color temperature: %s" % level)
+            raise ValueError("Invalid color temperature: %s" % level)
         if transition > 0:
             return self.send("set_ct_abx", [level, "smooth", transition])
         else:
@@ -386,7 +380,7 @@ class Yeelight(Device):
         """Set color in RGB."""
         for color in rgb:
             if color < 0 or color > 255:
-                raise YeelightException("Invalid color: %s" % color)
+                raise ValueError("Invalid color: %s" % color)
 
         return self.send("set_rgb", [rgb_to_int(rgb)])
 

--- a/miio/integrations/vacuum/dreame/dreamevacuum_miot.py
+++ b/miio/integrations/vacuum/dreame/dreamevacuum_miot.py
@@ -8,7 +8,6 @@ from typing import Dict, Optional
 import click
 
 from miio.click_common import command, format_output
-from miio.exceptions import DeviceException
 from miio.interfaces import FanspeedPresets, VacuumInterface
 from miio.miot_device import DeviceStatus as DeviceStatusContainer
 from miio.miot_device import MiotDevice, MiotMapping
@@ -638,7 +637,7 @@ class DreameVacuum(MiotDevice, VacuumInterface):
     def forward(self, distance: int) -> None:
         """Move forward."""
         if distance < self.MANUAL_DISTANCE_MIN or distance > self.MANUAL_DISTANCE_MAX:
-            raise DeviceException(
+            raise ValueError(
                 "Given distance is invalid, should be [%s, %s], was: %s"
                 % (self.MANUAL_DISTANCE_MIN, self.MANUAL_DISTANCE_MAX, distance)
             )
@@ -665,7 +664,7 @@ class DreameVacuum(MiotDevice, VacuumInterface):
             rotatation < self.MANUAL_ROTATION_MIN
             or rotatation > self.MANUAL_ROTATION_MAX
         ):
-            raise DeviceException(
+            raise ValueError(
                 "Given rotation is invalid, should be [%s, %s], was %s"
                 % (self.MANUAL_ROTATION_MIN, self.MANUAL_ROTATION_MAX, rotatation)
             )

--- a/miio/integrations/vacuum/roborock/__init__.py
+++ b/miio/integrations/vacuum/roborock/__init__.py
@@ -1,2 +1,2 @@
 # flake8: noqa
-from .vacuum import RoborockVacuum, VacuumException, VacuumStatus
+from .vacuum import RoborockVacuum, VacuumStatus

--- a/miio/integrations/vacuum/roborock/tests/test_vacuum.py
+++ b/miio/integrations/vacuum/roborock/tests/test_vacuum.py
@@ -4,16 +4,10 @@ from unittest.mock import patch
 
 import pytest
 
-from miio import RoborockVacuum, VacuumStatus
+from miio import RoborockVacuum, UnsupportedFeatureException, VacuumStatus
 from miio.tests.dummies import DummyDevice
 
-from ..vacuum import (
-    ROCKROBO_S7,
-    CarpetCleaningMode,
-    MopIntensity,
-    MopMode,
-    VacuumException,
-)
+from ..vacuum import ROCKROBO_S7, CarpetCleaningMode, MopIntensity, MopMode
 
 
 class DummyVacuum(DummyDevice, RoborockVacuum):
@@ -343,12 +337,12 @@ class TestVacuum(TestCase):
 
     def test_mop_intensity_model_check(self):
         """Test Roborock S7 check when getting mop intensity."""
-        with pytest.raises(VacuumException):
+        with pytest.raises(UnsupportedFeatureException):
             self.device.mop_intensity()
 
     def test_set_mop_intensity_model_check(self):
         """Test Roborock S7 check when setting mop intensity."""
-        with pytest.raises(VacuumException):
+        with pytest.raises(UnsupportedFeatureException):
             self.device.set_mop_intensity(MopIntensity.Intense)
 
 

--- a/miio/integrations/vacuum/viomi/viomivacuum.py
+++ b/miio/integrations/vacuum/viomi/viomivacuum.py
@@ -100,10 +100,6 @@ ERROR_CODES = {
 }
 
 
-class ViomiVacuumException(DeviceException):
-    """Exception raised by Viomi Vacuum."""
-
-
 class ViomiPositionPoint:
     """Vacuum position coordinate."""
 
@@ -829,7 +825,7 @@ class ViomiVacuum(Device, VacuumInterface):
         """Change current map."""
         maps = self.get_maps()
         if map_id not in [m["id"] for m in maps]:
-            raise ViomiVacuumException(f"Map id {map_id} doesn't exists")
+            raise ValueError(f"Map id {map_id} doesn't exists")
         return self.send("set_map", [map_id])
 
     @command(click.argument("map_id", type=int))
@@ -837,7 +833,7 @@ class ViomiVacuum(Device, VacuumInterface):
         """Delete map."""
         maps = self.get_maps()
         if map_id not in [m["id"] for m in maps]:
-            raise ViomiVacuumException(f"Map id {map_id} doesn't exists")
+            raise ValueError(f"Map id {map_id} doesn't exists")
         return self.send("del_map", [map_id])
 
     @command(
@@ -848,7 +844,7 @@ class ViomiVacuum(Device, VacuumInterface):
         """Rename map."""
         maps = self.get_maps()
         if map_id not in [m["id"] for m in maps]:
-            raise ViomiVacuumException(f"Map id {map_id} doesn't exists")
+            raise ValueError(f"Map id {map_id} doesn't exists")
         return self.send("rename_map", {"mapID": map_id, "name": map_name})
 
     @command(
@@ -869,16 +865,12 @@ class ViomiVacuum(Device, VacuumInterface):
             map_ids = [map_["id"] for map_ in maps if map_["name"] == map_name]
             if not map_ids:
                 map_names = ", ".join([m["name"] for m in maps])
-                raise ViomiVacuumException(
-                    f"Error: Bad map name, should be in {map_names}"
-                )
+                raise ValueError(f"Error: Bad map name, should be in {map_names}")
         elif map_id:
             maps = self.get_maps()
             if map_id not in [m["id"] for m in maps]:
                 map_ids_str = ", ".join([str(m["id"]) for m in maps])
-                raise ViomiVacuumException(
-                    f"Error: Bad map id, should be in {map_ids_str}"
-                )
+                raise ValueError(f"Error: Bad map id, should be in {map_ids_str}")
         # Get scheduled cleanup
         schedules = self.send("get_ordertime", [])
         scheduled_found, rooms = _get_rooms_from_schedules(schedules)
@@ -898,7 +890,7 @@ class ViomiVacuum(Device, VacuumInterface):
                 "* Select only the missed room\n"
                 "* Set as inactive scheduled cleanup\n"
             )
-            raise ViomiVacuumException(msg)
+            raise DeviceException(msg)
 
         self._cache["rooms"] = rooms
         return rooms

--- a/miio/integrations/viomidishwasher/test_viomidishwasher.py
+++ b/miio/integrations/viomidishwasher/test_viomidishwasher.py
@@ -4,7 +4,6 @@ from unittest import TestCase
 import pytest
 
 from miio import ViomiDishwasher
-from miio.exceptions import DeviceException
 from miio.tests.dummies import DummyDevice
 
 from .viomidishwasher import (
@@ -151,9 +150,7 @@ class TestViomiDishwasher(TestCase):
         assert self.is_on() is True
 
         too_short_time = datetime.now() + timedelta(hours=1)
-        self.assertRaises(
-            DeviceException, self.device.schedule, too_short_time, Program.Eco
-        )
+        self.assertRaises(ValueError, self.device.schedule, too_short_time, Program.Eco)
 
         self.device.stop()
         self.device.state["wash_process"] = 0

--- a/miio/integrations/viomidishwasher/viomidishwasher.py
+++ b/miio/integrations/viomidishwasher/viomidishwasher.py
@@ -323,7 +323,7 @@ class ViomiDishwasher(Device):
         """
 
         if program == Program.Unknown:
-            DeviceException(f"Program {program.name} is not valid for this function.")
+            ValueError(f"Program {program.name} is not valid for this function.")
 
         scheduled_finish_date = datetime.now().replace(
             hour=time.hour, minute=time.minute, second=0, microsecond=0
@@ -332,7 +332,7 @@ class ViomiDishwasher(Device):
             seconds=program.run_time
         )
         if scheduled_start_date < datetime.now():
-            raise DeviceException(
+            raise ValueError(
                 "Proposed time is in the past (the proposed time is the finishing time, not the start time)."
             )
 

--- a/miio/powerstrip.py
+++ b/miio/powerstrip.py
@@ -8,7 +8,6 @@ import click
 from .click_common import EnumType, command, format_output
 from .device import Device
 from .devicestatus import DeviceStatus, sensor, switch
-from .exceptions import DeviceException
 from .utils import deprecated
 
 _LOGGER = logging.getLogger(__name__)
@@ -37,10 +36,6 @@ AVAILABLE_PROPERTIES = {
         "power_price",
     ],
 }
-
-
-class PowerStripException(DeviceException):
-    pass
 
 
 class PowerMode(enum.Enum):
@@ -238,7 +233,7 @@ class PowerStrip(Device):
     def set_power_price(self, price: int):
         """Set the power price."""
         if price < 0 or price > 999:
-            raise PowerStripException("Invalid power price: %s" % price)
+            raise ValueError("Invalid power price: %s" % price)
 
         return self.send("set_power_price", [price])
 

--- a/miio/tests/test_airconditioner_miot.py
+++ b/miio/tests/test_airconditioner_miot.py
@@ -4,7 +4,6 @@ import pytest
 
 from miio import AirConditionerMiot
 from miio.airconditioner_miot import (
-    AirConditionerMiotException,
     CleaningStatus,
     FanSpeed,
     OperationMode,
@@ -125,13 +124,13 @@ class TestAirConditioner(TestCase):
         self.device.set_target_temperature(31.0)
         assert target_temperature() == 31.0
 
-        with pytest.raises(AirConditionerMiotException):
+        with pytest.raises(ValueError):
             self.device.set_target_temperature(15.5)
 
-        with pytest.raises(AirConditionerMiotException):
+        with pytest.raises(ValueError):
             self.device.set_target_temperature(24.6)
 
-        with pytest.raises(AirConditionerMiotException):
+        with pytest.raises(ValueError):
             self.device.set_target_temperature(31.5)
 
     def test_set_eco(self):
@@ -241,10 +240,10 @@ class TestAirConditioner(TestCase):
         self.device.set_fan_speed_percent(101)
         assert fan_speed_percent() == 101
 
-        with pytest.raises(AirConditionerMiotException):
+        with pytest.raises(ValueError):
             self.device.set_fan_speed_percent(102)
 
-        with pytest.raises(AirConditionerMiotException):
+        with pytest.raises(ValueError):
             self.device.set_fan_speed_percent(0)
 
     def test_set_timer(self):

--- a/miio/tests/test_airconditioningcompanion.py
+++ b/miio/tests/test_airconditioningcompanion.py
@@ -13,7 +13,6 @@ from miio import (
 from miio.airconditioningcompanion import (
     MODEL_ACPARTNER_V3,
     STORAGE_SLOT_ID,
-    AirConditioningCompanionException,
     AirConditioningCompanionStatus,
     FanSpeed,
     Led,
@@ -204,7 +203,7 @@ class TestAirConditioningCompanion(TestCase):
                 self.assertSequenceEqual(self.device.get_last_ir_played(), args["out"])
 
         for args in test_data["test_send_ir_code_exception"]:
-            with pytest.raises(AirConditioningCompanionException):
+            with pytest.raises(ValueError):
                 self.device.send_ir_code(*args["in"])
 
     def test_send_command(self):

--- a/miio/tests/test_airdehumidifier.py
+++ b/miio/tests/test_airdehumidifier.py
@@ -5,7 +5,6 @@ import pytest
 from miio import AirDehumidifier
 from miio.airdehumidifier import (
     MODEL_DEHUMIDIFIER_V1,
-    AirDehumidifierException,
     AirDehumidifierStatus,
     FanSpeed,
     OperationMode,
@@ -182,16 +181,16 @@ class TestAirDehumidifierV1(TestCase):
         self.device.set_target_humidity(60)
         assert target_humidity() == 60
 
-        with pytest.raises(AirDehumidifierException):
+        with pytest.raises(ValueError):
             self.device.set_target_humidity(-1)
 
-        with pytest.raises(AirDehumidifierException):
+        with pytest.raises(ValueError):
             self.device.set_target_humidity(30)
 
-        with pytest.raises(AirDehumidifierException):
+        with pytest.raises(ValueError):
             self.device.set_target_humidity(70)
 
-        with pytest.raises(AirDehumidifierException):
+        with pytest.raises(ValueError):
             self.device.set_target_humidity(110)
 
     def test_set_child_lock(self):

--- a/miio/tests/test_airqualitymonitor_miot.py
+++ b/miio/tests/test_airqualitymonitor_miot.py
@@ -3,11 +3,7 @@ from unittest import TestCase
 import pytest
 
 from miio import AirQualityMonitorCGDN1
-from miio.airqualitymonitor_miot import (
-    AirQualityMonitorMiotException,
-    ChargingState,
-    DisplayTemperatureUnitCGDN1,
-)
+from miio.airqualitymonitor_miot import ChargingState, DisplayTemperatureUnitCGDN1
 
 from .dummies import DummyMiotDevice
 
@@ -82,10 +78,10 @@ class TestAirQualityMonitor(TestCase):
         self.device.set_monitoring_frequency_duration(600)
         assert monitoring_frequency() == 600
 
-        with pytest.raises(AirQualityMonitorMiotException):
+        with pytest.raises(ValueError):
             self.device.set_monitoring_frequency_duration(-1)
 
-        with pytest.raises(AirQualityMonitorMiotException):
+        with pytest.raises(ValueError):
             self.device.set_monitoring_frequency_duration(601)
 
     def test_set_device_off_duration(self):
@@ -101,10 +97,10 @@ class TestAirQualityMonitor(TestCase):
         self.device.set_device_off_duration(60)
         assert device_off_duration() == 60
 
-        with pytest.raises(AirQualityMonitorMiotException):
+        with pytest.raises(ValueError):
             self.device.set_device_off_duration(-1)
 
-        with pytest.raises(AirQualityMonitorMiotException):
+        with pytest.raises(ValueError):
             self.device.set_device_off_duration(61)
 
     def test_set_screen_off_duration(self):
@@ -120,10 +116,10 @@ class TestAirQualityMonitor(TestCase):
         self.device.set_screen_off_duration(300)
         assert screen_off_duration() == 300
 
-        with pytest.raises(AirQualityMonitorMiotException):
+        with pytest.raises(ValueError):
             self.device.set_screen_off_duration(-1)
 
-        with pytest.raises(AirQualityMonitorMiotException):
+        with pytest.raises(ValueError):
             self.device.set_screen_off_duration(301)
 
     def test_set_display_temperature_unit(self):

--- a/miio/tests/test_chuangmi_ir.py
+++ b/miio/tests/test_chuangmi_ir.py
@@ -6,7 +6,6 @@ from unittest import TestCase
 import pytest
 
 from miio import ChuangmiIr
-from miio.chuangmi_ir import ChuangmiIrException
 
 from .dummies import DummyDevice
 
@@ -45,20 +44,20 @@ class TestChuangmiIr(TestCase):
         assert self.device.learn() is True
         assert self.device.learn(30) is True
 
-        with pytest.raises(ChuangmiIrException):
+        with pytest.raises(ValueError):
             self.device.learn(-1)
 
-        with pytest.raises(ChuangmiIrException):
+        with pytest.raises(ValueError):
             self.device.learn(1000001)
 
     def test_read(self):
         assert self.device.read() is True
         assert self.device.read(30) is True
 
-        with pytest.raises(ChuangmiIrException):
+        with pytest.raises(ValueError):
             self.device.read(-1)
 
-        with pytest.raises(ChuangmiIrException):
+        with pytest.raises(ValueError):
             self.device.read(1000001)
 
     def test_play_raw(self):
@@ -78,7 +77,7 @@ class TestChuangmiIr(TestCase):
                 )
 
         for args in test_data["test_pronto_exception"]:
-            with self.subTest(), pytest.raises(ChuangmiIrException):
+            with self.subTest(), pytest.raises(ValueError):
                 ChuangmiIr.pronto_to_raw(*args["in"])
 
     def test_play_pronto(self):
@@ -91,7 +90,7 @@ class TestChuangmiIr(TestCase):
                 )
 
         for args in test_data["test_pronto_exception"]:
-            with pytest.raises(ChuangmiIrException):
+            with pytest.raises(ValueError):
                 self.device.play_pronto(*args["in"])
 
     def test_play_auto(self):
@@ -117,11 +116,11 @@ class TestChuangmiIr(TestCase):
                     self.assertSequenceEqual(
                         self.device.state["last_ir_played"], args["out"]
                     )
-        with pytest.raises(ChuangmiIrException):
+        with pytest.raises(ValueError):
             self.device.play("invalid:command")
 
-        with pytest.raises(ChuangmiIrException):
+        with pytest.raises(ValueError):
             self.device.play("pronto:command:invalid:argument:count")
 
-        with pytest.raises(ChuangmiIrException):
+        with pytest.raises(ValueError):
             self.device.play("pronto:command:invalidargument")

--- a/miio/tests/test_heater.py
+++ b/miio/tests/test_heater.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 import pytest
 
 from miio import Heater
-from miio.heater import MODEL_HEATER_ZA1, Brightness, HeaterException, HeaterStatus
+from miio.heater import MODEL_HEATER_ZA1, Brightness, HeaterStatus
 
 from .dummies import DummyDevice
 
@@ -100,10 +100,10 @@ class TestHeater(TestCase):
         self.device.set_target_temperature(32)
         assert target_temperature() == 32
 
-        with pytest.raises(HeaterException):
+        with pytest.raises(ValueError):
             self.device.set_target_temperature(15)
 
-        with pytest.raises(HeaterException):
+        with pytest.raises(ValueError):
             self.device.set_target_temperature(33)
 
     def test_set_brightness(self):
@@ -148,8 +148,8 @@ class TestHeater(TestCase):
         self.device.delay_off(9)
         assert delay_off_countdown() == 9
 
-        with pytest.raises(HeaterException):
+        with pytest.raises(ValueError):
             self.device.delay_off(-1)
 
-        with pytest.raises(HeaterException):
+        with pytest.raises(ValueError):
             self.device.delay_off(9 * 3600 + 1)

--- a/miio/tests/test_heater_miot.py
+++ b/miio/tests/test_heater_miot.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 import pytest
 
 from miio import HeaterMiot
-from miio.heater_miot import HeaterMiotException, LedBrightness
+from miio.heater_miot import LedBrightness
 
 from .dummies import DummyMiotDevice
 
@@ -102,10 +102,10 @@ class TestHeater(TestCase):
         self.device.set_delay_off(9 * 3600 + 1)
         assert delay_off_countdown() == 9
 
-        with pytest.raises(HeaterMiotException):
+        with pytest.raises(ValueError):
             self.device.set_delay_off(-1)
 
-        with pytest.raises(HeaterMiotException):
+        with pytest.raises(ValueError):
             self.device.set_delay_off(13 * 3600)
 
     def test_set_target_temperature(self):
@@ -121,8 +121,8 @@ class TestHeater(TestCase):
         self.device.set_target_temperature(28)
         assert target_temperature() == 28
 
-        with pytest.raises(HeaterMiotException):
+        with pytest.raises(ValueError):
             self.device.set_target_temperature(17)
 
-        with pytest.raises(HeaterMiotException):
+        with pytest.raises(ValueError):
             self.device.set_target_temperature(29)

--- a/miio/tests/test_huizuo.py
+++ b/miio/tests/test_huizuo.py
@@ -2,12 +2,11 @@ from unittest import TestCase
 
 import pytest
 
-from miio import Huizuo, HuizuoLampFan, HuizuoLampHeater
+from miio import Huizuo, HuizuoLampFan, HuizuoLampHeater, UnsupportedFeatureException
 from miio.huizuo import MODEL_HUIZUO_FANWY  # Fan model extended
 from miio.huizuo import MODEL_HUIZUO_FANWY2  # Fan model basic
 from miio.huizuo import MODEL_HUIZUO_PIS123  # Basic model
 from miio.huizuo import MODEL_HUIZUO_WYHEAT  # Heater model
-from miio.huizuo import HuizuoException
 
 from .dummies import DummyMiotDevice
 
@@ -117,10 +116,10 @@ class TestHuizuo(TestCase):
         self.device.set_brightness(100)
         assert lamp_brightness() == 100
 
-        with pytest.raises(HuizuoException):
+        with pytest.raises(ValueError):
             self.device.set_brightness(-1)
 
-        with pytest.raises(HuizuoException):
+        with pytest.raises(ValueError):
             self.device.set_brightness(101)
 
     def test_color_temp(self):
@@ -134,10 +133,10 @@ class TestHuizuo(TestCase):
         self.device.set_color_temp(6400)
         assert lamp_color_temp() == 6400
 
-        with pytest.raises(HuizuoException):
+        with pytest.raises(ValueError):
             self.device.set_color_temp(2999)
 
-        with pytest.raises(HuizuoException):
+        with pytest.raises(ValueError):
             self.device.set_color_temp(6401)
 
 
@@ -173,10 +172,10 @@ class TestHuizuoFan(TestCase):
         self.device.set_fan_level(100)
         assert fan_level() == 100
 
-        with pytest.raises(HuizuoException):
+        with pytest.raises(ValueError):
             self.device.set_fan_level(-1)
 
-        with pytest.raises(HuizuoException):
+        with pytest.raises(ValueError):
             self.device.set_fan_level(101)
 
     def test_fan_motor_reverse(self):
@@ -202,10 +201,10 @@ class TestHuizuoFan(TestCase):
 class TestHuizuoFan2(TestCase):
     # This device has no 'reverse' mode, so let's check this
     def test_fan_motor_reverse(self):
-        with pytest.raises(HuizuoException):
+        with pytest.raises(UnsupportedFeatureException):
             self.device.fan_reverse_on()
 
-        with pytest.raises(HuizuoException):
+        with pytest.raises(UnsupportedFeatureException):
             self.device.fan_reverse_off()
 
 
@@ -234,7 +233,7 @@ class TestHuizuoHeater(TestCase):
         self.device.set_heat_level(3)
         assert heat_level() == 3
 
-        with pytest.raises(HuizuoException):
+        with pytest.raises(ValueError):
             self.device.set_heat_level(0)
-        with pytest.raises(HuizuoException):
+        with pytest.raises(ValueError):
             self.device.set_heat_level(4)

--- a/miio/tests/test_powerstrip.py
+++ b/miio/tests/test_powerstrip.py
@@ -7,7 +7,6 @@ from miio.powerstrip import (
     MODEL_POWER_STRIP_V1,
     MODEL_POWER_STRIP_V2,
     PowerMode,
-    PowerStripException,
     PowerStripStatus,
 )
 
@@ -227,10 +226,10 @@ class TestPowerStripV2(TestCase):
         self.device.set_power_price(2)
         assert power_price() == 2
 
-        with pytest.raises(PowerStripException):
+        with pytest.raises(ValueError):
             self.device.set_power_price(-1)
 
-        with pytest.raises(PowerStripException):
+        with pytest.raises(ValueError):
             self.device.set_power_price(1000)
 
     def test_status_without_power_price(self):

--- a/miio/tests/test_walkingpad.py
+++ b/miio/tests/test_walkingpad.py
@@ -3,13 +3,8 @@ from unittest import TestCase
 
 import pytest
 
-from miio import Walkingpad
-from miio.walkingpad import (
-    OperationMode,
-    OperationSensitivity,
-    WalkingpadException,
-    WalkingpadStatus,
-)
+from miio import DeviceException, Walkingpad
+from miio.walkingpad import OperationMode, OperationSensitivity, WalkingpadStatus
 
 from .dummies import DummyDevice
 
@@ -135,13 +130,13 @@ class TestWalkingpad(TestCase):
         self.device.set_mode(OperationMode.Manual)
         assert mode() == OperationMode.Manual
 
-        with pytest.raises(WalkingpadException):
+        with pytest.raises(ValueError):
             self.device.set_mode(-1)
 
-        with pytest.raises(WalkingpadException):
+        with pytest.raises(ValueError):
             self.device.set_mode(3)
 
-        with pytest.raises(WalkingpadException):
+        with pytest.raises(ValueError):
             self.device.set_mode("blah")
 
     def test_set_speed(self):
@@ -152,16 +147,16 @@ class TestWalkingpad(TestCase):
         self.device.set_speed(3.055)
         assert speed() == 3.055
 
-        with pytest.raises(WalkingpadException):
+        with pytest.raises(ValueError):
             self.device.set_speed(7.6)
 
-        with pytest.raises(WalkingpadException):
+        with pytest.raises(TypeError):
             self.device.set_speed(-1)
 
-        with pytest.raises(WalkingpadException):
+        with pytest.raises(TypeError):
             self.device.set_speed("blah")
 
-        with pytest.raises(WalkingpadException):
+        with pytest.raises(DeviceException):
             self.device.off()
             self.device.set_speed(3.4)
 
@@ -174,16 +169,16 @@ class TestWalkingpad(TestCase):
         self.device.set_start_speed(3.055)
         assert speed() == 3.055
 
-        with pytest.raises(WalkingpadException):
+        with pytest.raises(ValueError):
             self.device.set_start_speed(7.6)
 
-        with pytest.raises(WalkingpadException):
+        with pytest.raises(TypeError):
             self.device.set_start_speed(-1)
 
-        with pytest.raises(WalkingpadException):
+        with pytest.raises(TypeError):
             self.device.set_start_speed("blah")
 
-        with pytest.raises(WalkingpadException):
+        with pytest.raises(DeviceException):
             self.device.off()
             self.device.set_start_speed(3.4)
 
@@ -197,11 +192,11 @@ class TestWalkingpad(TestCase):
         self.device.set_sensitivity(OperationSensitivity.Medium)
         assert sensitivity() == OperationSensitivity.Medium
 
-        with pytest.raises(WalkingpadException):
+        with pytest.raises(TypeError):
             self.device.set_sensitivity(-1)
 
-        with pytest.raises(WalkingpadException):
+        with pytest.raises(TypeError):
             self.device.set_sensitivity(99)
 
-        with pytest.raises(WalkingpadException):
+        with pytest.raises(TypeError):
             self.device.set_sensitivity("blah")

--- a/miio/tests/test_yeelight_dual_switch.py
+++ b/miio/tests/test_yeelight_dual_switch.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 import pytest
 
 from miio import YeelightDualControlModule
-from miio.yeelight_dual_switch import Switch, YeelightDualControlModuleException
+from miio.yeelight_dual_switch import Switch
 
 from .dummies import DummyMiotDevice
 
@@ -83,8 +83,8 @@ class TestYeelightDualControlModule(TestCase):
         self.device.set_switch_off_delay(200, Switch.Second)
         assert self.device.status().switch_2_off_delay == 200
 
-        with pytest.raises(YeelightDualControlModuleException):
+        with pytest.raises(ValueError):
             self.device.set_switch_off_delay(-2, Switch.First)
 
-        with pytest.raises(YeelightDualControlModuleException):
+        with pytest.raises(ValueError):
             self.device.set_switch_off_delay(43300, Switch.Second)

--- a/miio/walkingpad.py
+++ b/miio/walkingpad.py
@@ -12,10 +12,6 @@ from .exceptions import DeviceException
 _LOGGER = logging.getLogger(__name__)
 
 
-class WalkingpadException(DeviceException):
-    pass
-
-
 class OperationMode(enum.Enum):
     Auto = 0
     Manual = 1
@@ -199,7 +195,7 @@ class Walkingpad(Device):
         """Set mode (auto/manual)."""
 
         if not isinstance(mode, OperationMode):
-            raise WalkingpadException("Invalid mode: %s" % mode)
+            raise ValueError("Invalid mode: %s" % mode)
 
         return self.send("set_mode", [mode.value])
 
@@ -212,13 +208,13 @@ class Walkingpad(Device):
 
         # In case the treadmill is not already turned on, throw an exception.
         if not self.status().is_on:
-            raise WalkingpadException("Cannot set the speed, device is turned off")
+            raise DeviceException("Cannot set the speed, device is turned off")
 
         if not isinstance(speed, float):
-            raise WalkingpadException("Invalid speed: %s" % speed)
+            raise TypeError("Invalid speed: %s" % speed)
 
         if speed < 0 or speed > 6:
-            raise WalkingpadException("Invalid speed: %s" % speed)
+            raise ValueError("Invalid speed: %s" % speed)
 
         return self.send("set_speed", [speed])
 
@@ -231,15 +227,13 @@ class Walkingpad(Device):
 
         # In case the treadmill is not already turned on, throw an exception.
         if not self.status().is_on:
-            raise WalkingpadException(
-                "Cannot set the start speed, device is turned off"
-            )
+            raise DeviceException("Cannot set the start speed, device is turned off")
 
         if not isinstance(speed, float):
-            raise WalkingpadException("Invalid start speed: %s" % speed)
+            raise TypeError("Invalid start speed: %s" % speed)
 
         if speed < 0 or speed > 6:
-            raise WalkingpadException("Invalid start speed: %s" % speed)
+            raise ValueError("Invalid start speed: %s" % speed)
 
         return self.send("set_start_speed", [speed])
 
@@ -251,7 +245,7 @@ class Walkingpad(Device):
         """Set sensitivity."""
 
         if not isinstance(sensitivity, OperationSensitivity):
-            raise WalkingpadException("Invalid mode: %s" % sensitivity)
+            raise TypeError("Invalid mode: %s" % sensitivity)
 
         return self.send("set_sensitivity", [sensitivity.value])
 

--- a/miio/wifirepeater.py
+++ b/miio/wifirepeater.py
@@ -4,13 +4,8 @@ import click
 
 from .click_common import command, format_output
 from .device import Device, DeviceStatus
-from .exceptions import DeviceException
 
 _LOGGER = logging.getLogger(__name__)
-
-
-class WifiRepeaterException(DeviceException):
-    pass
 
 
 class WifiRepeaterStatus(DeviceStatus):

--- a/miio/yeelight_dual_switch.py
+++ b/miio/yeelight_dual_switch.py
@@ -4,12 +4,7 @@ from typing import Any, Dict
 import click
 
 from .click_common import EnumType, command, format_output
-from .exceptions import DeviceException
 from .miot_device import DeviceStatus, MiotDevice, MiotMapping
-
-
-class YeelightDualControlModuleException(DeviceException):
-    pass
 
 
 class Switch(enum.Enum):
@@ -204,7 +199,7 @@ class YeelightDualControlModule(MiotDevice):
     def set_switch_off_delay(self, delay: int, switch: Switch):
         """Set switch off delay, should be between -1 to 43200 (in seconds)"""
         if delay < -1 or delay > 43200:
-            raise YeelightDualControlModuleException(
+            raise ValueError(
                 "Invalid switch delay: %s (should be between -1 to 43200)" % delay
             )
 


### PR DESCRIPTION
**Breaking change: all custom `DeviceException` derived classes are removed in favor of standard python exceptions and pure DeviceException instances.**

This commit removes all unnecessary custom classes in favor of using standard python exceptions or DeviceExceptions:
* Invalid input values are now reported using TypeErrors and ValueErrors
* New `UnsupportedFeatureException` gets now raised if the device does not support the wanted feature

Most downstream users are hopefully catching DeviceExceptions for error handling so this change requires no further action.

The full list of removed exception classes:
* AirConditionerMiotException
* AirConditioningCompanionException
* AirConditioningCompanionException
* AirDehumidifierException
* AirQualityMonitorException
* AirQualityMonitorMiotException
* CameraException
* ChuangmiIrException
* CookerException
* FanException
* HeaterException
* HeaterMiotException
* HuizuoException
* AirDogException
* AirFreshException
* AirFreshException
* AirPurifierException
* FanLeshowException
* AirHumidifierJsqsException
* AirHumidifierException
* AirHumidifierException
* AirHumidifierException
* AirHumidifierMiotException
* AirPurifierMiotException
* CeilException
* PhilipsBulbException
* PhilipsEyecareException
* PhilipsMoonlightException
* PhilipsRwreadException
* YeelightException
* VacuumException
* ViomiVacuumException
* PowerStripException
* WalkingpadException
* WifiRepeaterException
* YeelightDualControlModuleException