### PR TITLE
Add generic miot support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,12 +9,13 @@ This library (and its accompanying cli tool) can be used to interface with devic
 Getting started
 ---------------
 
-If you already have a token for your device and the device type, you can directly start using `miiocli` tool.
-If you don't have a token for your device, refer to `Getting started <https://python-miio.readthedocs.io/en/latest/discovery.html>`__ section of `the manual <https://python-miio.readthedocs.io>`__ for instructions how to obtain it.
+The ``miiocli`` command allows controlling supported devices from the command line,
+given that you know their IP addresses and tokens.
+You can use ``miiocli cloud`` command to obtain this information from the cloud.
+Refer to `Getting started <https://python-miio.readthedocs.io/en/latest/discovery.html>`__ section of `the manual <https://python-miio.readthedocs.io>`__ for more detailed instructions.
 
-The `miiocli` is the main way to execute commands from command line.
-You can always use `--help` to get more information about the available commands.
-For example, executing it without any extra arguments will print out options and available commands::
+You can always use ``--help`` to get more information about available commands, subcommands, and their options.
+For example, to print out options and available commands::
 
     $ miiocli --help
     Usage: miiocli [OPTIONS] COMMAND [ARGS]...
@@ -28,7 +29,7 @@ For example, executing it without any extra arguments will print out options and
       airconditioningcompanion
       ..
 
-You can get some information from any miIO/MIoT device, including its device model, using the `info` command::
+You can get some information from any miIO/MIoT device, including its device model, using the ``info`` command::
 
     miiocli device --ip <ip> --token <token> info
 
@@ -38,8 +39,28 @@ You can get some information from any miIO/MIoT device, including its device mod
     Network: {'localIp': '<ip>', 'mask': '255.255.255.0', 'gw': '<ip>'}
     AP: {'rssi': -73, 'ssid': '<nnetwork>', 'primary': 11, 'bssid': '<bssid>'}
 
-Different devices are supported by their corresponding modules (e.g., `roborockvacuum` or `fan`).
-You can get the list of available commands for any given module by passing `--help` argument to it::
+
+Controlling MIoT devices
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+MiOT devices are supported by the ``genericmiot`` integration which provides basic support for all MiOT devices.
+Internally, it downloads ``miot-spec`` files to find out about supported features.
+All features of supported devices are available using these common commands::
+
+-  ``miiocli genericmiot status`` to print the device status information, including settings (prefixed with ``[S]``).
+-  ``miiocli genericmiot set`` to change settings.
+-  ``miiocli genericmiot actions`` to list available actions.
+-  ``miiocli genericmiot call`` to execute actions.
+
+Use ``miiocli genericmiot --help`` for more available commands.
+
+
+Controlling other devices
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Older devices are mainly supported by their corresponding modules (e.g., ``roborockvacuum`` or ``fan``).
+
+You can get the list of available commands for any given module by passing ``--help`` argument to it::
 
     $ miiocli roborockvacuum --help
 
@@ -63,25 +84,30 @@ You can avoid this by specifying the model manually::
 
 API usage
 ---------
-All functionality is accessible through the `miio` module::
+All functionalities of this library are accessible through the ``miio`` module.
+While you can initialize individual integration classes manually,
+the simplest way to obtain a device instance is to use ``DeviceFactory``::
 
-    from miio import RoborockVacuum
+    from miio import DeviceFactory
 
-    vac = RoborockVacuum("<ip address>", "<token>")
-    vac.start()
+    dev = DeviceFactory.create("<ip address>", "<token>")
+    dev.info()
 
-Each separate device type inherits from `miio.Device`
-(and in case of MIoT devices, `miio.MiotDevice`) which provides a common API.
 
-Each command invocation will automatically detect (and cache) the device model necessary for some actions
-by querying the device.
-You can avoid this by specifying the model manually::
+This will perform an ``info`` query to the device to detect its model information,
+which is crucial especially for MiOT devices.
 
-    from miio import RoborockVacuum
+Introspecting supported features
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    vac = RoborockVacuum("<ip address>", "<token>", model="roborock.vacuum.s5")
+You can introspect device classes using the following methods::
 
-Please refer to `API documentation <https://python-miio.readthedocs.io/en/latest/api/miio.html>`__ for more information.
+-  ``actions()`` to return information about available device actions.
+-  ``settings()`` to obtain information about available settings that can be changed.
+-  ``sensors()`` to obtain information about sensors.
+
+Each of these return `device descriptor objects <https://python-miio.readthedocs.io/en/latest/api/miio.descriptors.html>`__,
+which contain the necessary metadata about the available features to allow constructing generic interfaces.
 
 
 Troubleshooting
@@ -89,6 +115,7 @@ Troubleshooting
 You can find some solutions for the most common problems can be found in `Troubleshooting <https://python-miio.readthedocs.io/en/latest/troubleshooting.html>`__ section.
 
 If you have any questions, or simply want to join up for a chat, check `our Matrix room <https://matrix.to/#/#python-miio-chat:matrix.org>`__.
+
 
 Contributing
 ------------
