### PR TITLE
Add mop dryer add-on of the S7 MaxV Ultra station

### DIFF
--- a/miio/integrations/vacuum/roborock/tests/test_vacuum.py
+++ b/miio/integrations/vacuum/roborock/tests/test_vacuum.py
@@ -41,70 +41,71 @@ class DummyVacuum(DummyDevice, RoborockVacuum):
         self._maps = None
         self._map_enum_cache = None
 
-        self.dummies = {}
-        self.dummies["consumables"] = [
-            {
-                "filter_work_time": 32454,
-                "sensor_dirty_time": 3798,
-                "side_brush_work_time": 32454,
-                "main_brush_work_time": 32454,
-                "strainer_work_times": 44,
-                "cleaning_brush_work_times": 44,
-            }
-        ]
-        self.dummies["clean_summary"] = [
-            174145,
-            2410150000,
-            82,
-            [
-                1488240000,
-                1488153600,
-                1488067200,
-                1487980800,
-                1487894400,
-                1487808000,
-                1487548800,
+        self.dummies = {
+            "consumables": [
+                {
+                    "filter_work_time": 32454,
+                    "sensor_dirty_time": 3798,
+                    "side_brush_work_time": 32454,
+                    "main_brush_work_time": 32454,
+                    "strainer_work_times": 44,
+                    "cleaning_brush_work_times": 44,
+                }
             ],
-        ]
-        self.dummies["dnd_timer"] = [
-            {
-                "enabled": 1,
-                "start_minute": 0,
-                "end_minute": 0,
-                "start_hour": 22,
-                "end_hour": 8,
-            }
-        ]
-        self.dummies["multi_maps"] = [
-            {
-                "max_multi_map": 4,
-                "max_bak_map": 1,
-                "multi_map_count": 3,
-                "map_info": [
-                    {
-                        "mapFlag": 0,
-                        "add_time": 1664448893,
-                        "length": 10,
-                        "name": "Downstairs",
-                        "bak_maps": [{"mapFlag": 4, "add_time": 1663577737}],
-                    },
-                    {
-                        "mapFlag": 1,
-                        "add_time": 1663580330,
-                        "length": 8,
-                        "name": "Upstairs",
-                        "bak_maps": [{"mapFlag": 5, "add_time": 1663577752}],
-                    },
-                    {
-                        "mapFlag": 2,
-                        "add_time": 1663580384,
-                        "length": 5,
-                        "name": "Attic",
-                        "bak_maps": [{"mapFlag": 6, "add_time": 1663577765}],
-                    },
+            "clean_summary": [
+                174145,
+                2410150000,
+                82,
+                [
+                    1488240000,
+                    1488153600,
+                    1488067200,
+                    1487980800,
+                    1487894400,
+                    1487808000,
+                    1487548800,
                 ],
-            }
-        ]
+            ],
+            "dnd_timer": [
+                {
+                    "enabled": 1,
+                    "start_minute": 0,
+                    "end_minute": 0,
+                    "start_hour": 22,
+                    "end_hour": 8,
+                }
+            ],
+            "multi_maps": [
+                {
+                    "max_multi_map": 4,
+                    "max_bak_map": 1,
+                    "multi_map_count": 3,
+                    "map_info": [
+                        {
+                            "mapFlag": 0,
+                            "add_time": 1664448893,
+                            "length": 10,
+                            "name": "Downstairs",
+                            "bak_maps": [{"mapFlag": 4, "add_time": 1663577737}],
+                        },
+                        {
+                            "mapFlag": 1,
+                            "add_time": 1663580330,
+                            "length": 8,
+                            "name": "Upstairs",
+                            "bak_maps": [{"mapFlag": 5, "add_time": 1663577752}],
+                        },
+                        {
+                            "mapFlag": 2,
+                            "add_time": 1663580384,
+                            "length": 5,
+                            "name": "Attic",
+                            "bak_maps": [{"mapFlag": 6, "add_time": 1663577765}],
+                        },
+                    ],
+                }
+            ],
+        }
 
         self.return_values = {
             "get_status": lambda x: [self.state],
@@ -446,7 +447,7 @@ class TestVacuum(TestCase):
     def test_mop_dryer_model_check(self):
         """Test Roborock S7 check when getting mop dryer status."""
         with pytest.raises(UnsupportedFeatureException):
-            self.device.mop_dryer_status()
+            self.device.mop_dryer_settings()
 
     def test_set_mop_dryer_enabled_model_check(self):
         """Test Roborock S7 check when setting mop dryer enabled."""
@@ -474,19 +475,30 @@ class DummyVacuumS7(DummyVacuum):
         super().__init__(args, kwargs)
 
         self._model = ROCKROBO_S7
-        self.state = self.state | {
-            "dry_status": 1,
-        }
-        self.return_values = self.return_values | {
-            "get_water_box_custom_mode": lambda x: [203],
-            "set_water_box_custom_mode": lambda x: [203],
-            "app_get_dryer_setting": lambda x: {
-                "status": 0,
-                "on": {"cliff_on": 1, "cliff_off": 1, "count": 10, "dry_time": 10800},
-                "off": {"cliff_on": 2, "cliff_off": 1, "count": 10},
+        self.state = {
+            **self.state,
+            **{
+                "dry_status": 1,
             },
-            "app_set_dryer_setting": lambda x: ["ok"],
-            "app_set_dryer_status": lambda x: ["ok"],
+        }
+        self.return_values = {
+            **self.return_values,
+            **{
+                "get_water_box_custom_mode": lambda x: [203],
+                "set_water_box_custom_mode": lambda x: [203],
+                "app_get_dryer_setting": lambda x: {
+                    "status": 0,
+                    "on": {
+                        "cliff_on": 1,
+                        "cliff_off": 1,
+                        "count": 10,
+                        "dry_time": 10800,
+                    },
+                    "off": {"cliff_on": 2, "cliff_off": 1, "count": 10},
+                },
+                "app_set_dryer_setting": lambda x: ["ok"],
+                "app_set_dryer_status": lambda x: ["ok"],
+            },
         }
 
 
@@ -505,9 +517,9 @@ class TestVacuumS7(TestCase):
         """Test setting mop intensity."""
         assert self.device.set_mop_intensity(MopIntensity.Intense)
 
-    def test_mop_dryer_status(self):
-        """Test getting mop dryer status."""
-        assert not self.device.mop_dryer_status().enabled
+    def test_mop_dryer_settings(self):
+        """Test getting mop dryer settings."""
+        assert not self.device.mop_dryer_settings().enabled
 
     def test_set_mop_dryer_enabled_model_check(self):
         """Test setting mop dryer enabled."""

--- a/miio/integrations/vacuum/roborock/tests/test_vacuum.py
+++ b/miio/integrations/vacuum/roborock/tests/test_vacuum.py
@@ -457,7 +457,7 @@ class TestVacuum(TestCase):
     def test_set_mop_dryer_dry_time_model_check(self):
         """Test Roborock S7 check when setting mop dryer dry time."""
         with pytest.raises(UnsupportedFeatureException):
-            self.device.set_mop_dryer_dry_time(dry_time=2)
+            self.device.set_mop_dryer_dry_time(dry_time_seconds=10800)
 
     def test_start_mop_drying_model_check(self):
         """Test Roborock S7 check when starting mop drying."""
@@ -528,15 +528,23 @@ class TestVacuumS7(TestCase):
 
     def test_mop_dryer_remaining_seconds(self):
         """Test getting mop dryer remaining seconds."""
-        assert self.device.status().mop_dryer_remaining_seconds == 3600
+        assert self.device.status().mop_dryer_remaining_seconds == datetime.timedelta(
+            seconds=3600
+        )
 
     def test_set_mop_dryer_enabled_model_check(self):
         """Test setting mop dryer enabled."""
-        assert self.device.set_mop_dryer_enabled(enabled=True)
+        with patch.object(self.device, "send", return_value=["ok"]) as mock_method:
+            assert self.device.set_mop_dryer_enabled(enabled=False)
+            mock_method.assert_called_once_with("app_set_dryer_setting", {"status": 0})
 
     def test_set_mop_dryer_dry_time_model_check(self):
         """Test setting mop dryer dry time."""
-        assert self.device.set_mop_dryer_dry_time(dry_time=2)
+        with patch.object(self.device, "send", return_value=["ok"]) as mock_method:
+            assert self.device.set_mop_dryer_dry_time(dry_time_seconds=14400)
+            mock_method.assert_called_once_with(
+                "app_set_dryer_setting", {"on": {"dry_time": 14400}}
+            )
 
     def test_start_mop_drying_model_check(self):
         """Test starting mop drying."""

--- a/miio/integrations/vacuum/roborock/tests/test_vacuum.py
+++ b/miio/integrations/vacuum/roborock/tests/test_vacuum.py
@@ -479,6 +479,7 @@ class DummyVacuumS7(DummyVacuum):
             **self.state,
             **{
                 "dry_status": 1,
+                "rdt": 3600,
             },
         }
         self.return_values = {
@@ -487,7 +488,7 @@ class DummyVacuumS7(DummyVacuum):
                 "get_water_box_custom_mode": lambda x: [203],
                 "set_water_box_custom_mode": lambda x: [203],
                 "app_get_dryer_setting": lambda x: {
-                    "status": 0,
+                    "status": 1,
                     "on": {
                         "cliff_on": 1,
                         "cliff_off": 1,
@@ -519,7 +520,15 @@ class TestVacuumS7(TestCase):
 
     def test_mop_dryer_settings(self):
         """Test getting mop dryer settings."""
-        assert not self.device.mop_dryer_settings().enabled
+        assert self.device.mop_dryer_settings().enabled
+
+    def test_mop_dryer_is_drying(self):
+        """Test getting mop dryer status."""
+        assert self.device.status().is_mop_drying
+
+    def test_mop_dryer_remaining_seconds(self):
+        """Test getting mop dryer remaining seconds."""
+        assert self.device.status().mop_dryer_remaining_seconds == 3600
 
     def test_set_mop_dryer_enabled_model_check(self):
         """Test setting mop dryer enabled."""

--- a/miio/integrations/vacuum/roborock/vacuum.py
+++ b/miio/integrations/vacuum/roborock/vacuum.py
@@ -965,11 +965,6 @@ class RoborockVacuum(Device, VacuumInterface):
         if self.model not in [ROCKROBO_S7, ROCKROBO_S7_MAXV]:
             raise UnsupportedFeatureException("Dryer not supported by %s", self.model)
 
-        # check if `dry_status` attribute is in status response
-        # this a good indication if the add-on has been installed
-        if self.status().is_mop_drying is None:
-            raise UnsupportedFeatureException("Mop dryer add-on not installed")
-
     @command()
     def mop_dryer_settings(self) -> MopDryerSettings:
         """Get mop dryer settings."""
@@ -983,11 +978,13 @@ class RoborockVacuum(Device, VacuumInterface):
         return self.send("app_set_dryer_setting", {"status": int(enabled)})[0] == "ok"
 
     @command(click.argument("dry_time", type=int))
-    def set_mop_dryer_dry_time(self, dry_time: int) -> bool:
+    def set_mop_dryer_dry_time(self, dry_time_seconds: int) -> bool:
         """Set mop dryer add-on dry time."""
         self._verify_mop_dryer_supported()
         return (
-            self.send("app_set_dryer_setting", {"on": {"dry_time": dry_time * 3600}})[0]
+            self.send("app_set_dryer_setting", {"on": {"dry_time": dry_time_seconds}})[
+                0
+            ]
             == "ok"
         )
 

--- a/miio/integrations/vacuum/roborock/vacuum.py
+++ b/miio/integrations/vacuum/roborock/vacuum.py
@@ -52,6 +52,7 @@ from .vacuumcontainers import (
     SoundStatus,
     Timer,
     VacuumStatus,
+    MopDryerStatus,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -957,6 +958,51 @@ class RoborockVacuum(Device, VacuumInterface):
     def set_child_lock(self, lock: bool) -> bool:
         """Set child lock setting."""
         return self.send("set_child_lock_status", {"lock_status": int(lock)})[0] == "ok"
+
+    def _verify_mop_dryer_supported(self) -> None:
+        """Checks if model supports mop dryer add-on."""
+        # dryer add-on is only supported by following models
+        if self.model not in [ROCKROBO_S7_MAXV]:
+            raise UnsupportedFeatureException(
+                "Dryer not supported by %s", self.model
+            )
+
+        # check if `dry_status` attribute is in status response
+        # this a good indication if the add-on has been installed
+        if not hasattr(self.status(), "dry_status"):
+            raise UnsupportedFeatureException("Mop dryer add-on not installed")
+
+    @command()
+    def mop_dryer_status(self) -> MopDryerStatus:
+        """Get mop dryer status."""
+        self._verify_mop_dryer_supported()
+        return MopDryerStatus(self.send("app_get_dryer_setting"), self.status())
+
+    @command(click.argument("enabled", type=bool))
+    def set_mop_dryer_enabled(self, enabled: bool) -> bool:
+        """Set mop dryer add-on enabled."""
+        self._verify_mop_dryer_supported()
+        return self.send("app_set_dryer_setting", {"status": int(enabled)})[0] == "ok"
+
+    @command(click.argument("dry_time", type=int))
+    def set_mop_dryer_dry_time(self, dry_time: int) -> bool:
+        """Set mop dryer add-on dry time."""
+        self._verify_mop_dryer_supported()
+        return self.send("app_set_dryer_setting", {"on": {"dry_time": dry_time * 3600}})[0] == "ok"
+
+    @command()
+    @action(name="Start mop drying", icon="mdi:tumble-dryer")
+    def start_mop_drying(self):
+        """Start mop drying."""
+        self._verify_mop_dryer_supported()
+        self.send("app_set_dryer_status", {"status": 1})
+
+    @command()
+    @action(name="Stop mop drying", icon="mdi:tumble-dryer")
+    def stop_mop_drying(self):
+        """Stop mop drying."""
+        self._verify_mop_dryer_supported()
+        self.send("app_set_dryer_status", {"status": 0})
 
     @classmethod
     def get_device_group(cls):

--- a/miio/integrations/vacuum/roborock/vacuum.py
+++ b/miio/integrations/vacuum/roborock/vacuum.py
@@ -971,8 +971,8 @@ class RoborockVacuum(Device, VacuumInterface):
             raise UnsupportedFeatureException("Mop dryer add-on not installed")
 
     @command()
-    def mop_dryer_status(self) -> MopDryerSettings:
-        """Get mop dryer status."""
+    def mop_dryer_settings(self) -> MopDryerSettings:
+        """Get mop dryer settings."""
         self._verify_mop_dryer_supported()
         return MopDryerSettings(self.send("app_get_dryer_setting"))
 

--- a/miio/integrations/vacuum/roborock/vacuumcontainers.py
+++ b/miio/integrations/vacuum/roborock/vacuumcontainers.py
@@ -953,3 +953,67 @@ class CarpetModeStatus(DeviceStatus):
     @property
     def current_integral(self) -> int:
         return self.data["current_integral"]
+
+
+class MopDryerStatus(DeviceStatus):
+    """Container for mop dryer add-on."""
+
+    def __init__(self, data: Dict[str, Any], status_data: Dict[str, Any]):
+        # {'status': 0, 'on': {'cliff_on': 1, 'cliff_off': 1, 'count': 10, 'dry_time': 10800},
+        # 'off': {'cliff_on': 2, 'cliff_off': 1, 'count': 10}}
+        self.data = data
+        self.status_data = status_data
+
+    @property
+    @setting(
+        "Mop dryer enabled",
+        setter_name="set_mop_dryer_enabled",
+        icon="mdi:tumble-dryer",
+        entity_category="config",
+        enabled_default=False,
+    )
+    def enabled(self) -> bool:
+        """Return if mop dryer is enabled."""
+        return self.data["status"] == "1"
+
+    @property
+    @setting(
+        "Mop dry time",
+        setter_name="set_mop_dryer_dry_time",
+        icon="mdi:fan",
+        unit="hour",
+        min_value=2,
+        max_value=4,
+        step=1,
+        entity_category="config",
+        enabled_default=False,
+    )
+    def dry_time(self) -> bool:
+        """Return mop dry time."""
+        return self.data["on"]["dry_time"] * 3600
+
+    @property
+    @sensor(
+        "Mop is drying",
+        icon="mdi:tumble-dryer",
+        entity_category="diagnostic",
+        enabled_default=False,
+    )
+    def is_drying(self) -> Optional[bool]:
+        """Return if mop drying is running."""
+        if "dry_status" in self.status_data:
+            return self.status_data["dry_status"] == 1
+        return None
+
+    @property
+    @sensor(
+        "Dryer remaining seconds",
+        unit="s",
+        entity_category="diagnostic",
+        enabled_default=False,
+    )
+    def remaining_seconds(self) -> Optional[int]:
+        """Return remaining mop drying seconds."""
+        if "rdt" in self.status_data:
+            return self.status_data["rdt"]
+        return None

--- a/miio/integrations/vacuum/roborock/vacuumcontainers.py
+++ b/miio/integrations/vacuum/roborock/vacuumcontainers.py
@@ -410,6 +410,32 @@ class VacuumStatus(VacuumDeviceStatus):
         """True if an error has occurred."""
         return self.error_code != 0
 
+    @property
+    @sensor(
+        "Mop is drying",
+        icon="mdi:tumble-dryer",
+        entity_category="diagnostic",
+        enabled_default=False,
+    )
+    def is_mop_drying(self) -> Optional[bool]:
+        """Return if mop drying is running."""
+        if "dry_status" in self.data:
+            return self.data["dry_status"] == 1
+        return None
+
+    @property
+    @sensor(
+        "Dryer remaining seconds",
+        unit="s",
+        entity_category="diagnostic",
+        enabled_default=False,
+    )
+    def mop_dryer_remaining_seconds(self) -> Optional[int]:
+        """Return remaining mop drying seconds."""
+        if "rdt" in self.data:
+            return self.data["rdt"]
+        return None
+
 
 class CleaningSummary(DeviceStatus):
     """Contains summarized information about available cleaning runs."""
@@ -955,14 +981,13 @@ class CarpetModeStatus(DeviceStatus):
         return self.data["current_integral"]
 
 
-class MopDryerStatus(DeviceStatus):
+class MopDryerSettings(DeviceStatus):
     """Container for mop dryer add-on."""
 
-    def __init__(self, data: Dict[str, Any], status_data: Dict[str, Any]):
+    def __init__(self, data: Dict[str, Any]):
         # {'status': 0, 'on': {'cliff_on': 1, 'cliff_off': 1, 'count': 10, 'dry_time': 10800},
         # 'off': {'cliff_on': 2, 'cliff_off': 1, 'count': 10}}
         self.data = data
-        self.status_data = status_data
 
     @property
     @setting(
@@ -991,29 +1016,3 @@ class MopDryerStatus(DeviceStatus):
     def dry_time(self) -> bool:
         """Return mop dry time."""
         return self.data["on"]["dry_time"] * 3600
-
-    @property
-    @sensor(
-        "Mop is drying",
-        icon="mdi:tumble-dryer",
-        entity_category="diagnostic",
-        enabled_default=False,
-    )
-    def is_drying(self) -> Optional[bool]:
-        """Return if mop drying is running."""
-        if "dry_status" in self.status_data:
-            return self.status_data["dry_status"] == 1
-        return None
-
-    @property
-    @sensor(
-        "Dryer remaining seconds",
-        unit="s",
-        entity_category="diagnostic",
-        enabled_default=False,
-    )
-    def remaining_seconds(self) -> Optional[int]:
-        """Return remaining mop drying seconds."""
-        if "rdt" in self.status_data:
-            return self.status_data["rdt"]
-        return None

--- a/miio/integrations/vacuum/roborock/vacuumcontainers.py
+++ b/miio/integrations/vacuum/roborock/vacuumcontainers.py
@@ -430,10 +430,10 @@ class VacuumStatus(VacuumDeviceStatus):
         entity_category="diagnostic",
         enabled_default=False,
     )
-    def mop_dryer_remaining_seconds(self) -> Optional[int]:
+    def mop_dryer_remaining_seconds(self) -> Optional[timedelta]:
         """Return remaining mop drying seconds."""
         if "rdt" in self.data:
-            return self.data["rdt"]
+            return pretty_seconds(self.data["rdt"])
         return None
 
 
@@ -1006,13 +1006,13 @@ class MopDryerSettings(DeviceStatus):
         "Mop dry time",
         setter_name="set_mop_dryer_dry_time",
         icon="mdi:fan",
-        unit="hour",
-        min_value=2,
-        max_value=4,
-        step=1,
+        unit="s",
+        min_value=7200,
+        max_value=14400,
+        step=3600,
         entity_category="config",
         enabled_default=False,
     )
-    def dry_time(self) -> bool:
+    def dry_time(self) -> timedelta:
         """Return mop dry time."""
-        return self.data["on"]["dry_time"] * 3600
+        return pretty_seconds(self.data["on"]["dry_time"])

--- a/miio/integrations/vacuum/roborock/vacuumcontainers.py
+++ b/miio/integrations/vacuum/roborock/vacuumcontainers.py
@@ -999,7 +999,7 @@ class MopDryerSettings(DeviceStatus):
     )
     def enabled(self) -> bool:
         """Return if mop dryer is enabled."""
-        return self.data["status"] == "1"
+        return self.data["status"] == 1
 
     @property
     @setting(


### PR DESCRIPTION
The S7 MaxV Ultra station (and AFAIK also the S7 Ultra station) has an optional mop dryer add-on. Based on reverse engineering of the Mi Home app plugin code, I added support for this.

Currently this code is partially untested as I am waiting for my add-on to be delivered. Delivery is expected around 12/19.

But I appreciate code review and feedback already :) 