### PR TITLE
Use type instead of string for SensorDescriptor type

### DIFF
--- a/miio/descriptors.py
+++ b/miio/descriptors.py
@@ -38,7 +38,7 @@ class SensorDescriptor:
     """
 
     id: str
-    type: str
+    type: type
     name: str
     property: str
     unit: Optional[str] = None

--- a/miio/devicestatus.py
+++ b/miio/devicestatus.py
@@ -151,10 +151,7 @@ def sensor(name: str, *, unit: Optional[str] = None, **kwargs):
             if get_origin(rtype) is Union:  # Unwrap Optional[]
                 rtype, _ = get_args(rtype)
 
-            if rtype == bool:
-                return "binary"
-            else:
-                return "sensor"
+            return rtype
 
         sensor_type = _sensor_type_for_return_type(func)
         descriptor = SensorDescriptor(


### PR DESCRIPTION
The descriptor reports now the return type of the property instead of artificial "sensor" or "binary_sensor", leaving it to the downstream to handle it as they wish.