@@ -100,11 +127,14 @@ To ease the process of setting up a development environment we have prepared `a 
 Supported devices
 -----------------
 
+While all MIoT devices are supported through the ``genericmiot`` integration,
+this library supports also the following devices::
+
 -  Xiaomi Mi Robot Vacuum V1, S4, S4 MAX, S5, S5 MAX, S6 Pure, M1S, S7
 -  Xiaomi Mi Home Air Conditioner Companion
 -  Xiaomi Mi Smart Air Conditioner A (xiaomi.aircondition.mc1, mc2, mc4, mc5)
 -  Xiaomi Mi Air Purifier 2, 3H, 3C, 4, Pro, Pro H, 4 Pro (zhimi.airpurifier.m2, mb3, mb4, mb5, v7, vb2, va2), 4 Lite
--  Xiaomi Mi Air (Purifier) Dog X3, X5, X7SM (airdog.airpurifier.x3, airdog.airpurifier.x5, airdog.airpurifier.x7sm)
+-  Xiaomi Mi Air (Purifier) Dog X3, X5, X7SM (airdog.airpurifier.x3, x5, x7sm)
 -  Xiaomi Mi Air Humidifier
 -  Smartmi Air Purifier
 -  Xiaomi Aqara Camera
@@ -139,9 +169,8 @@ Supported devices
 -  Xiaomi Smart WiFi Speaker
 -  Xiaomi Mi WiFi Repeater 2
 -  Xiaomi Mi Smart Rice Cooker
--  Xiaomi Smartmi Fresh Air System VA2 (zhimi.airfresh.va2), VA4 (zhimi.airfresh.va4),
-   A1 (dmaker.airfresh.a1), T2017 (dmaker.airfresh.t2017)
--  Yeelight lights (basic support, we recommend using `python-yeelight <https://gitlab.com/stavros/python-yeelight/>`__)
+-  Xiaomi Smartmi Fresh Air System VA2 (zhimi.airfresh.va2), VA4 (va4), T2017 (t2017), A1 (dmaker.airfresh.a1)
+-  Yeelight lights (see also `python-yeelight <https://gitlab.com/stavros/python-yeelight/>`__)
 -  Xiaomi Mi Air Dehumidifier
 -  Xiaomi Tinymu Smart Toilet Cover
 -  Xiaomi 16 Relays Module

--- a/miio/__init__.py
+++ b/miio/__init__.py
@@ -47,6 +47,7 @@ from miio.integrations.airpurifier import (
     AirPurifierMiot,
 )
 from miio.integrations.fan import Fan, Fan1C, FanLeshow, FanMiot, FanP5, FanZA5
