### PR TITLE
Fix inconsistent constructor signatures for device classes

### DIFF
--- a/miio/airconditioningcompanion.py
+++ b/miio/airconditioningcompanion.py
@@ -231,9 +231,12 @@ class AirConditioningCompanion(Device):
         start_id: int = 0,
         debug: int = 0,
         lazy_discover: bool = True,
+        timeout: int = None,
         model: str = MODEL_ACPARTNER_V2,
     ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
+        super().__init__(
+            ip, token, start_id, debug, lazy_discover, timeout=timeout, model=model
+        )
 
         if self.model not in MODELS_SUPPORTED:
             _LOGGER.error(

--- a/miio/airconditioningcompanionMCN.py
+++ b/miio/airconditioningcompanionMCN.py
@@ -106,11 +106,14 @@ class AirConditioningCompanionMcn02(Device):
         start_id: int = None,
         debug: int = 0,
         lazy_discover: bool = True,
+        timeout: int = None,
         model: str = MODEL_ACPARTNER_MCN02,
     ) -> None:
         if start_id is None:
             start_id = random.randint(0, 999)  # nosec
-        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
+        super().__init__(
+            ip, token, start_id, debug, lazy_discover, timeout=timeout, model=model
+        )
 
         if model != MODEL_ACPARTNER_MCN02:
             _LOGGER.error(

--- a/miio/gateway/gateway.py
+++ b/miio/gateway/gateway.py
@@ -94,11 +94,14 @@ class Gateway(Device):
         start_id: int = 0,
         debug: int = 0,
         lazy_discover: bool = True,
+        timeout: int = None,
         *,
         model: str = None,
         push_server=None,
     ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
+        super().__init__(
+            ip, token, start_id, debug, lazy_discover, timeout=timeout, model=model
+        )
 
         self._alarm = Alarm(parent=self)
         self._radio = Radio(parent=self)

--- a/miio/huizuo.py
+++ b/miio/huizuo.py
@@ -218,6 +218,7 @@ class Huizuo(MiotDevice):
         start_id: int = 0,
         debug: int = 0,
         lazy_discover: bool = True,
+        timeout: int = None,
         model: str = MODEL_HUIZUO_PIS123,
     ) -> None:
 
@@ -230,7 +231,9 @@ class Huizuo(MiotDevice):
         if model in MODELS_WITH_HEATER:
             self.mapping.update(_ADDITIONAL_MAPPING_HEATER)
 
-        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
+        super().__init__(
+            ip, token, start_id, debug, lazy_discover, timeout=timeout, model=model
+        )
 
         if model not in MODELS_SUPPORTED:
             self._model = MODEL_HUIZUO_PIS123

--- a/miio/integrations/fan/dmaker/fan.py
+++ b/miio/integrations/fan/dmaker/fan.py
@@ -100,9 +100,12 @@ class FanP5(Device):
         start_id: int = 0,
         debug: int = 0,
         lazy_discover: bool = True,
+        timeout: int = None,
         model: str = MODEL_FAN_P5,
     ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
+        super().__init__(
+            ip, token, start_id, debug, lazy_discover, timeout=timeout, model=model
+        )
 
     @command(
         default_output=format_output(

--- a/miio/integrations/fan/dmaker/fan_miot.py
+++ b/miio/integrations/fan/dmaker/fan_miot.py
@@ -411,9 +411,12 @@ class Fan1C(MiotDevice):
         start_id: int = 0,
         debug: int = 0,
         lazy_discover: bool = True,
+        timeout: int = None,
         model: str = MODEL_FAN_1C,
     ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
+        super().__init__(
+            ip, token, start_id, debug, lazy_discover, timeout=timeout, model=model
+        )
 
     @command(
         default_output=format_output(

--- a/miio/integrations/light/yeelight/yeelight.py
+++ b/miio/integrations/light/yeelight/yeelight.py
@@ -298,9 +298,12 @@ class Yeelight(Device, LightInterface):
         start_id: int = 0,
         debug: int = 0,
         lazy_discover: bool = True,
+        timeout: int = None,
         model: str = None,
     ) -> None:
-        super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
+        super().__init__(
+            ip, token, start_id, debug, lazy_discover, timeout=timeout, model=model
+        )
 
         self._model_info = Yeelight._spec_helper.get_model_info(self.model)
         self._light_type = YeelightSubLightType.Main

--- a/miio/integrations/vacuum/roborock/vacuum.py
+++ b/miio/integrations/vacuum/roborock/vacuum.py
@@ -126,10 +126,14 @@ class RoborockVacuum(Device, VacuumInterface):
         token: str = None,
         start_id: int = 0,
         debug: int = 0,
+        lazy_discover: bool = True,
+        timeout: int = None,
         *,
         model=None,
     ):
-        super().__init__(ip, token, start_id, debug, model=model)
+        super().__init__(
+            ip, token, start_id, debug, lazy_discover, timeout, model=model
+        )
         self.manual_seqnum = -1
 
     @command()

--- a/miio/integrations/vacuum/viomi/viomivacuum.py
+++ b/miio/integrations/vacuum/viomi/viomivacuum.py
@@ -598,11 +598,18 @@ class ViomiVacuum(Device, VacuumInterface):
         start_id: int = 0,
         debug: int = 0,
         lazy_discover: bool = False,
+        timeout: int = None,
         *,
         model: str = None,
     ) -> None:
         super().__init__(
-            ip, token, start_id, debug, lazy_discover=lazy_discover, model=model
+            ip,
+            token,
+            start_id,
+            debug,
+            lazy_discover=lazy_discover,
+            timeout=timeout,
+            model=model,
         )
         self.manual_seqnum = -1
         self._cache: Dict[str, Any] = {"edge_state": None, "rooms": {}, "maps": {}}

--- a/miio/tests/test_device.py
+++ b/miio/tests/test_device.py
@@ -146,3 +146,26 @@ def test_device_ctor_model(cls):
 def test_device_supported_models(cls):
     """Make sure that every device subclass has a non-empty supported models."""
     assert cls.supported_models
+
+
+@pytest.mark.parametrize("cls", DEVICE_CLASSES)
+def test_init_signature(cls, mocker):
+    """Make sure that __init__ of every device-inheriting class accepts the expected
+    parameters."""
+    mocker.patch("miio.Device.send")
+    parent_init = mocker.spy(Device, "__init__")
+    kwargs = {
+        "ip": "IP",
+        "token": None,
+        "start_id": 0,
+        "debug": False,
+        "lazy_discover": True,
+        "timeout": None,
+        "model": None,
+    }
+    cls(**kwargs)
+
+    # A rather hacky way to check for the arguments, we cannot use assert_called_with
+    # as some arguments are passed by inheriting classes using kwargs
+    total_args = len(parent_init.call_args.args) + len(parent_init.call_args.kwargs)
+    assert total_args == 8


### PR DESCRIPTION
This makes all `__init__()` parameters consistent for Device-derived classes.