### PR TITLE
Add metadata support for genericmiot

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,8 @@ repos:
   - id: end-of-file-fixer
   - id: check-docstring-first
   - id: check-yaml
+    # unsafe to workaround '!include' syntax
+    args: ['--unsafe']
   - id: check-json
   - id: check-toml
   - id: debug-statements

--- a/miio/integrations/genericmiot/meta.py
+++ b/miio/integrations/genericmiot/meta.py
@@ -1,0 +1,119 @@
+import logging
+import os
+from pathlib import Path
+from typing import Dict, Optional
+
+import yaml
+from pydantic import BaseModel
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Loader(yaml.SafeLoader):
+    """Loader to implement !include command.
+
+    From https://stackoverflow.com/a/9577670
+    """
+
+    def __init__(self, stream):
+        self._root = os.path.split(stream.name)[0]
+        super().__init__(stream)
+
+    def include(self, node):
+        filename = os.path.join(self._root, self.construct_scalar(node))
+
+        with open(filename) as f:
+            return yaml.load(f, Loader)  # nosec
+
+
+Loader.add_constructor("!include", Loader.include)
+
+
+class MetaBase(BaseModel):
+    """Base class for metadata definitions."""
+
+    description: str
+    icon: Optional[str] = None
+    device_class: Optional[str] = None  # homeassistant only
+
+    class Config:
+        extra = "forbid"
+
+
+class ActionMeta(MetaBase):
+    """Metadata for actions."""
+
+
+class PropertyMeta(MetaBase):
+    """Metadata for properties."""
+
+
+class ServiceMeta(MetaBase):
+    """Describes a service."""
+
+    action: Optional[Dict[str, ActionMeta]]
+    property: Optional[Dict[str, PropertyMeta]]
+    event: Optional[Dict]
+
+    class Config:
+        extra = "forbid"
+
+
+class Namespace(MetaBase):
+    fallback: Optional["Namespace"] = None  # fallback
+    services: Optional[Dict[str, ServiceMeta]]
+
+
+class Metadata(BaseModel):
+    namespaces: Dict[str, Namespace]
+
+    @classmethod
+    def load(cls, file: Path = None):
+        if file is None:
+            datadir = Path(__file__).resolve().parent
+            file = datadir / "metadata" / "extras.yaml"
+
+        _LOGGER.debug("Loading metadata file %s", file)
+        data = yaml.load(file.open(), Loader)  # nosec
+        definitions = cls(**data)
+
+        return definitions
+
+    def get_metadata(self, desc):
+        extras = {}
+        urn = desc.extras["urn"]
+        ns_name = urn.namespace
+        service = desc.service.name
+        type_ = urn.type
+        ns = self.namespaces.get(ns_name)
+        full_name = f"{ns_name}:{service}:{type_}:{urn.name}"
+        _LOGGER.debug("Looking metadata for %s", full_name)
+        if ns is not None:
+            serv = ns.services.get(service)
+            if serv is None:
+                _LOGGER.warning("Unable to find service: %s", service)
+                return extras
+
+            type_dict = getattr(serv, urn.type, None)
+            if type_dict is None:
+                _LOGGER.warning(
+                    "Unable to find type for service %s: %s", service, urn.type
+                )
+                return extras
+
+            # TODO: implement fallback to parent?
+            extras = type_dict.get(urn.name)
+            if extras is None:
+                _LOGGER.warning(
+                    "Unable to find extras for %s (%s)", urn.name, full_name
+                )
+            else:
+                if extras.icon is None:
+                    _LOGGER.warning("Icon missing for %s", full_name)
+                if extras.description is None:
+                    _LOGGER.warning("Description missing for %s", full_name)
+        else:
+            _LOGGER.warning("Namespace not found: %s", ns_name)
+            # TODO: implement fallback?
+
+        return extras

--- a/miio/integrations/genericmiot/meta.py
+++ b/miio/integrations/genericmiot/meta.py
@@ -68,7 +68,7 @@ class Metadata(BaseModel):
     namespaces: Dict[str, Namespace]
 
     @classmethod
-    def load(cls, file: Path = None):
+    def load(cls, file: Optional[Path] = None):
         if file is None:
             datadir = Path(__file__).resolve().parent
             file = datadir / "metadata" / "extras.yaml"

