### PR TITLE
Use __ as delimiter for embedded statuses

### DIFF
--- a/miio/devicestatus.py
+++ b/miio/devicestatus.py
@@ -113,21 +113,21 @@ class DeviceStatus(metaclass=_StatusMeta):
         self._embedded[other_name] = other
 
         for name, sensor in other.sensors().items():
-            final_name = f"{other_name}:{name}"
+            final_name = f"{other_name}__{name}"
             import attr
 
             self._sensors[final_name] = attr.evolve(sensor, property=final_name)
 
         for name, setting in other.settings().items():
-            final_name = f"{other_name}:{name}"
+            final_name = f"{other_name}__{name}"
             self._settings[final_name] = attr.evolve(setting, property=final_name)
 
-    def __getattribute__(self, item):
+    def __getattr__(self, item):
         """Overridden to lookup properties from embedded containers."""
-        if ":" not in item:
-            return super().__getattribute__(item)
+        if "__" not in item:
+            return super().__getattr__(item)
 
-        embed, prop = item.split(":")
+        embed, prop = item.split("__")
         return getattr(self._embedded[embed], prop)
 
 

--- a/miio/tests/test_devicestatus.py
+++ b/miio/tests/test_devicestatus.py
@@ -201,7 +201,7 @@ def test_embed():
     assert len(sensors) == 2
 
     assert getattr(main, sensors["main_sensor"].property) == "main"
-    assert getattr(main, sensors["SubStatus:sub_sensor"].property) == "sub"
+    assert getattr(main, sensors["SubStatus__sub_sensor"].property) == "sub"
 
     with pytest.raises(KeyError):
         main.sensors()["nonexisting_sensor"]


### PR DESCRIPTION
Leaves ":" free for other uses,
converts to use `__getattr__` instead of `__getattribute__` to avoid checking on every attribute access.