### PR TITLE
default unit to None in sensor decorator

### DIFF
--- a/miio/devicestatus.py
+++ b/miio/devicestatus.py
@@ -131,7 +131,7 @@ class DeviceStatus(metaclass=_StatusMeta):
         return getattr(self._embedded[embed], prop)
 
 
-def sensor(name: str, *, unit: str = "", **kwargs):
+def sensor(name: str, *, unit: Optional[str] = None, **kwargs):
     """Syntactic sugar to create SensorDescriptor objects.
 
     The information can be used by users of the library to programmatically find out what


### PR DESCRIPTION
Split out from: https://github.com/rytilahti/python-miio/pull/1586
fix sensor unit beeing set to "" instead of None (HomeAssistant default)