### PR TITLE
Allow passing custom name for miotdevice.set_property_by

### DIFF
--- a/miio/miot_device.py
+++ b/miio/miot_device.py
@@ -170,7 +170,7 @@ class MiotDevice(Device):
             value = value_type.value(value)
 
         if name is None:
-            f"set-{siid}-{piid}"
+            name = f"set-{siid}-{piid}"
 
         return self.send(
             "set_properties",

--- a/miio/miot_device.py
+++ b/miio/miot_device.py
@@ -150,13 +150,16 @@ class MiotDevice(Device):
         click.argument(
             "value_type", type=EnumType(MiotValueType), required=False, default=None
         ),
+        click.option("--name", required=False),
     )
     def set_property_by(
         self,
         siid: int,
         piid: int,
         value: Union[int, float, str, bool],
+        *,
         value_type: Any = None,
+        name: str = None,
     ):
         """Set a single property (siid/piid) to given value.
 
@@ -166,9 +169,12 @@ class MiotDevice(Device):
         if value_type is not None:
             value = value_type.value(value)
 
+        if name is None:
+            f"set-{siid}-{piid}"
+
         return self.send(
             "set_properties",
-            [{"did": f"set-{siid}-{piid}", "siid": siid, "piid": piid, "value": value}],
+            [{"did": name, "siid": siid, "piid": piid, "value": value}],
         )
 
     def set_property(self, property_key: str, value):

--- a/miio/tests/test_miotdevice.py
+++ b/miio/tests/test_miotdevice.py
@@ -61,7 +61,7 @@ def test_get_property_by(dev):
 def test_set_property_by(dev, value_type, value):
     siid = 1
     piid = 1
-    _ = dev.set_property_by(siid, piid, value, value_type)
+    _ = dev.set_property_by(siid, piid, value, value_type=value_type)
 
     if value_type is not None:
         value = value_type.value(value)
@@ -69,6 +69,18 @@ def test_set_property_by(dev, value_type, value):
     dev.send.assert_called_with(
         "set_properties",
         [{"did": f"set-{siid}-{piid}", "siid": siid, "piid": piid, "value": value}],
+    )
+
+
+def test_set_property_by_name(dev):
+    siid = 1
+    piid = 1
+    value = 1
+    _ = dev.set_property_by(siid, piid, value, name="test-name")
+
+    dev.send.assert_called_with(
+        "set_properties",
+        [{"did": "test-name", "siid": siid, "piid": piid, "value": value}],
     )
 
 


### PR DESCRIPTION
This allows passing a name to use instead of the hardcoded `set-{siid}-{piid}` as `did` for miotdevice requests:
```
dev = MiotDevice(...)
dev.get_property_by(111, 222, 333, name="dummy-name")
```
will cause request did to be set to `dummy_name`.
```
{"did": "dummy-name", "siid": 111, "piid": 222, "value": 333}
```

**Breaking change**
The `set_property_by`'s `value_type` is converted to keyword-only argument.