### PR TITLE
Bump codecov-action to @v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           poetry run pytest --cov miio --cov-report xml
       - name: "Upload coverage to Codecov"
-        uses: "codecov/codecov-action@v2"
+        uses: "codecov/codecov-action@v3"
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Fixes the following warning:
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: codecov/codecov-action@v2
