### PR TITLE
Raise exception on not-implemented @setting(setter)

### DIFF
--- a/miio/devicestatus.py
+++ b/miio/devicestatus.py
@@ -199,7 +199,9 @@ def setting(
         property_name = func.__name__
 
         if setter is None and setter_name is None:
-            raise Exception("Either setter or setter_name needs to be defined")
+            raise Exception("setter_name needs to be defined")
+        if setter_name is None:
+            raise Exception("setter not yet implemented, use setter_name instead")
 
         common_values = {
             "id": str(property_name),

--- a/miio/devicestatus.py
+++ b/miio/devicestatus.py
@@ -201,7 +201,7 @@ def setting(
         if setter is None and setter_name is None:
             raise Exception("setter_name needs to be defined")
         if setter_name is None:
-            raise Exception("setter not yet implemented, use setter_name instead")
+            raise NotImplementedError("setter not yet implemented, use setter_name instead")
 
         common_values = {
             "id": str(property_name),

--- a/miio/devicestatus.py
+++ b/miio/devicestatus.py
@@ -201,7 +201,9 @@ def setting(
         if setter is None and setter_name is None:
             raise Exception("setter_name needs to be defined")
         if setter_name is None:
-            raise NotImplementedError("setter not yet implemented, use setter_name instead")
+            raise NotImplementedError(
+                "setter not yet implemented, use setter_name instead"
+            )
 
         common_values = {
             "id": str(property_name),


### PR DESCRIPTION
Split out from https://github.com/rytilahti/python-miio/pull/1586
warn for setter input from setting decorator, since it will not work to put in a function directly in the decorator since the class object has not yet been created. Therefore always the setter_name schould be used and the binding of the setter methods schould take place when the class object gets created.