### PR TITLE
Off fan speed for Roborock S7

### DIFF
--- a/miio/integrations/vacuum/roborock/vacuum_enums.py
+++ b/miio/integrations/vacuum/roborock/vacuum_enums.py
@@ -50,6 +50,7 @@ class FanspeedE2(FanspeedEnum):
 
 
 class FanspeedS7(FanspeedEnum):
+    Off = 105
     Silent = 101
     Standard = 102
     Medium = 103


### PR DESCRIPTION
The Roborock S7 MaxV includes the Off fan speed, but the S7 does not. That speed is also valid for the S7 (it can only use the mop too). Checked with `firmware 4.3.5_1578`.