### PR TITLE
Use piid-siid instead of did for mapping genericmiot responses

### DIFF
--- a/miio/integrations/genericmiot/genericmiot.py
+++ b/miio/integrations/genericmiot/genericmiot.py
@@ -106,24 +106,14 @@ class GenericMiotStatus(DeviceStatus):
         return self._data[item]
 
     def property_dict(self) -> Dict[str, MiotProperty]:
-        """Return (siid, piid)-keyed dictionary of properties."""
+        """Return name-keyed dictionary of properties."""
         res = {}
 
-        # TODO: the device may not always report the did back correctly, see #1619
+        # We use (siid, piid) to locate the property as not all devices mirror the did in response
         for (siid, piid), value in self._data_by_siid_piid.items():
             prop = self._model.get_property_by_siid_piid(siid, piid)
             prop.value = value
             res[prop.name] = prop
-
-        """
-        for did, value in self._data.items():
-            self._model.get_property()
-
-            service, prop_name = did.split(":")
-            prop = self._model.get_property(service, prop_name)
-            prop.value = value
-            res[did] = prop
-        """
 
         return res
 


### PR DESCRIPTION
Some devices (like zhimi.heater.mc2) do not mirror the did back, so this converts to use the (siid, piid) combination for obtaining the property for generic miot responses.

Fixes #1619