### PR TITLE
Use __qualname__ to make ids unique for settings and sensors

### DIFF
--- a/miio/devicestatus.py
+++ b/miio/devicestatus.py
@@ -143,7 +143,8 @@ def sensor(name: str, *, unit: str = "", **kwargs):
     """
 
     def decorator_sensor(func):
-        property_name = func.__name__
+        property_name = str(func.__name__)
+        qualified_name = str(func.__qualname__)
 
         def _sensor_type_for_return_type(func):
             rtype = get_type_hints(func).get("return")
@@ -157,8 +158,8 @@ def sensor(name: str, *, unit: str = "", **kwargs):
 
         sensor_type = _sensor_type_for_return_type(func)
         descriptor = SensorDescriptor(
-            id=str(property_name),
-            property=str(property_name),
+            id=qualified_name,
+            property=property_name,
             name=name,
             unit=unit,
             type=sensor_type,
@@ -196,14 +197,15 @@ def setting(
     """
 
     def decorator_setting(func):
-        property_name = func.__name__
+        property_name = str(func.__name__)
+        qualified_name = str(func.__qualname__)
 
         if setter is None and setter_name is None:
             raise Exception("Either setter or setter_name needs to be defined")
 
         common_values = {
-            "id": str(property_name),
-            "property": str(property_name),
+            "id": qualified_name,
+            "property": property_name,
             "name": name,
             "unit": unit,
             "setter": setter,


### PR DESCRIPTION
Split out from https://github.com/rytilahti/python-miio/pull/1586

set the id to the qualified_name instead of only the function name (in order to prevent unique_id collisions in HomeAssistant for example with DNDStatus.start and CleaningDetails.start)