--- a/miio/integrations/genericmiot/metadata/dreamespec.yaml
+++ b/miio/integrations/genericmiot/metadata/dreamespec.yaml
@@ -1,0 +1,83 @@
+description: Metadata for dreame-specific services
+services:
+  vacuum-extend:
+    description: Extended vacuum services for dreame
+    action:
+      stop-clean:
+        description: Stop cleaning
+        icon: mdi:stop
+      position:
+        description: Locate robot
+    property:
+      work-mode:
+        description: Work mode
+      mop-mode:
+        description: Mop mode
+      waterbox-status:
+        description: Water box attached
+        icon: mdi:cup-water
+      cleaning-mode:
+        description: Cleaning mode
+      cleaning-time:
+        description: Cleaned time
+        icon: mdi:timer-sand
+      cleaning-area:
+        description: Cleaned area
+        icon: mdi:texture-box
+      serial-number:
+        description: Serial number
+      faults:
+        description: Error status
+        icon: mdi:alert
+
+  do-not-disturb:
+    description: DnD for dreame
+    icon: mdi:minus-circle-off
+    property:
+      enable:
+        description: DnD enabled
+        icon: mdi:minus-circle-off
+      start-time:
+        description: DnD start
+        icon: mdi:minus-circle-off
+      end-time:
+        description: DnD end
+        icon: mdi:minus-circle-off
+
+  audio:
+    description: Audio service for dreame
+    action:
+      position:
+        description: Find device
+        icon: mdi:target
+      play-sound:
+        description: Test sound level
+        icon: mdi:volume-medium
+    property:
+      volume:
+        description: Volume
+        icon: mdi:volume-medium
+      voice-packet-id:
+        description: Voice package id
+        icon: mdi:volume-medium
+
+  clean-logs:
+    description: Cleaning logs for dreame
+    property:
+      first-clean-time:
+        description: First cleaned
+      total-clean-time:
+        description: Total cleaning time
+        icon: mdi:timer-sand
+      total-clean-times:
+        description: Total cleaning count
+        icon: mdi:counter
+      total-clean-area:
+        description: Total cleaned area
+        icon: mdi:texture-box
+
+  time:
+    description: Time information for dreame
+    property:
+      time-zone:
+        description: Timezone

--- a/miio/integrations/genericmiot/metadata/extras.yaml
+++ b/miio/integrations/genericmiot/metadata/extras.yaml
@@ -1,0 +1,17 @@
+generic:
+  property:
+    cleaning-time:
+      description: Time cleaned
+      icon: mdi:timer-sand
+    cleaning-area:
+      description: Area cleaned
+      icon: mdi:texture-box
+    brightness:
+      description: Brightness
+      icon: mdi:brightness-6
+    battery:
+      device_class: battery
+      icon: mdi:battery
+namespaces:
+  miot-spec-v2: !include miotspec.yaml
+  dreame-spec: !include dreamespec.yaml

--- a/miio/integrations/genericmiot/metadata/miotspec.yaml
+++ b/miio/integrations/genericmiot/metadata/miotspec.yaml
@@ -1,0 +1,102 @@
+description: Metadata miot-spec-v2 namespace
+services:
+  battery:
+    description: Battery service
+    icon: mdi:battery
+    action:
+      start-charge:
+        description: Go charging
+    property:
+      charging-state:
+        description: Charging status
+      battery-level:
+        description: Battery level
+        icon: mdi:battery
+
+  filter:
+    description: Filter service
+    action:
+      reset-filter-life:
+        description: Reset filter life
+        icon: mdi:air-filter
+    property:
+      filter-life-level:
+        description: Filter life level
+        icon: mdi:air-filter
+      filter-left-time:
+        description: Filter time left
+        icon: mdi:air-filter
+
+  brush-cleaner:
+    description: Brush service
+    action:
+      reset-brush-life:
+        description: Reset brush life level
+        icon: mdi:brush
+    property:
+      brush-life-level:
+        description: Brush life level
+        icon: mdi:brush
+      brush-left-time:
+        description: Brush time left
+        icon: mdi:brush
+
+  identify:
+    description: Find device service
+    action:
+      identify:
+        description: Find device
+        icon: mdi:target
+
+  light:
+    description: Light service
+    action:
+      toggle:
+        description: Toggle
+        icon: mdi:toggle-switch
+      brightness-down:
+        description: Decrease brightness
+        icon: mdi:brightness-3
+      brightness-up:
+        description: Increase brightness
+        icon: mdi:brightness-4
+    property:
+      brightness:
+        description: Brightness
+        icon: mdi:brightness-6
+
+  vacuum:
+    description: Vacuum service
+    icon: mdi:vacuum
+    action:
+      start-sweep:
+        description: Start cleaning
+        icon: mdi:play
+      stop-sweeping:
+        description: Stop cleaning
+        icon: mdi:stop
+      start-mop:
+        description: Start mopping
+        icon: mdi:play
+      start-sweep-mop:
+        description: Start cleaning and mopping
+        icon: mdi:play
+      start-charge:
+        description: Return home
+        icon: mdi:home
+
+    property:
+      status:
+        description: Status
+      fault:
+        description: Error
+        icon: mdi:alert
+      mode:
+        description: Fan speed
+        icon: mdi:fan
+      cleaning-time:
+        description: Time cleaned
+        icon: mdi:timer-sand
+      cleaning-area:
+        description: Area cleaned
+        icon: mdi:texture-box

--- a/miio/miot_models.py
+++ b/miio/miot_models.py
@@ -119,6 +119,11 @@ class MiotBaseModel(BaseModel):
             return f"{self.service.name}:{self.urn.name}"  # type: ignore
         return "unitialized"
 
+    @property
+    def full_name(self) -> str:
+        """Returns full name including the namespace and type."""
+        return f"{self.urn.namespace}:{self.urn.type}:{self.name}"
+
 
 class MiotAction(MiotBaseModel):
     """Action presentation for miot."""


