### PR TITLE
Update pre-commit url for flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     - id: docformatter
       args: [--in-place, --wrap-summaries, '88', --wrap-descriptions, '88']
 
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/pycqa/flake8
   rev: 3.9.2
   hooks:
   - id: flake8


### PR DESCRIPTION
Flake8 has moved to github, this fixes the build.