### PR TITLE
Improve viomi.vacuum.v8 (styj02ym) support

### DIFF
--- a/miio/integrations/vacuum/viomi/viomivacuum.py
+++ b/miio/integrations/vacuum/viomi/viomivacuum.py
@@ -505,9 +505,9 @@ class ViomiVacuumStatus(VacuumDeviceStatus):
         return self.data["start_time"]
 
     @property
-    @setting("Sound volume", unit="%", setter_name="set_sound_volume", max_value=100)
+    @setting("Sound volume", setter_name="set_sound_volume", max_value=10)
     def sound_volume(self) -> int:
-        """Voice volume level (from 0 to 100%, 0 means Off)."""
+        """Voice volume level (from 0 to 10, 0 means Off)."""
         return self.data["v_state"]
 
     @property
@@ -924,9 +924,10 @@ class ViomiVacuum(Device, VacuumInterface):
     @command(click.argument("volume", type=click.IntRange(0, 10)))
     def set_sound_volume(self, volume: int):
         """Switch the voice on or off."""
-        enabled = 1
-        if volume == 0:
-            enabled = 0
+        if volume < 0 or volume > 10:
+            raise ValueError("Invalid sound volume, should be [0, 10]")
+
+        enabled = int(volume != 0)
         return self.send("set_voice", [enabled, volume])
 
     @command(click.argument("state", type=bool))

--- a/miio/integrations/vacuum/viomi/viomivacuum.py
+++ b/miio/integrations/vacuum/viomi/viomivacuum.py
@@ -96,8 +96,13 @@ ERROR_CODES = {
     530: "Mop and water tank missing",
     531: "Water tank is not installed",
     2101: "Unsufficient battery, continuing cleaning after recharge",
+    2102: "Returning to base",
     2103: "Charging",
+    2104: "Returning to base",
     2105: "Fully charged",
+    2108: "Returning to previous location?",
+    2109: "Cleaning up again (repeat cleaning?)",
+    2110: "Self-inspecting",
 }
 
 

--- a/miio/integrations/vacuum/viomi/viomivacuum.py
+++ b/miio/integrations/vacuum/viomi/viomivacuum.py
@@ -1078,3 +1078,8 @@ class ViomiVacuum(Device, VacuumInterface):
         This seems doing nothing on STYJ02YM
         """
         return self.send("set_carpetturbo", [mode.value])
+
+    @command()
+    def find(self):
+        """Find the robot."""
+        return self.send("set_resetpos", [1])

--- a/miio/integrations/vacuum/viomi/viomivacuum.py
+++ b/miio/integrations/vacuum/viomi/viomivacuum.py
@@ -225,11 +225,6 @@ class ViomiLanguage(Enum):
     EN = 2  # English
 
 
-class ViomiLedState(Enum):
-    Off = 0
-    On = 1
-
-
 class ViomiCarpetTurbo(Enum):
     Off = 0
     Medium = 1
@@ -449,6 +444,7 @@ class ViomiVacuumStatus(VacuumDeviceStatus):
         return self.data["hw_info"]
 
     @property
+    @sensor("Is charging")
     def charging(self) -> bool:
         """True if battery is charging.
 
@@ -487,12 +483,14 @@ class ViomiVacuumStatus(VacuumDeviceStatus):
 
         return ViomiRoutePattern(route)
 
-    # @property
-    # def order_time(self) -> int:
-    #    """FIXME: ??? int or bool."""
-    #    return self.data["order_time"]
+    @property
+    @sensor("Order time?")
+    def order_time(self) -> int:
+        """FIXME: ??? int or bool."""
+        return self.data["order_time"]
 
     @property
+    @sensor("Repeat cleaning active")
     def repeat_cleaning(self) -> bool:
         """Secondary clean up state.
 
@@ -500,10 +498,11 @@ class ViomiVacuumStatus(VacuumDeviceStatus):
         """
         return self.data["repeat_state"]
 
-    # @property
-    # def start_time(self) -> int:
-    #    """FIXME: ??? int or bool."""
-    #    return self.data["start_time"]
+    @property
+    @sensor("Start time")
+    def start_time(self) -> int:
+        """FIXME: ??? int or bool."""
+        return self.data["start_time"]
 
     @property
     @setting("Sound volume", unit="%", setter_name="set_sound_volume", max_value=100)
@@ -511,15 +510,17 @@ class ViomiVacuumStatus(VacuumDeviceStatus):
         """Voice volume level (from 0 to 100%, 0 means Off)."""
         return self.data["v_state"]
 
-    # @property
-    # def water_percent(self) -> int:
-    #    """FIXME: ??? int or bool."""
-    #    return self.data["water_percent"]
+    @property
+    @sensor("Water level", unit="%")
+    def water_percent(self) -> int:
+        """FIXME: ??? int or bool."""
+        return self.data.get("water_percent")
 
