### PR TITLE
Add range_attribute parameter to NumberSettingDescriptor

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -316,12 +316,28 @@ Numerical Settings
 ^^^^^^^^^^^^^^^^^^
 
 The number descriptor allows defining a range of values and information about the steps.
-The *max_value* is the only mandatory parameter. If not given, *min_value* defaults to ``0`` and *steps* to ``1``.
+*range_attribute* can be used to define an attribute that is used to read the definitions,
+which is useful when the values depend on a device model.
+
+.. code-block::
+
+    class ExampleStatus(DeviceStatus):
+
+        @property
+        @setting(name="Color temperature", range_attribute="color_temperature_range")
+        def colortemp(): ...
+
+    class ExampleDevice(Device):
+        def color_temperature_range() -> ValidSettingRange:
+            return ValidSettingRange(0, 100, 5)
+
+Alternatively, *min_value*, *max_value*, and *step* can be used.
+The *max_value* is the only mandatory parameter. If not given, *min_value* defaults to ``0`` and *step* to ``1``.
 
 .. code-block::
 
     @property
-    @setting(name="Fan Speed", min_value=0, max_value=100, steps=5, setter_name="set_fan_speed")
+    @setting(name="Fan Speed", min_value=0, max_value=100, step=5, setter_name="set_fan_speed")
     def fan_speed(self) -> int:
         """Return the current fan speed."""
 

--- a/miio/descriptors.py
+++ b/miio/descriptors.py
@@ -17,6 +17,15 @@ import attr
 
 
 @attr.s(auto_attribs=True)
+class ValidSettingRange:
+    """Describes a valid input range for a setting."""
+
+    min_value: int
+    max_value: int
+    step: int = 1
+
+
+@attr.s(auto_attribs=True)
 class ActionDescriptor:
     """Describes a button exposed by the device."""
 
@@ -93,9 +102,14 @@ class EnumSettingDescriptor(SettingDescriptor):
 
 @attr.s(auto_attribs=True, kw_only=True)
 class NumberSettingDescriptor(SettingDescriptor):
-    """Presents a settable, numerical value."""
+    """Presents a settable, numerical value.
+
+    If `range_attribute` is set, the named property that should return
+    :class:ValidSettingRange will be used to obtain {min,max}_value and step.
+    """
 
     min_value: int
     max_value: int
     step: int
+    range_attribute: Optional[str] = attr.ib(default=None)
     type: SettingType = SettingType.Number

--- a/miio/device.py
+++ b/miio/device.py
@@ -1,7 +1,7 @@
 import logging
 from enum import Enum
 from inspect import getmembers
-from typing import Any, Dict, List, Optional, Union  # noqa: F401
+from typing import Any, Dict, List, Optional, Union, cast  # noqa: F401
 
 import click
 
@@ -9,8 +9,10 @@ from .click_common import DeviceGroupMeta, LiteralParamType, command, format_out
 from .descriptors import (
     ActionDescriptor,
     EnumSettingDescriptor,
+    NumberSettingDescriptor,
     SensorDescriptor,
     SettingDescriptor,
+    SettingType,
 )
 from .deviceinfo import DeviceInfo
 from .devicestatus import DeviceStatus
@@ -279,6 +281,13 @@ class Device(metaclass=DeviceGroupMeta):
             ):
                 retrieve_choices_function = getattr(self, setting.choices_attribute)
                 setting.choices = retrieve_choices_function()  # This can do IO
+            if setting.type == SettingType.Number:
+                setting = cast(NumberSettingDescriptor, setting)
+                if setting.range_attribute is not None:
+                    range_def = getattr(self, setting.range_attribute)
+                    setting.min_value = range_def.min_value
+                    setting.max_value = range_def.max_value
+                    setting.step = range_def.step
 
         return settings
 