+from miio.integrations.genericmiot import GenericMiot
 from miio.integrations.humidifier import (
     AirHumidifier,
     AirHumidifierJsq,

--- a/miio/device.py
+++ b/miio/device.py
@@ -145,7 +145,8 @@ class Device(metaclass=DeviceGroupMeta):
             self._info = devinfo
             _LOGGER.debug("Detected model %s", devinfo.model)
             cls = self.__class__.__name__
-            bases = ["Device", "MiotDevice"]
+            # Ignore bases and generic classes
+            bases = ["Device", "MiotDevice", "GenericMiot"]
             if devinfo.model not in self.supported_models and cls not in bases:
                 _LOGGER.warning(
                     "Found an unsupported model '%s' for class '%s'. If this is working for you, please open an issue at https://github.com/rytilahti/python-miio/",

--- a/miio/devicefactory.py
+++ b/miio/devicefactory.py
@@ -62,7 +62,11 @@ class DeviceFactory:
         wildcard_models = {
             m: impl for m, impl in cls._supported_models.items() if m.endswith("*")
         }
-        for wildcard_model, impl in wildcard_models.items():
+        # We sort here to return the implementation with most specific prefix
+        sorted_by_longest_prefix = sorted(
+            wildcard_models.items(), key=lambda item: len(item[0]), reverse=True
+        )
+        for wildcard_model, impl in sorted_by_longest_prefix:
             m = wildcard_model.rstrip("*")
             if model.startswith(m):
                 _LOGGER.debug(

--- a/miio/devicefactory.py
+++ b/miio/devicefactory.py
@@ -80,13 +80,27 @@ class DeviceFactory:
         raise DeviceException("No implementation found for model %s" % model)
 
     @classmethod
-    def create(self, host: str, token: str, model: Optional[str] = None) -> Device:
+    def create(
+        self,
+        host: str,
+        token: str,
+        model: Optional[str] = None,
+        *,
+        force_generic_miot=False,
+    ) -> Device:
         """Return instance for the given host and token, with optional model override.
 
         The optional model parameter can be used to override the model detection.
         """
+        dev: Device
+        if force_generic_miot:  # TODO: find a better way to handle this.
+            from .integrations.genericmiot import GenericMiot
+
+            dev = GenericMiot(host, token, model=model)
+            dev.info()  # HACK: we have to force update to load the miot schema
+            return dev
         if model is None:
-            dev: Device = Device(host, token)
+            dev = Device(host, token)
             info = dev.info()
             model = info.model
 

--- a/miio/devicefactory.py
+++ b/miio/devicefactory.py
@@ -33,11 +33,12 @@ class DeviceFactory:
         for model in integration_cls.supported_models:  # type: ignore
             if model in cls._supported_models:
                 _LOGGER.debug(
-                    "Got duplicate of %s for %s, previously registered by %s",
+                    "Ignoring duplicate of %s for %s, previously registered by %s",
                     model,
                     integration_cls,
                     cls._supported_models[model],
                 )
+                continue
 
             _LOGGER.debug("  * %s => %s", model, integration_cls)
             cls._supported_models[model] = integration_cls
@@ -97,7 +98,7 @@ class DeviceFactory:
             from .integrations.genericmiot import GenericMiot
 
             dev = GenericMiot(host, token, model=model)
-            dev.info()  # HACK: we have to force update to load the miot schema
+            dev.info()
             return dev
         if model is None:
             dev = Device(host, token)

--- a/miio/integrations/genericmiot/__init__.py
+++ b/miio/integrations/genericmiot/__init__.py
@@ -1,0 +1,3 @@
+from .genericmiot import GenericMiot
+
+__all__ = ["GenericMiot"]

--- a/miio/integrations/genericmiot/genericmiot.py
+++ b/miio/integrations/genericmiot/genericmiot.py
@@ -1,0 +1,445 @@
+import logging
+from enum import Enum
+from functools import partial
+from typing import Dict, List, Optional, Union
+
+import click
+
+from miio import DeviceInfo, DeviceStatus, MiotDevice
+from miio.click_common import LiteralParamType, command, format_output
+from miio.descriptors import (
+    ActionDescriptor,
+    BooleanSettingDescriptor,
+    EnumSettingDescriptor,
+    NumberSettingDescriptor,
+    SensorDescriptor,
+    SettingDescriptor,
+)
+from miio.miot_cloud import MiotCloud
+from miio.miot_device import MiotMapping
+from miio.miot_models import DeviceModel, MiotAction, MiotProperty, MiotService
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def pretty_status(result: "GenericMiotStatus"):
+    """Pretty print status information."""
+    out = ""
+    props = result.property_dict()
+    for _name, prop in props.items():
+        pretty_value = prop.pretty_value
+
+        if "write" in prop.access:
+            out += "[S] "
+
+        out += f"{prop.description} ({prop.name}): {pretty_value}"
+
+        if prop.choices is not None:  # TODO: hide behind verbose flag?
+            out += (
+                " (from: "
+                + ", ".join([f"{c.description} ({c.value})" for c in prop.choices])
+                + ")"
+            )
+
+        if prop.range is not None:  # TODO: hide behind verbose flag?
+            out += (
+                f" (min: {prop.range[0]}, max: {prop.range[1]}, step: {prop.range[2]})"
+            )
+
+        out += "\n"
+
+    return out
+
+
+def pretty_actions(result: Dict[str, ActionDescriptor]):
+    """Pretty print actions."""
+    out = ""
+    for _, desc in result.items():
+        out += f"{desc.id}\t\t{desc.name}\n"
+
+    return out
+
+
+def pretty_settings(result: Dict[str, SettingDescriptor]):
+    """Pretty print settings."""
+    out = ""
+    for _, desc in result.items():
+        out += f"# {desc.id} ({desc.name})"
+        out += f'  urn: {repr(desc.extras["urn"])}\n'
+        out += f'  siid: {desc.extras["siid"]}\n'
+        out += f'  piid: {desc.extras["piid"]}\n'
+
+    return out
+
+
+class GenericMiotStatus(DeviceStatus):
+    """Generic status for miot devices."""
+
+    def __init__(self, response, dev):
+        self._model = dev._miot_model
+        self._dev = dev
+        self._data = {elem["did"]: elem["value"] for elem in response}
+
+    def __getattr__(self, item):
+        """Return attribute for name.
+
+        This is overridden to provide access to properties using (siid, piid) tuple.
+        """
+        # TODO: find a better way to encode the property information
+        serv, prop = item.split(":")
+        prop = self._model.get_property(serv, prop)
+        value = self._data[item]
+
+        # TODO: this feels like a wrong place to convert value to enum..
+        if prop.choices is not None:
+            for choice in prop.choices:
+                if choice.value == value:
+                    return choice.description
+
+            _LOGGER.warning(
+                "Unable to find choice for value: %s: %s", value, prop.choices
+            )
+
+        return self._data[item]
+
+    def property_dict(self) -> Dict[str, MiotProperty]:
+        """Return (siid, piid)-keyed dictionary of properties."""
+        res = {}
+        for did, value in self._data.items():
+            service, prop_name = did.split(":")
+            prop = self._model.get_property(service, prop_name)
+            prop.value = value
+            res[did] = prop
+
+        return res
+
+    def __repr__(self):
+        s = f"<{self.__class__.__name__}"
+        for name, value in self.property_dict().items():
+            s += f" {name}={value}"
+        s += ">"
+
+        return s
+
+
+class GenericMiot(MiotDevice):
+    _supported_models = [
+        "*"
+    ]  # we support all devices, if not, it is a responsibility of caller to verify that
+
+    def __init__(
+        self,
+        ip: str = None,
+        token: str = None,
+        start_id: int = 0,
+        debug: int = 0,
+        lazy_discover: bool = True,
+        timeout: int = None,
+        *,
+        model: str = None,
+        mapping: MiotMapping = None,
+    ):
+        super().__init__(
+            ip,
+            token,
+            start_id,
+            debug,
+            lazy_discover,
+            timeout,
+            model=model,
+            mapping=mapping,
+        )
+        self._model = model
+        self._miot_model: Optional[DeviceModel] = None
+
+        self._actions: Dict[str, ActionDescriptor] = {}
+        self._sensors: Dict[str, SensorDescriptor] = {}
+        self._settings: Dict[str, SettingDescriptor] = {}
+        self._properties: List[MiotProperty] = []
+
+    def initialize_model(self):
+        """Initialize the miot model and create descriptions."""
+        if self._miot_model is not None:
+            return
+
+        miotcloud = MiotCloud()
+        self._miot_model = miotcloud.get_device_model(self.model)
+        _LOGGER.debug("Initialized: %s", self._miot_model)
+        self._create_descriptors()
+
+    @command(default_output=format_output(result_msg_fmt=pretty_status))
+    def status(self) -> GenericMiotStatus:
+        """Return status based on the miot model."""
+        properties = []
+        for prop in self._properties:
+            if "read" not in prop.access:
+                _LOGGER.debug("Property has no read access, skipping: %s", prop)
+                continue
+
+            siid = prop.siid
+            piid = prop.piid
+            name = prop.name  # f"{prop.service.urn.name}:{prop.name}"
+            q = {"siid": siid, "piid": piid, "did": name}
+            properties.append(q)
+
+        # TODO: max properties needs to be made configurable (or at least splitted to avoid too large udp datagrams
+        #       some devices are stricter: https://github.com/rytilahti/python-miio/issues/1550#issuecomment-1303046286
+        response = self.get_properties(
+            properties, property_getter="get_properties", max_properties=10
+        )
+
+        return GenericMiotStatus(response, self)
+
+    def _create_action(self, act: MiotAction) -> Optional[ActionDescriptor]:
+        """Create action descriptor for miot action."""
+        if act.inputs:
+            # TODO: need to figure out how to expose input parameters for downstreams
+            _LOGGER.warning(
+                "Got inputs for action, skipping as handling is unknown: %s", act
+            )
+            return None
+
+        call_action = partial(self.call_action_by, act.siid, act.aiid)
+
+        id_ = act.name
+
+        # TODO: move extras handling to the model
+        extras = act.extras
+        extras["urn"] = act.urn
+        extras["siid"] = act.siid
+        extras["aiid"] = act.aiid
+
+        return ActionDescriptor(
+            id=id_,
+            name=act.description,
+            method=call_action,
+            extras=extras,
+        )
+
+    def _create_actions(self, serv: MiotService):
+        """Create action descriptors."""
+        for act in serv.actions:
+            act_desc = self._create_action(act)
+            if act_desc is None:  # skip actions we cannot handle for now..
+                continue
+
+            if (
+                act_desc.name in self._actions
+            ):  # TODO: find a way to handle duplicates, suffix maybe?
+                _LOGGER.warning("Got used name name, ignoring '%s': %s", act.name, act)
+                continue
+
+            self._actions[act_desc.name] = act_desc
+
+    def _create_sensor(self, prop: MiotProperty) -> SensorDescriptor:
+        """Create sensor descriptor for a property."""
+        property_name = prop.name
+
+        return SensorDescriptor(
+            id=property_name,
+            name=prop.description,
+            property=property_name,
+            type=prop.format,
+            extras=prop.extras,
+        )
+
+    def _create_sensors_and_settings(self, serv: MiotService):
+        """Create sensor and setting descriptors for a service."""
+        for prop in serv.properties:
+            if prop.access == ["notify"]:
+                _LOGGER.debug("Skipping notify-only property: %s", prop)
+                continue
+            if "read" not in prop.access:  # TODO: handle write-only properties
+                _LOGGER.warning("Skipping write-only: %s", prop)
+                continue
+
+            desc = self._descriptor_for_property(prop)
+            if isinstance(desc, SensorDescriptor):
+                self._sensors[prop.name] = desc
+            elif isinstance(desc, SettingDescriptor):
+                self._settings[prop.name] = desc
+            else:
+                raise Exception("unknown descriptor type")
+
+            self._properties.append(prop)
+
+    def _descriptor_for_property(self, prop: MiotProperty):
+        """Create a descriptor based on the property information."""
+        desc: SettingDescriptor
+        name = prop.description
+        property_name = prop.name
+
+        setter = partial(self.set_property_by, prop.siid, prop.piid, name=property_name)
+
+        # TODO: move extras handling to the model
+        extras = prop.extras
+        extras["urn"] = prop.urn
+        extras["siid"] = prop.siid
+        extras["piid"] = prop.piid
+
+        # Handle settable ranged properties
+        if prop.range is not None:
+            return self._create_range_setting(name, prop, property_name, setter, extras)
+
+        # Handle settable enums
+        elif prop.choices is not None:
+            # TODO: handle two-value enums as booleans?
+            return self._create_choices_setting(
+                name, prop, property_name, setter, extras
+            )
+
+        # Handle settable booleans
+        elif "write" in prop.access and prop.format == bool:
+            return BooleanSettingDescriptor(
+                id=property_name,
+                name=name,
+                property=property_name,
+                setter=setter,
+                unit=prop.unit,
+                extras=extras,
+            )
+
+        # Fallback to sensors
+        return self._create_sensor(prop)
+
+    def _create_choices_setting(
+        self, name, prop, property_name, setter, extras
+    ) -> Union[SensorDescriptor, EnumSettingDescriptor]:
+        """Create a descriptor for enum-based setting."""
+        try:
+            choices = Enum(
+                prop.description, {c.description: c.value for c in prop.choices}
+            )
+            _LOGGER.debug("Created enum %s", choices)
+        except ValueError as ex:
+            _LOGGER.error("Unable to create enum for %s: %s", prop, ex)
+            raise
+
+        desc = EnumSettingDescriptor(
+            id=property_name,
+            name=name,
+            property=property_name,
+            unit=prop.unit,
+            choices=choices,
+            extras=extras,
+        )
+        if "write" in prop.access:
+            desc.setter = setter
+            return desc
+        else:
+            return self._create_sensor(prop)
+
+    def _create_range_setting(self, name, prop, property_name, setter, extras):
+        """Create a descriptor for range-based setting."""
+        desc = NumberSettingDescriptor(
+            id=property_name,
+            name=name,
+            property=property_name,
+            min_value=prop.range[0],
+            max_value=prop.range[1],
+            step=prop.range[2],
+            unit=prop.unit,
+            extras=extras,
+        )
+        if "write" in prop.access:
+            desc.setter = setter
+            return desc
+        else:
+            return self._create_sensor(prop)
+
+    def _create_descriptors(self):
+        """Create descriptors based on the miot model."""
+        for serv in self._miot_model.services:
+            if serv.siid == 1:
+                continue  # Skip device details
+
+            self._create_actions(serv)
+            self._create_sensors_and_settings(serv)
+
+        _LOGGER.debug("Created %s actions", len(self._actions))
+        for act in self._actions.values():
+            _LOGGER.debug(f"\t{act}")
+        _LOGGER.debug("Created %s sensors", len(self._sensors))
+        for sensor in self._sensors.values():
+            _LOGGER.debug(f"\t{sensor}")
+        _LOGGER.debug("Created %s settings", len(self._settings))
+        for setting in self._settings.values():
+            _LOGGER.debug(f"\t{setting}")
+
+    def _get_action_by_name(self, name: str):
+        """Return action by name."""
+        # TODO: cache service:action?
+        for act in self._actions.values():
+            if act.id == name:
+                if act.method_name is not None:
+                    act.method = getattr(self, act.method_name)
+
+                return act
+
+        raise ValueError("No action with name/id %s" % name)
+
+    @command(
+        click.argument("name"),
+        click.argument("params", type=LiteralParamType(), required=False),
+        name="call",
+    )
+    def call_action(self, name: str, params=None):
+        """Call action by name."""
+        params = params or []
+        act = self._get_action_by_name(name)
+        return act.method(params)
+
+    @command(
+        click.argument("name"),
+        click.argument("params", type=LiteralParamType(), required=True),
+        name="set",
+    )
+    def change_setting(self, name: str, params=None):
+        """Change setting value."""
+        params = params if params is not None else []
+        # TODO: create a name/plain name getter to the device model
+        service, prop_name = name.split(":")
+        # prop = self._miot_model.get_property(service, prop)
+        setting = self._settings.get(name, None)
+        if setting is None:
+            raise ValueError("No setting found for name %s" % name)
+
+        return setting.setter(value=setting.cast_value(params))
+
+    def _fetch_info(self) -> DeviceInfo:
+        """Hook to perform the model initialization."""
+        info = super()._fetch_info()
+        self.initialize_model()
+
+        return info
+
+    @command(default_output=format_output(result_msg_fmt=pretty_actions))
+    def actions(self) -> Dict[str, ActionDescriptor]:
+        """Return available actions."""
+        return self._actions
+
+    @command()
+    def sensors(self) -> Dict[str, SensorDescriptor]:
+        """Return available sensors."""
+        return self._sensors
+
+    @command(default_output=format_output(result_msg_fmt=pretty_settings))
+    def settings(self) -> Dict[str, SettingDescriptor]:
+        """Return available settings."""
+        return self._settings
+
+    @property
+    def device_type(self) -> Optional[str]:
+        """Return device type."""
+        # TODO: this should be probably mapped to an enum
+        if self._miot_model is not None:
+            return self._miot_model.urn.type
+        return None
+
+    @classmethod
+    def get_device_group(cls):
+        """Return device command group.
+
+        TODO: insert the actions from the model for better click integration
+        """
+        return super().get_device_group()

--- a/miio/miot_device.py
+++ b/miio/miot_device.py
@@ -77,9 +77,6 @@ class MiotDevice(Device):
             ip, token, start_id, debug, lazy_discover, timeout, model=model
         )
 
-        if mapping is None and not hasattr(self, "mapping") and not self._mappings:
-            _LOGGER.warning("Neither the class nor the parameter defines the mapping")
-
         if mapping is not None:
             self.mapping = mapping
 

--- a/miio/miot_models.py
+++ b/miio/miot_models.py
@@ -39,8 +39,13 @@ class URN(BaseModel):
             version=version,
         )
 
+    @property
+    def urn_string(self) -> str:
+        """Return string presentation of the URN."""
+        return f"urn:{self.namespace}:{self.type}:{self.name}:{self.internal_id}:{self.model}:{self.version}"
+
     def __repr__(self):
-        return f"<URN urn:{self.namespace}:{self.type}:{self.name}:{self.internal_id}:{self.model}:{self.version} parent:{self.parent_urn}>"
+        return f"<URN {self.urn_string} parent:{self.parent_urn}>"
 
 
 class MiotFormat(type):

--- a/miio/tests/test_devicefactory.py
+++ b/miio/tests/test_devicefactory.py
@@ -1,6 +1,6 @@
 import pytest
 
-from miio import Device, DeviceFactory, Gateway, GenericMiot, MiotDevice
+from miio import Device, DeviceFactory, DeviceInfo, Gateway, GenericMiot, MiotDevice
 
 DEVICE_CLASSES = Device.__subclasses__() + MiotDevice.__subclasses__()  # type: ignore
 DEVICE_CLASSES.remove(MiotDevice)
@@ -39,3 +39,42 @@ def test_device_class_for_wildcard():
 def test_device_class_for_model_unknown():
     """Test that unknown model returns genericmiot."""
     assert DeviceFactory.class_for_model("foo.foo.xyz.invalid") == GenericMiot
+
+
+@pytest.mark.parametrize("cls", DEVICE_CLASSES)
+@pytest.mark.parametrize("force_model", [True, False])
+def test_create(cls, force_model, mocker):
+    """Test create for both forced and autodetected models."""
+    mocker.patch("miio.Device.send")
+
+    model = None
+    first_supported_model = next(iter(cls.supported_models))
+    if force_model:
+        model = first_supported_model
+
+    dummy_info = DeviceInfo({"model": first_supported_model})
+    info = mocker.patch("miio.Device.info", return_value=dummy_info)
+
+    device = DeviceFactory.create("127.0.0.1", 32 * "0", model=model)
+    device_class = DeviceFactory.class_for_model(device.model)
+    assert isinstance(device, device_class)
+
+    if force_model:
+        info.assert_not_called()
+    else:
+        info.assert_called()
+
+
+@pytest.mark.parametrize("cls", DEVICE_CLASSES)
+def test_create_force_miot(cls, mocker):
+    """Test that force_generic_miot works."""
+    mocker.patch("miio.Device.send")
+    mocker.patch("miio.Device.info")
+    class_for_model = mocker.patch("miio.DeviceFactory.class_for_model")
+
+    assert isinstance(
+        DeviceFactory.create("127.0.0.1", 32 * "0", force_generic_miot=True),
+        GenericMiot,
+    )
+
+    class_for_model.assert_not_called()

--- a/miio/tests/test_devicefactory.py
+++ b/miio/tests/test_devicefactory.py
@@ -1,6 +1,6 @@
 import pytest
 
-from miio import Device, DeviceException, DeviceFactory, Gateway, MiotDevice
+from miio import Device, DeviceFactory, Gateway, GenericMiot, MiotDevice
 
 DEVICE_CLASSES = Device.__subclasses__() + MiotDevice.__subclasses__()  # type: ignore
 DEVICE_CLASSES.remove(MiotDevice)
@@ -37,6 +37,5 @@ def test_device_class_for_wildcard():
 
 
 def test_device_class_for_model_unknown():
-    """Test that unknown model raises an exception."""
-    with pytest.raises(DeviceException):
-        DeviceFactory.class_for_model("foo.foo.xyz")
+    """Test that unknown model returns genericmiot."""
+    assert DeviceFactory.class_for_model("foo.foo.xyz.invalid") == GenericMiot

--- a/miio/tests/test_miot_models.py
+++ b/miio/tests/test_miot_models.py
@@ -13,6 +13,42 @@ from miio.miot_models import (
     MiotService,
 )
 
+DUMMY_SERVICE = """
+    {
+        "iid": 1,
+        "description": "test service",
+        "type": "urn:miot-spec-v2:service:device-information:00000001:dummy:1",
+        "properties": [
+        {
+            "iid": 4,
+            "type": "urn:miot-spec-v2:property:firmware-revision:00000005:dummy:1",
+            "description": "Current Firmware Version",
+            "format": "string",
+            "access": [
+              "read"
+            ]
+        }
+        ],
+        "actions": [
+        {
+            "iid": 1,
+            "type": "urn:miot-spec-v2:action:start-sweep:00000004:dummy:1",
+            "description": "Start Sweep",
+            "in": [],
+            "out": []
+        }
+        ],
+        "events": [
+        {
+            "iid": 1,
+            "type": "urn:miot-spec-v2:event:low-battery:00000003:dummy:1",
+            "description": "Low Battery",
+            "arguments": []
+        }
+        ]
+    }
+"""
+
 
 def test_enum():
     """Test that enum parsing works."""
@@ -117,6 +153,32 @@ def test_service():
     assert serv.actions == []
     assert serv.properties == []
     assert serv.events == []
+
+
+@pytest.mark.parametrize("entity_type", ["actions", "properties", "events"])
+def test_service_back_references(entity_type):
+    """Check that backrefs are created correctly for properties, actions, and events."""
+    serv = MiotService.parse_raw(DUMMY_SERVICE)
+    assert serv.siid == 1
+    assert serv.urn.type == "service"
+
+    entities = getattr(serv, entity_type)
+    assert len(entities) == 1
+    entity_to_test = entities[0]
+
+    assert entity_to_test.service.siid == serv.siid
+
+
+@pytest.mark.parametrize("entity_type", ["actions", "properties", "events"])
+def test_entity_names(entity_type):
+    """Check that entity name consists of service name and entity's plain name."""
+    serv = MiotService.parse_raw(DUMMY_SERVICE)
+
+    entities = getattr(serv, entity_type)
+    assert len(entities) == 1
+    entity_to_test = entities[0]
+
+    assert entity_to_test.name == f"{serv.name}:{entity_to_test.plain_name}"
 
 
 def test_event():

--- a/miio/tests/test_miot_models.py
+++ b/miio/tests/test_miot_models.py
@@ -98,8 +98,9 @@ def test_urn():
     assert urn.model == "dummy.model"
     assert urn.version == 1
 
-    # Check that the serialization works, too
-    assert repr(urn) == urn_string
+    # Check that the serialization works
+    assert urn.urn_string == urn_string
+    assert repr(urn) == f"<URN {urn_string} parent:None>"
 
 
 def test_service():

--- a/miio/tests/test_miotdevice.py
+++ b/miio/tests/test_miotdevice.py
@@ -3,6 +3,7 @@ from unittest.mock import ANY
 import pytest
 
 from miio import Huizuo, MiotDevice
+from miio.integrations.genericmiot import GenericMiot
 from miio.miot_device import MiotValueType, _filter_request_fields
 
 MIOT_DEVICES = MiotDevice.__subclasses__()
@@ -17,16 +18,9 @@ def dev(module_mocker):
     device = MiotDevice(
         "127.0.0.1", "68ffffffffffffffffffffffffffffff", mapping=DUMMY_MAPPING
     )
-    device._model = "testmodel"
+    device._model = "test.model"
     module_mocker.patch.object(device, "send")
     return device
-
-
-def test_missing_mapping(caplog):
-    """Make sure ctor raises exception if neither class nor parameter defines the
-    mapping."""
-    _ = MiotDevice("127.0.0.1", "68ffffffffffffffffffffffffffffff")
-    assert "Neither the class nor the parameter defines the mapping" in caplog.text
 
 
 def test_ctor_mapping():
@@ -115,13 +109,13 @@ def test_call_action_by(dev):
 @pytest.mark.parametrize(
     "model,expected_mapping,expected_log",
     [
-        ("some_model", {"x": {"y": 1}}, ""),
-        ("unknown_model", {"x": {"y": 1}}, "Unable to find mapping"),
+        ("some.model", {"x": {"y": 1}}, ""),
+        ("unknown.model", {"x": {"y": 1}}, "Unable to find mapping"),
     ],
 )
 def test_get_mapping(dev, caplog, model, expected_mapping, expected_log):
     """Test _get_mapping logic for fallbacks."""
-    dev._mappings["some_model"] = {"x": {"y": 1}}
+    dev._mappings["some.model"] = {"x": {"y": 1}}
     dev._model = model
     assert dev._get_mapping() == expected_mapping
 
@@ -145,6 +139,9 @@ def test_mapping_deprecation(cls):
 @pytest.mark.parametrize("cls", MIOT_DEVICES)
 def test_mapping_structure(cls):
     """Check that mappings are structured correctly."""
+    if cls == GenericMiot:
+        pytest.skip("Skipping genericmiot as it provides no mapping")
+
     assert cls._mappings
 
     model, contents = next(iter(cls._mappings.items()))
@@ -163,13 +160,15 @@ def test_mapping_structure(cls):
 @pytest.mark.parametrize("cls", MIOT_DEVICES)
 def test_supported_models(cls):
     assert cls.supported_models == list(cls._mappings.keys())
+    if cls == GenericMiot:
+        pytest.skip("Skipping genericmiot as it uses supported_models for now")
 
     # make sure that that _supported_models is not defined
     assert not cls._supported_models
 
 
 def test_call_action(dev):
-    dev._mappings["testmodel"] = {"test_action": {"siid": 1, "aiid": 1}}
+    dev._mappings["test.model"] = {"test_action": {"siid": 1, "aiid": 1}}
 
     dev.call_action("test_action")
 
@@ -188,7 +187,7 @@ def test_call_action(dev):
 def test_get_properties_for_mapping_readables(mocker, dev, props, included_in_request):
     base_props = {"readable_property": {"siid": 1, "piid": 1}}
     base_request = [{"did": k, **v} for k, v in base_props.items()]
-    dev._mappings["testmodel"] = mapping = {
+    dev._mappings["test.model"] = mapping = {
         **base_props,
         "property_under_test": {"siid": 1, "piid": 2, **props},
     }


### PR DESCRIPTION
## Foreword

* **If you are using the `miiocli` tool or the library to control your devices:** it would be appreciated if you could test if this is working fine for you.
* **If you are using homeassistant and arrived here as this PR was marked to close your issue**:  you need to wait a bit longer until this code is ready to be released.


## Description

This PR adds a new integration, `genericmiot`, that uses the miotspec files to provide support for all miot devices that can be controlled over local network.
The basic functionality is implemented and has been tested to work on a Mi Smart LED Bulb (Warm White) (`yeelink.light.mono6`) light and on different simulated devices.

This PR *does not* implement sending commands over the cloud interface, which may be necessary on some devices to function.
If you want to test or help with this, please read read further :-)

## Current functionality
* Obtaining status (`status` command)
* Changing settings (`settings`, `set` commands)
* Executing simple actions (`actions`, `call_action` commands)

## TODO
* This PR will provide only a very basic support, more todos are listed in #1114 under "MiOT support"

## Instructions to test
1. You can either test against a simulator or a real device:

    * 1a. To test against a simulated device, use the miot-simulator located under the devtools command:
    ```
    miiocli -d devtools miot-simulator --model <model> # e.g., dreame.vacuum.p2140p
    ```

    * 1b. To test against a real device, obtain the token and the address
    ```
    miiocli cloud list
    ```

3. Export the address and token to avoid repeating `--ip` and `--token` for every command. The examples below are after doing these two exports: 
```
export MIIO_GENERICMIOT_IP=127.0.0.1
export MIIO_GENERICMIOT_TOKEN=00000000000000000000000000000000
```

4. Try if the status is being reported correctly (following commands are tested against a simulated dreame vacuum mentioned above:
```
miiocli genericmiot status

Status (vacuum:status): Paused (value: 3) (from: Sweeping (1), Idle (2), Paused (3), Error (4), Go Charging (5), Charging (6), Mopping (7))
Device Fault (vacuum:fault): 10  (min: 0, max: 100, step: 1)
[S] Mode (vacuum:mode): Strong (value: 2) (from: Silent (0), Basic (1), Strong (2), Full Speed (3))
Battery Level (battery:battery-level): 10 % (min: 0, max: 100, step: 1)
Charging State (battery:charging-state): Charging (value: 1) (from: Charging (1), Not Charging (2), Go Charging (5))
Brush Left Time (brush-cleaner:brush-left-time): 1 day, 17:00:00 (min: 0, max: 200, step: 1)
Brush Life Level (brush-cleaner:brush-life-level): 16 % (min: 0, max: 100, step: 1)
Filter Life Level (filter:filter-life-level): 48 % (min: 0, max: 100, step: 1)
Filter Left Time (filter:filter-left-time): 3 days, 22:00:00 (min: 0, max: 150, step: 1)
工作模式 (vacuum-extend:work-mode): 2  (min: 0, max: 50, step: 1)
清扫时长 (vacuum-extend:cleaning-time): 3 days, 11:51:00 (min: 0, max: 32767, step: 1)
清扫面积 (vacuum-extend:cleaning-area): 17352  (min: 0, max: 32767, step: 1)
[S] 清扫模式 (vacuum-extend:cleaning-mode): 3 (value: 3) (from: 0 (0), 1 (1), 2 (2), 3 (3))
[S]  (vacuum-extend:mop-mode): 3  (min: 1, max: 3, step: 1)
水箱状态 (vacuum-extend:waterbox-status): 1 (value: 1) (from: 0 (0), 1 (1))
 (vacuum-extend:task-status): Notask (value: 0) (from: Notask (0), AutoClean (1), CustomClean (2), SelectAreanClean (3), SpotArea (4))
[S] break-point-restart (vacuum-extend:break-point-restart): 关闭 (value: 0) (from: 关闭 (0), 打开 (1))
[S] carpet-press (vacuum-extend:carpet-press): 关闭 (value: 0) (from: 关闭 (0), 打开 (1))
serial-number (vacuum-extend:serial-number): piid 14 
keep-sweeper-time (vacuum-extend:keep-sweeper-time): 338 days, 21:18:00 (min: -1, max: 1000000, step: 1)
faults (vacuum-extend:faults): piid 18 
[S] 使能 (do-not-disturb:enable): True
[S] 勿扰起始时间 (do-not-disturb:start-time): piid 2 
[S] 勿扰结束时间 (do-not-disturb:end-time): piid 3 
[S] 音量 (audio:volume): 19  (min: 0, max: 100, step: 1)
[S] 语音包id (audio:voice-packet-id): piid 2 
语音包切换时的状态 (audio:voice-change-state): piid 3 
主机时区获取 (time:time-zone): piid 1 
[S] timer-clean (time:timer-clean): piid 2 
首次清扫的开始时间 (clean-logs:first-clean-time): 2164597218  (min: 0, max: 4294967295, step: 1)
总清扫时间 (clean-logs:total-clean-time): 2044084 days, 21:41:00 (min: 0, max: 4294967295, step: 1)
总清扫次数 (clean-logs:total-clean-times): 3387871266  (min: 0, max: 4294967295, step: 1)
总清扫面积 (clean-logs:total-clean-area): 3821312175  (min: 0, max: 4294967295, step: 1)
[S] save-map-status (vslam-extend:save-map-status): 关闭 (value: 0) (from: 关闭 (0), 打开 (1))
```

5. The variables marked with `[S]` are settings (also accessible using `miiocli genericmiot settings`) that can be changed:
```
miiocli genericmiot set vacuum:mode 0  # set to silent

...
```

6. List actions:
```
miiocli genericmiot actions

vacuum:start-sweep              Start Sweep
vacuum:stop-sweeping            Stop Sweeping
battery:start-charge            Start Charge
brush-cleaner:reset-brush-life          Reset Brush Life
filter:reset-filter-life                Reset Filter Life
vacuum-extend:stop-clean                停止清扫（非暂停，停止清扫任务）
audio:position          定位我的机器人
audio:play-sound                试听语音
```

7. Invoking actions:
```
miiocli genericmiot call_action vacuum:start-sweep  # start cleaning
```

## Homeassistant support

The homeassistant support is currently very rudimentary, and implements only the base platforms (switch, button, select, sensor, binary_sensor, number, ..), but that will hopefully change in the near future. Here's how it is looking currently:

![image](https://user-images.githubusercontent.com/3705853/200456607-39fd4d5d-a042-41f0-b617-ec08fd508929.png)


**Help needed!**
If you are a developer and want to help, please feel free to contact me per e-mail or via discord.
The current code is living in the `entities_from_upstream` branch: https://github.com/rytilahti/home-assistant/tree/xiaomi_miio/feat/entities_from_upstream) – any help is welcome!

Below only links to close related issues and pull requests.
<details>
<summary>List of related issues and pull requests</summary>

Closes #1394
Closes #1550
Closes #1571
Closes #1300
Closes #870
Closes #1563
Closes #1217
Closes #1397
Closes #1434
Closes #1553
Closes #1544
Closes #1541
Closes #1418
Closes #1271
Closes #778
Closes #1513
Closes #1512
Closes #1330
Closes #1319
Closes #1273
Closes #1485
Closes #1455
Closes #1447
Closes #1441
Closes #1133
Closes #1428
Closes #1412
Closes #1375
Closes #1400
Closes #839
Closes #1182
Closes #1338
Closes #812
Closes #1326
Closes #844
Closes #1162
Closes #1267
Closes #1218
Closes  #1283
Closes #913
Closes #1209
Closes #1001
Closes #1061
Closes #835
Closes #974
Closes #896
Closes #889
Closes #837
Closes #618
Closes #901

Obsoletes and closes #672
Obsoletes and closes #1254
Obsoletes and closes #1029
Obsoletes and closes #1019
</details>