-    # @property
-    # def zone_data(self) -> int:
-    #    """FIXME: ??? int or bool."""
-    #    return self.data["zone_data"]
+    @property
+    @sensor("Zone data")
+    def zone_data(self) -> int:
+        """FIXME: ??? int or bool."""
+        return self.data["zone_data"]
 
 
 def _get_rooms_from_schedules(schedules: List[str]) -> Tuple[bool, Dict]:

--- a/miio/integrations/vacuum/viomi/viomivacuum.py
+++ b/miio/integrations/vacuum/viomi/viomivacuum.py
@@ -53,7 +53,7 @@ import click
 
 from miio.click_common import EnumType, command, format_output
 from miio.device import Device
-from miio.devicestatus import sensor, setting, switch
+from miio.devicestatus import sensor, setting
 from miio.exceptions import DeviceException
 from miio.integrations.vacuum.roborock.vacuumcontainers import (
     ConsumableStatus,
@@ -171,13 +171,13 @@ class ViomiConsumableStatus(ConsumableStatus):
         self.sensor_dirty_total = timedelta(seconds=0)
 
     @property
-    @sensor("Mop used")
+    @sensor("Mop used", icon="mdi:timer-sand", device_class="duration", unit="s")
     def mop(self) -> timedelta:
         """Return ``sensor_dirty_time``"""
         return pretty_seconds(self.data["mop_dirty_time"])
 
     @property
-    @sensor("Mop left")
+    @sensor("Mop left", icon="mdi:timer-sand", device_class="duration", unit="s")
     def mop_left(self) -> timedelta:
         """How long until the mop should be changed."""
         return self.mop_total - self.mop
@@ -358,13 +358,13 @@ class ViomiVacuumStatus(VacuumDeviceStatus):
         return bool(self.data["mop_type"])
 
     @property
-    @sensor("Error code")
+    @sensor("Error code", icon="mdi:alert")
     def error_code(self) -> int:
         """Error code from vacuum."""
         return self.data["err_state"]
 
     @property
-    @sensor("Error")
+    @sensor("Error", icon="mdi:alert")
     def error(self) -> Optional[str]:
         """String presentation for the error code."""
         if self.vacuum_state != VacuumState.Error:
@@ -373,7 +373,7 @@ class ViomiVacuumStatus(VacuumDeviceStatus):
         return ERROR_CODES.get(self.error_code, f"Unknown error {self.error_code}")
 
     @property
-    @sensor("Battery", unit="%")
+    @sensor("Battery", unit="%", device_class="battery")
     def battery(self) -> int:
         """Battery in percentage."""
         return self.data["battary_life"]
@@ -385,43 +385,53 @@ class ViomiVacuumStatus(VacuumDeviceStatus):
         return ViomiBinType(self.data["box_type"])
 
     @property
-    @sensor("Cleaning time", unit="s")
+    @sensor("Cleaning time", unit="s", icon="mdi:timer-sand", device_class="duration")
     def clean_time(self) -> timedelta:
         """Cleaning time."""
         return pretty_seconds(self.data["s_time"] * 60)
 
     @property
-    @sensor("Cleaning area", unit="m2")
+    @sensor("Cleaning area", unit="m²", icon="mdi:texture-box")
     def clean_area(self) -> float:
         """Cleaned area in square meters."""
         return self.data["s_area"]
 
     @property
-    @setting("Fan speed", choices=ViomiVacuumSpeed, setter_name="set_fan_speed")
+    @setting(
+        "Fan speed",
+        choices=ViomiVacuumSpeed,
+        setter_name="set_fan_speed",
+        icon="mdi:fan",
+    )
     def fanspeed(self) -> ViomiVacuumSpeed:
         """Current fan speed."""
         return ViomiVacuumSpeed(self.data["suction_grade"])
 
     @property
-    @setting("Water grade", choices=ViomiWaterGrade, setter_name="set_water_grade")
+    @setting(
+        "Water grade",
+        choices=ViomiWaterGrade,
+        setter_name="set_water_grade",
+        icon="mdi:cup-water",
+    )
     def water_grade(self) -> ViomiWaterGrade:
         """Water grade."""
         return ViomiWaterGrade(self.data["water_grade"])
 
     @property
-    @switch("Remember map", setter_name="set_remember_map")
+    @setting("Remember map", setter_name="set_remember_map", icon="mdi:floor-plan")
     def remember_map(self) -> bool:
         """True to remember the map."""
         return bool(self.data["remember_map"])
 
     @property
-    @sensor("Has map")
+    @sensor("Has map", icon="mdi:floor-plan")
     def has_map(self) -> bool:
         """True if device has map?"""
         return bool(self.data["has_map"])
 
     @property
-    @sensor("New map scanned")
+    @sensor("New map scanned", icon="mdi:floor-plan")
     def has_new_map(self) -> bool:
         """True if the device has scanned a new map (like a new floor)."""
         return bool(self.data["has_newmap"])
@@ -433,7 +443,7 @@ class ViomiVacuumStatus(VacuumDeviceStatus):
         return ViomiMode(self.data["is_mop"])
 
     @property
-    @sensor("Current map id")
+    @sensor("Current map id", icon="mdi:floor-plan")
     def current_map_id(self) -> float:
         """Current map id."""
         return self.data["cur_mapid"]
@@ -444,7 +454,7 @@ class ViomiVacuumStatus(VacuumDeviceStatus):
         return self.data["hw_info"]
 
     @property
-    @sensor("Is charging")
+    @sensor("Is charging", icon="mdi:battery")
     def charging(self) -> bool:
         """True if battery is charging.
 
@@ -453,13 +463,13 @@ class ViomiVacuumStatus(VacuumDeviceStatus):
         return not bool(self.data["is_charge"])
 
     @property
-    @switch("Power", setter_name="set_power")
+    @setting("Power", setter_name="set_power")
     def is_on(self) -> bool:
         """True if device is working."""
         return not bool(self.data["is_work"])
 
     @property
-    @switch("LED state", setter_name="led")
+    @setting("LED state", setter_name="led", icon="mdi:led-outline")
     def led_state(self) -> bool:
         """Led state.
 
@@ -468,13 +478,18 @@ class ViomiVacuumStatus(VacuumDeviceStatus):
         return bool(self.data["light_state"])
 
     @property
-    @sensor("Count of saved maps")
+    @sensor("Count of saved maps", icon="mdi:floor-plan")
     def map_number(self) -> int:
         """Number of saved maps."""
         return self.data["map_num"]
 
     @property
-    @setting("Mop pattern", choices=ViomiRoutePattern, setter_name="set_route_pattern")
+    @setting(
+        "Mop pattern",
+        choices=ViomiRoutePattern,
+        setter_name="set_route_pattern",
+        icon="mdi:swap-horizontal-variant",
+    )
     def route_pattern(self) -> Optional[ViomiRoutePattern]:
         """Pattern mode."""
         route = self.data["mop_route"]
@@ -490,7 +505,7 @@ class ViomiVacuumStatus(VacuumDeviceStatus):
         return self.data["order_time"]
 
     @property
-    @switch("Repeat cleaning active", setter_name="set_repeat_cleaning")
+    @setting("Repeat cleaning active", setter_name="set_repeat_cleaning")
     def repeat_cleaning(self) -> bool:
         """Secondary clean up state.
 
@@ -505,13 +520,18 @@ class ViomiVacuumStatus(VacuumDeviceStatus):
         return self.data["start_time"]
 
     @property
-    @setting("Sound volume", setter_name="set_sound_volume", max_value=10)
+    @setting(
+        "Sound volume",
+        setter_name="set_sound_volume",
+        max_value=10,
+        icon="mdi:volume-medium",
+    )
     def sound_volume(self) -> int:
         """Voice volume level (from 0 to 10, 0 means Off)."""
         return self.data["v_state"]
 
     @property
-    @sensor("Water level", unit="%")
+    @sensor("Water level", unit="%", icon="mdi:cup-water")
     def water_percent(self) -> int:
         """FIXME: ??? int or bool."""
         return self.data.get("water_percent")
@@ -577,10 +597,13 @@ class ViomiVacuum(Device, VacuumInterface):
         token: str = None,
         start_id: int = 0,
         debug: int = 0,
+        lazy_discover: bool = False,
         *,
         model: str = None,
     ) -> None:
-        super().__init__(ip, token, start_id, debug, model=model)
+        super().__init__(
+            ip, token, start_id, debug, lazy_discover=lazy_discover, model=model
+        )
         self.manual_seqnum = -1
         self._cache: Dict[str, Any] = {"edge_state": None, "rooms": {}, "maps": {}}
 


### PR DESCRIPTION
**Breaking change: the naming of properties and methods have been adjusted to be more clear about their intention, enums with boolean values have been replaced with booleans.**

This PR improves support for viomi vacuums and aims to make it available for homeassistant without custom components (like https://github.com/KrzysztofHajdamowicz/home-assistant-vacuum-styj02ym). While this has been developed against "Mi Robot Vacuum-Mop P" (viomi.vacuum.v8, styj02ym), it should work on all other viomivacuum supported vacuums. Thanks to @KrzysztofHajdamowicz for providing access to a test device :-)

This is related to #1495 and requires using https://github.com/rytilahti/home-assistant/tree/xiaomi_miio/feat/entities_from_upstream for the time being. The screenshot below shows the current (WIP) state.

![image](https://user-images.githubusercontent.com/3705853/203569890-2e23a7a1-6192-4163-816c-cd48094b58d4.png)

Closes #1161
Closes #750
Closes #1003

TODO:
* [x] Consolidate common vacuum API (e.g., states need to be standardized for homeassistant to make it compatible with the vacuum platform)
* [x] Sensor/setting/switch icons and other metadata
* [x] Add actions 
* [-] Add buttons (reset consumables, ..)

Some notes:
* The class previously requested properties unknown for this model, causing the mismatch in the number of elements requested vs. reported.
* The device seems to be rather unresponsive for requests in many cases, this needs some investigation.