--- a/miio/devicestatus.py
+++ b/miio/devicestatus.py
@@ -179,6 +179,7 @@ def setting(
     min_value: Optional[int] = None,
     max_value: Optional[int] = None,
     step: Optional[int] = None,
+    range_attribute: Optional[str] = None,
     choices: Optional[Type[Enum]] = None,
     choices_attribute: Optional[str] = None,
     type: Optional[SettingType] = None,
@@ -192,6 +193,8 @@ def setting(
     The interface is kept minimal, but you can pass any extra keyword arguments.
     These extras are made accessible over :attr:`~miio.descriptors.SettingDescriptor.extras`,
     and can be interpreted downstream users as they wish.
+
+    The `_attribute` suffixed options allow defining a property to be used to return the information dynamically.
     """
 
     def decorator_setting(func):
@@ -215,12 +218,13 @@ def setting(
             "extras": kwargs,
         }
 
-        if min_value or max_value:
+        if min_value or max_value or range_attribute:
             descriptor = NumberSettingDescriptor(
                 **common_values,
                 min_value=min_value or 0,
                 max_value=max_value,
                 step=step or 1,
+                range_attribute=range_attribute,
             )
         elif choices or choices_attribute:
             descriptor = EnumSettingDescriptor(

--- a/miio/integrations/light/yeelight/yeelight.py
+++ b/miio/integrations/light/yeelight/yeelight.py
@@ -26,16 +26,16 @@ SUBLIGHT_COLOR_MODE_PROP = {
 }
 
 
-def cli_format_yeelight(self) -> str:
+def cli_format_yeelight(result) -> str:
     """Return human readable sub lights string."""
-    s = f"Name: {self.name}\n"
-    s += f"Update default on change: {self.save_state_on_change}\n"
-    s += f"Delay in minute before off: {self.delay_off}\n"
-    if self.music_mode is not None:
-        s += f"Music mode: {self.music_mode}\n"
-    if self.developer_mode is not None:
-        s += f"Developer mode: {self.developer_mode}\n"
-    for light in self.lights:
+    s = f"Name: {result.name}\n"
+    s += f"Update default on change: {result.save_state_on_change}\n"
+    s += f"Delay in minute before off: {result.delay_off}\n"
+    if result.music_mode is not None:
+        s += f"Music mode: {result.music_mode}\n"
+    if result.developer_mode is not None:
+        s += f"Developer mode: {result.developer_mode}\n"
+    for light in result.lights:
         s += f"{light.type.name} light\n"
         s += f"   Power: {light.is_on}\n"
         s += f"   Brightness: {light.brightness}\n"
@@ -49,10 +49,10 @@ def cli_format_yeelight(self) -> str:
         s += f"   Color flowing mode: {light.color_flowing}\n"
         if light.color_flowing:
             s += f"   Color flowing parameters: {light.color_flow_params}\n"
-    if self.moonlight_mode is not None:
+    if result.moonlight_mode is not None:
         s += "Moonlight\n"
-        s += f"   Is in mode: {self.moonlight_mode}\n"
-        s += f"   Moonlight mode brightness: {self.moonlight_mode_brightness}\n"
+        s += f"   Is in mode: {result.moonlight_mode}\n"
+        s += f"   Moonlight mode brightness: {result.moonlight_mode_brightness}\n"
     s += "\n"
     return s
 

--- a/miio/integrations/light/yeelight/yeelight.py
+++ b/miio/integrations/light/yeelight/yeelight.py
@@ -4,8 +4,9 @@ from typing import List, Optional, Tuple
 
 import click
 
-from miio import ColorTemperatureRange, LightInterface
+from miio import LightInterface
 from miio.click_common import command, format_output
+from miio.descriptors import ValidSettingRange
 from miio.device import Device, DeviceStatus
 from miio.devicestatus import sensor, setting
 from miio.utils import int_to_rgb, rgb_to_int
@@ -23,6 +24,37 @@ SUBLIGHT_COLOR_MODE_PROP = {
     YeelightSubLightType.Main: "color_mode",
     YeelightSubLightType.Background: "bg_lmode",
 }
+
+
+def cli_format_yeelight(self) -> str:
+    """Return human readable sub lights string."""
+    s = f"Name: {self.name}\n"
+    s += f"Update default on change: {self.save_state_on_change}\n"
+    s += f"Delay in minute before off: {self.delay_off}\n"
+    if self.music_mode is not None:
+        s += f"Music mode: {self.music_mode}\n"
+    if self.developer_mode is not None:
+        s += f"Developer mode: {self.developer_mode}\n"
+    for light in self.lights:
+        s += f"{light.type.name} light\n"
+        s += f"   Power: {light.is_on}\n"
+        s += f"   Brightness: {light.brightness}\n"
+        s += f"   Color mode: {light.color_mode}\n"
+        if light.color_mode == YeelightMode.RGB:
+            s += f"   RGB: {light.rgb}\n"
+        elif light.color_mode == YeelightMode.HSV:
+            s += f"   HSV: {light.hsv}\n"
+        else:
+            s += f"   Temperature: {light.color_temp}\n"
+        s += f"   Color flowing mode: {light.color_flowing}\n"
+        if light.color_flowing:
+            s += f"   Color flowing parameters: {light.color_flow_params}\n"
+    if self.moonlight_mode is not None:
+        s += "Moonlight\n"
+        s += f"   Is in mode: {self.moonlight_mode}\n"
+        s += f"   Moonlight mode brightness: {self.moonlight_mode_brightness}\n"
+    s += "\n"
+    return s
 
 
 class YeelightMode(IntEnum):
@@ -113,13 +145,19 @@ class YeelightStatus(DeviceStatus):
         self.data = data
 
     @property
-    @setting("Power", setter_name="set_power")
+    @setting("Power", setter_name="set_power", id="light:on")
     def is_on(self) -> bool:
         """Return whether the light is on or off."""
         return self.lights[0].is_on
 
     @property
-    @setting("Brightness", unit="%", setter_name="set_brightness", max_value=100)
+    @setting(
+        "Brightness",
+        unit="%",
+        setter_name="set_brightness",
+        max_value=100,
+        id="light:brightness",
+    )
     def brightness(self) -> int:
         """Return current brightness."""
         return self.lights[0].brightness
@@ -147,9 +185,13 @@ class YeelightStatus(DeviceStatus):
         return self.lights[0].hsv
 
     @property
-    @sensor(
-        "Color temperature", setter_name="set_color_temperature"
-    )  # TODO: we need to allow ranges by attribute to fix this
+    @setting(
+        "Color temperature",
+        setter_name="set_color_temperature",
+        range_attribute="color_temperature_range",
+        id="light:color-temp",
+        unit="kelvin",
+    )
     def color_temp(self) -> Optional[int]:
         """Return current color temperature, if applicable."""
         return self.lights[0].color_temp
@@ -233,37 +275,6 @@ class YeelightStatus(DeviceStatus):
             )
         return sub_lights
 
-    @property
-    def cli_format(self) -> str:
-        """Return human readable sub lights string."""
-        s = f"Name: {self.name}\n"
-        s += f"Update default on change: {self.save_state_on_change}\n"
-        s += f"Delay in minute before off: {self.delay_off}\n"
-        if self.music_mode is not None:
-            s += f"Music mode: {self.music_mode}\n"
-        if self.developer_mode is not None:
-            s += f"Developer mode: {self.developer_mode}\n"
-        for light in self.lights:
-            s += f"{light.type.name} light\n"
-            s += f"   Power: {light.is_on}\n"
-            s += f"   Brightness: {light.brightness}\n"
-            s += f"   Color mode: {light.color_mode}\n"
-            if light.color_mode == YeelightMode.RGB:
-                s += f"   RGB: {light.rgb}\n"
-            elif light.color_mode == YeelightMode.HSV:
-                s += f"   HSV: {light.hsv}\n"
-            else:
-                s += f"   Temperature: {light.color_temp}\n"
-            s += f"   Color flowing mode: {light.color_flowing}\n"
-            if light.color_flowing:
-                s += f"   Color flowing parameters: {light.color_flow_params}\n"
-        if self.moonlight_mode is not None:
-            s += "Moonlight\n"
-            s += f"   Is in mode: {self.moonlight_mode}\n"
-            s += f"   Moonlight mode brightness: {self.moonlight_mode_brightness}\n"
-        s += "\n"
-        return s
-
 
 class Yeelight(Device, LightInterface):
     """A rudimentary support for Yeelight bulbs.
@@ -294,9 +305,8 @@ class Yeelight(Device, LightInterface):
         self._model_info = Yeelight._spec_helper.get_model_info(self.model)
         self._light_type = YeelightSubLightType.Main
         self._light_info = self._model_info.lamps[self._light_type]
-        self._color_temp_range = self._light_info.color_temp
 
-    @command(default_output=format_output("", "{result.cli_format}"))
+    @command(default_output=format_output("", result_msg_fmt=cli_format_yeelight))
     def status(self) -> YeelightStatus:
         """Retrieve properties."""
         properties = [
@@ -336,15 +346,16 @@ class Yeelight(Device, LightInterface):
         return YeelightStatus(dict(zip(properties, values)))
 
     @property
-    def valid_temperature_range(self) -> ColorTemperatureRange:
+    def valid_temperature_range(self) -> ValidSettingRange:
         """Return supported color temperature range."""
         _LOGGER.warning("Deprecated, use color_temperature_range instead")
-        return self._color_temp_range
+        return self.color_temperature_range
 
     @property
-    def color_temperature_range(self) -> Optional[ColorTemperatureRange]:
+    def color_temperature_range(self) -> ValidSettingRange:
         """Return supported color temperature range."""
-        return self._color_temp_range
+        temps = self._light_info.color_temp
+        return ValidSettingRange(min_value=temps[0], max_value=temps[1])
 
     @command(
         click.option("--transition", type=int, required=False, default=0),
@@ -415,8 +426,8 @@ class Yeelight(Device, LightInterface):
     def set_color_temperature(self, level, transition=500):
         """Set color temp in kelvin."""
         if (
-            level > self.valid_temperature_range.max
-            or level < self.valid_temperature_range.min
+            level > self.color_temperature_range.max_value
+            or level < self.color_temperature_range.min_value
         ):
             raise ValueError("Invalid color temperature: %s" % level)
         if transition > 0:

--- a/miio/interfaces/lightinterface.py
+++ b/miio/interfaces/lightinterface.py
@@ -2,6 +2,8 @@
 from abc import abstractmethod
 from typing import NamedTuple, Optional, Tuple
 
+from miio.descriptors import ValidSettingRange
+
 
 class ColorTemperatureRange(NamedTuple):
     """Color temperature range."""
@@ -22,7 +24,7 @@ class LightInterface:
         """Set the light brightness [0,100]."""
 
     @property
-    def color_temperature_range(self) -> Optional[ColorTemperatureRange]:
+    def color_temperature_range(self) -> Optional[ValidSettingRange]:
         """Return the color temperature range, if supported."""
         return None
 


### PR DESCRIPTION
Allows defining a property to use for obtaining the valid range for a setting that can be used for model-specific ranges (e.g., for color temperatures and fan angles).

This also converts yeelight and `LightInterface` to use it.