### PR TITLE
Remove SwitchDescriptor in favor of BooleanSettingDescriptor

### DIFF
--- a/miio/descriptors.py
+++ b/miio/descriptors.py
@@ -45,18 +45,6 @@ class SensorDescriptor:
     extras: Optional[Dict] = attr.ib(default={})
 
 
-@attr.s(auto_attribs=True)
-class SwitchDescriptor:
-    """Presents toggleable switch."""
-
-    id: str
-    name: str
-    property: str
-    setter_name: Optional[str] = None
-    setter: Optional[Callable] = None
-    extras: Optional[Dict] = attr.ib(default={})
-
-
 class SettingType(Enum):
     Undefined = auto()
     Number = auto()

--- a/miio/device.py
+++ b/miio/device.py
@@ -5,12 +5,7 @@ from typing import Any, Dict, List, Optional, Union  # noqa: F401
 import click
 
 from .click_common import DeviceGroupMeta, LiteralParamType, command, format_output
-from .descriptors import (
-    ButtonDescriptor,
-    SensorDescriptor,
-    SettingDescriptor,
-    SwitchDescriptor,
-)
+from .descriptors import ButtonDescriptor, SensorDescriptor, SettingDescriptor
 from .deviceinfo import DeviceInfo
 from .devicestatus import DeviceStatus
 from .exceptions import DeviceInfoUnavailableException, PayloadDecodeException
@@ -271,21 +266,6 @@ class Device(metaclass=DeviceGroupMeta):
         # TODO: the latest status should be cached and re-used by all meta information getters
         sensors = self.status().sensors()
         return sensors
-
-    def switches(self) -> Dict[str, SwitchDescriptor]:
-        """Return toggleable switches."""
-        switches = self.status().switches()
-        for switch in switches.values():
-            # TODO: Bind setter methods, this should probably done only once during init.
-            if switch.setter is None:
-                if switch.setter_name is None:
-                    # TODO: this is ugly, how to fix the issue where setter_name is optional and thus not acceptable for getattr?
-                    raise Exception(
-                        f"Neither setter or setter_name was defined for {switch}"
-                    )
-                switch.setter = getattr(self, switch.setter_name)
-
-        return switches
 
     def __repr__(self):
         return f"<{self.__class__.__name__ }: {self.ip} (token: {self.token})>"

--- a/miio/integrations/fan/zhimi/fan.py
+++ b/miio/integrations/fan/zhimi/fan.py
@@ -5,7 +5,7 @@ import click
 
 from miio import Device, DeviceStatus
 from miio.click_common import EnumType, command, format_output
-from miio.devicestatus import sensor, setting, switch
+from miio.devicestatus import sensor, setting
 from miio.fan_common import LedBrightness, MoveDirection
 
 _LOGGER = logging.getLogger(__name__)
@@ -82,7 +82,7 @@ class FanStatus(DeviceStatus):
         return self.data["power"]
 
     @property
-    @switch("Power", setter_name="set_power")
+    @setting("Power", setter_name="set_power")
     def is_on(self) -> bool:
         """True if device is currently on."""
         return self.power == "on"
@@ -104,7 +104,7 @@ class FanStatus(DeviceStatus):
         return None
 
     @property
-    @switch("LED", setter_name="set_led")
+    @setting("LED", setter_name="set_led")
     def led(self) -> Optional[bool]:
         """True if LED is turned on, if available."""
         if "led" in self.data and self.data["led"] is not None:
@@ -120,13 +120,13 @@ class FanStatus(DeviceStatus):
         return None
 
     @property
-    @switch("Buzzer", setter_name="set_buzzer")
+    @setting("Buzzer", setter_name="set_buzzer")
     def buzzer(self) -> bool:
         """True if buzzer is turned on."""
         return self.data["buzzer"] in ["on", 1, 2]
 
     @property
-    @switch("Child Lock", setter_name="set_child_lock")
+    @setting("Child Lock", setter_name="set_child_lock")
     def child_lock(self) -> bool:
         """True if child lock is on."""
         return self.data["child_lock"] == "on"
@@ -148,7 +148,7 @@ class FanStatus(DeviceStatus):
         return None
 
     @property
-    @switch("Oscillate", setter_name="set_oscillate")
+    @setting("Oscillate", setter_name="set_oscillate")
     def oscillate(self) -> bool:
         """True if oscillation is enabled."""
         return self.data["angle_enable"] == "on"

--- a/miio/integrations/humidifier/zhimi/airhumidifier.py
+++ b/miio/integrations/humidifier/zhimi/airhumidifier.py
@@ -7,7 +7,7 @@ import click
 
 from miio import Device, DeviceError, DeviceInfo, DeviceStatus
 from miio.click_common import EnumType, command, format_output
-from miio.devicestatus import sensor, setting, switch
+from miio.devicestatus import sensor, setting
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -112,7 +112,7 @@ class AirHumidifierStatus(DeviceStatus):
         return self.data["humidity"]
 
     @property