### PR DESCRIPTION
This PR is continuation for #1581 and improves genericmiot by adding support for defining metadata (e.g., description, icon) for miotspec entities.

The idea behind this PR is to have consolidated descriptions, icons, etc. for standard properties, actions, and settings no matter what is defined in the the miotspec file.

At the moment the following metadata can be defined:
* description (overrides the spec file given one)
* icon
* device_class

The structure for metadata files is:
```
<namespace>:
  services:
    <service_name>:
       action:
         <action_name>:
           # metadata
       property:
         <property_name>:
           # metadata
```
Example definition (namespace defined one level higher and thus not shown here):
```
description: Metadata miot-spec-v2 namespace
services:
  battery:
    description: Battery service
    icon: mdi:battery
    action:
      start-charge:
        description: Go charging
    property:
      charging-state:
        description: Charging status
      battery-level:
        description: Battery level
        icon: mdi:battery
```

The screenshot below shows what a simulated `dreame.vacuum.p2009` looks like in homeassistant (compare to the one in #1581).

![image](https://user-images.githubusercontent.com/3705853/205768097-58aa2c43-00bd-4459-91ef-bd7b7fce3fcb.png)

`miiocli status` output showing also items in Chinese that have no metadata defined:
```
Status (vacuum:status): Idle (value: 2) (from: Sweeping (1), Idle (2), Paused (3), Error (4), Go Charging (5), Charging (6), Mopping (7))
Error (vacuum:fault): 33  (min: 0, max: 100, step: 1)
[S] Fan speed (vacuum:mode): Full Speed (value: 3) (from: Silent (0), Basic (1), Strong (2), Full Speed (3))
Battery level (battery:battery-level): 8 % (min: 0, max: 100, step: 1)
Charging status (battery:charging-state): Charging (value: 1) (from: Charging (1), Not Charging (2), Go Charging (5))
Brush time left (brush-cleaner:brush-left-time): 4 days, 9:00:00 (min: 0, max: 200, step: 1)
Brush life level (brush-cleaner:brush-life-level): 85 % (min: 0, max: 100, step: 1)
Filter life level (filter:filter-life-level): 79 % (min: 0, max: 100, step: 1)
Filter time left (filter:filter-left-time): 2 days, 1:00:00 (min: 0, max: 150, step: 1)
Work mode (vacuum-extend:work-mode): 50  (min: 0, max: 50, step: 1)
Cleaned time (vacuum-extend:cleaning-time): 13:02:00 (min: 0, max: 32767, step: 1)
Cleaned area (vacuum-extend:cleaning-area): 18633  (min: 0, max: 32767, step: 1)
[S] Cleaning mode (vacuum-extend:cleaning-mode): 1 (value: 1) (from: 0 (0), 1 (1), 2 (2), 3 (3))
[S] Mop mode (vacuum-extend:mop-mode): 中 (value: 2) (from: 低 (1), 中 (2), 高 (3))
Water box attached (vacuum-extend:waterbox-status): 0 (value: 0) (from: 0 (0), 1 (1))
 (vacuum-extend:task-status): 0  (min: 0, max: 20, step: 1)
[S] break-point-restart (vacuum-extend:break-point-restart): 打开 (value: 1) (from: 关闭 (0), 打开 (1))
[S] carpet-press (vacuum-extend:carpet-press): 关闭 (value: 0) (from: 关闭 (0), 打开 (1))
Serial number (vacuum-extend:serial-number): piid 14 
[S] clean-rags-tip (vacuum-extend:clean-rags-tip): 0:48:00 (min: 0, max: 120, step: 1)
keep-sweeper-time (vacuum-extend:keep-sweeper-time): 446 days, 13:57:00 (min: -1, max: 1000000, step: 1)
Error status (vacuum-extend:faults): piid 18 
nation-matched (vacuum-extend:nation-matched): piid 19 None
relocation-status (vacuum-extend:relocation-status): 9806 None (min: 0, max: 1000000, step: 1)
[S] DnD enabled (do-not-disturb:enable): True
[S] DnD start (do-not-disturb:start-time): piid 2 
[S] DnD end (do-not-disturb:end-time): piid 3 
[S] mult-map-state (map:mult-map-state): Open (value: 1) (from: Close (0), Open (1))
mult-map-info (map:mult-map-info): piid 8 
[S] Volume (audio:volume): 90  (min: 0, max: 100, step: 1)
[S] Voice package id (audio:voice-packet-id): piid 2 
语音包切换时的状态 (audio:voice-change-state): piid 3 
Timezone (time:time-zone): piid 1 
[S] timer-clean (time:timer-clean): piid 2 
First cleaned (clean-logs:first-clean-time): 3324166495  (min: 0, max: 4294967295, step: 1)
Total cleaning time (clean-logs:total-clean-time): 1956346 days, 2:03:00 (min: 0, max: 4294967295, step: 1)
Total cleaning count (clean-logs:total-clean-times): 1271949570  (min: 0, max: 4294967295, step: 1)
Total cleaned area (clean-logs:total-clean-area): 3255108244  (min: 0, max: 4294967295, step: 1)
```