### PR TITLE
Update decorators

### DIFF
--- a/miio/devicestatus.py
+++ b/miio/devicestatus.py
@@ -2,16 +2,7 @@ import inspect
 import logging
 import warnings
 from enum import Enum
-from typing import (
-    Callable,
-    Dict,
-    Optional,
-    Type,
-    Union,
-    get_args,
-    get_origin,
-    get_type_hints,
-)
+from typing import Dict, Optional, Type, Union, get_args, get_origin, get_type_hints
 
 from .descriptors import (
     BooleanSettingDescriptor,
@@ -131,7 +122,7 @@ class DeviceStatus(metaclass=_StatusMeta):
         return getattr(self._embedded[embed], prop)
 
 
-def sensor(name: str, *, unit: str = "", **kwargs):
+def sensor(name: str, *, unit: Optional[str] = None, **kwargs):
     """Syntactic sugar to create SensorDescriptor objects.
 
     The information can be used by users of the library to programmatically find out what
@@ -143,7 +134,8 @@ def sensor(name: str, *, unit: str = "", **kwargs):
     """
 
     def decorator_sensor(func):
-        property_name = func.__name__
+        property_name = str(func.__name__)
+        qualified_name = str(func.__qualname__)
 
         def _sensor_type_for_return_type(func):
             rtype = get_type_hints(func).get("return")
@@ -157,8 +149,8 @@ def sensor(name: str, *, unit: str = "", **kwargs):
 
         sensor_type = _sensor_type_for_return_type(func)
         descriptor = SensorDescriptor(
-            id=str(property_name),
-            property=str(property_name),
+            id=qualified_name,
+            property=property_name,
             name=name,
             unit=unit,
             type=sensor_type,
@@ -174,7 +166,6 @@ def sensor(name: str, *, unit: str = "", **kwargs):
 def setting(
     name: str,
     *,
-    setter: Optional[Callable] = None,
     setter_name: Optional[str] = None,
     unit: Optional[str] = None,
     min_value: Optional[int] = None,
@@ -196,14 +187,15 @@ def setting(
     """
 
     def decorator_setting(func):
-        property_name = func.__name__
+        property_name = str(func.__name__)
+        qualified_name = str(func.__qualname__)
 
-        if setter is None and setter_name is None:
-            raise Exception("Either setter or setter_name needs to be defined")
+        if setter_name is None:
+            raise Exception("Setter_name needs to be defined")
 
         common_values = {
-            "id": str(property_name),
-            "property": str(property_name),
+            "id": qualified_name,
+            "property": property_name,
             "name": name,
             "unit": unit,
             "setter": setter,

--- a/miio/devicestatus.py
+++ b/miio/devicestatus.py
@@ -198,7 +198,6 @@ def setting(
             "property": property_name,
             "name": name,
             "unit": unit,
-            "setter": setter,
             "setter_name": setter_name,
             "extras": kwargs,
         }


### PR DESCRIPTION
- set the id to the qualified_name instead of only the function name (in order to prevent unique_id collisions in HomeAssistant for example with DNDStatus.start and CleaningDetails.start)
- fix sensor unit beeing set to "" instead of None (HomeAssistant default)
- remove setter input from setting decorator, since it will not work to put in a function directly in the decorator since the class object has not yet been created. Therefore always the setter_name schould be used and the binding of the setter methods schould take place when the class object gets created.