-    @switch(
+    @setting(
         name="Buzzer",
         icon="mdi:volume-high",
         setter_name="set_buzzer",
@@ -138,7 +138,7 @@ class AirHumidifierStatus(DeviceStatus):
         return None
 
     @property
-    @switch(
+    @setting(
         name="Child Lock",
         icon="mdi:lock",
         setter_name="set_child_lock",
@@ -279,7 +279,7 @@ class AirHumidifierStatus(DeviceStatus):
         return None
 
     @property
-    @switch(
+    @setting(
         name="Dry Mode",
         icon="mdi:hair-dryer",
         setter_name="set_dry",

--- a/miio/integrations/light/yeelight/yeelight.py
+++ b/miio/integrations/light/yeelight/yeelight.py
@@ -7,7 +7,7 @@ import click
 from miio import ColorTemperatureRange, LightInterface
 from miio.click_common import command, format_output
 from miio.device import Device, DeviceStatus
-from miio.devicestatus import sensor, setting, switch
+from miio.devicestatus import sensor, setting
 from miio.utils import int_to_rgb, rgb_to_int
 
 from .spec_helper import YeelightSpecHelper, YeelightSubLightType
@@ -113,7 +113,7 @@ class YeelightStatus(DeviceStatus):
         self.data = data
 
     @property
-    @switch("Power", setter_name="set_power")
+    @setting("Power", setter_name="set_power")
     def is_on(self) -> bool:
         """Return whether the light is on or off."""
         return self.lights[0].is_on
@@ -167,7 +167,7 @@ class YeelightStatus(DeviceStatus):
         return self.lights[0].color_flow_params
 
     @property
-    @switch("Developer mode enabled", setter_name="set_developer_mode")
+    @setting("Developer mode enabled", setter_name="set_developer_mode")
     def developer_mode(self) -> Optional[bool]:
         """Return whether the developer mode is active."""
         lan_ctrl = self.data["lan_ctrl"]
@@ -176,7 +176,7 @@ class YeelightStatus(DeviceStatus):
         return None
 
     @property
-    @switch("Save state on change enabled", setter_name="set_save_state_on_change")
+    @setting("Save state on change enabled", setter_name="set_save_state_on_change")
     def save_state_on_change(self) -> bool:
         """Return whether the bulb state is saved on change."""
         return bool(int(self.data["save_state"]))

--- a/miio/integrations/vacuum/mijia/pro2vacuum.py
+++ b/miio/integrations/vacuum/mijia/pro2vacuum.py
@@ -6,7 +6,7 @@ from typing import Dict
 import click
 
 from miio.click_common import EnumType, command, format_output
-from miio.devicestatus import sensor, switch
+from miio.devicestatus import sensor, setting
 from miio.interfaces import FanspeedPresets, VacuumInterface
 from miio.miot_device import DeviceStatus, MiotDevice
 
@@ -172,7 +172,7 @@ class Pro2Status(DeviceStatus):
         return DeviceState(self.data["state"])
 
     @property
-    @switch(name="Fan Speed", choices=FanSpeedMode, setter_name="set_fan_speed")
+    @setting(name="Fan Speed", choices=FanSpeedMode, setter_name="set_fan_speed")
     def fan_speed(self) -> FanSpeedMode:
         """Fan Speed."""
         return FanSpeedMode(self.data["fan_speed"])

--- a/miio/powerstrip.py
+++ b/miio/powerstrip.py
@@ -7,7 +7,7 @@ import click
 
 from .click_common import EnumType, command, format_output
 from .device import Device
-from .devicestatus import DeviceStatus, sensor, switch
+from .devicestatus import DeviceStatus, sensor, setting
 from .utils import deprecated
 
 _LOGGER = logging.getLogger(__name__)
@@ -61,7 +61,7 @@ class PowerStripStatus(DeviceStatus):
         return self.data["power"]
 
     @property
-    @switch(name="Power", setter_name="set_power", device_class="outlet")
+    @setting(name="Power", setter_name="set_power", device_class="outlet")
     def is_on(self) -> bool:
         """True if the device is turned on."""
         return self.power == "on"
@@ -105,7 +105,7 @@ class PowerStripStatus(DeviceStatus):
         return self.led
 
     @property
-    @switch(
+    @setting(
         name="LED", icon="mdi:led-outline", setter_name="set_led", device_class="switch"
     )
     def led(self) -> Optional[bool]:

--- a/miio/tests/test_devicestatus.py
+++ b/miio/tests/test_devicestatus.py
@@ -4,7 +4,7 @@ import pytest
 
 from miio import Device, DeviceStatus
 from miio.descriptors import EnumSettingDescriptor, NumberSettingDescriptor
-from miio.devicestatus import sensor, setting, switch
+from miio.devicestatus import sensor, setting
 
 
 def test_multiple():
@@ -100,29 +100,6 @@ def test_sensor_decorator():
     assert sensors["only_name"].name == "Only name"
 
     assert "unknown_kwarg" in sensors["unknown"].extras
-
-
-def test_switch_decorator(mocker):
-    class DecoratedSwitches(DeviceStatus):
-        @property
-        @switch(name="Power", setter_name="set_power")
-        def power(self):
-            pass
-
-    mocker.patch("miio.Device.send")
-    d = Device("127.0.0.1", "68ffffffffffffffffffffffffffffff")
-
-    # Patch status to return our class
-    mocker.patch.object(d, "status", return_value=DecoratedSwitches())
-    # Patch to create a new setter as defined in the status class
-    set_power = mocker.patch.object(d, "set_power", create=True, return_value=1)
-
-    sensors = d.switches()
-    assert len(sensors) == 1
-    assert sensors["power"].name == "Power"
-
-    sensors["power"].setter(True)
-    set_power.assert_called_with(True)
 
 
 def test_setting_decorator_number(mocker):


### PR DESCRIPTION
New `BooleanSettingDescriptor` allows defining boolean settings, so having
a separate handling for switches is unnecessary and just complicates the code.