### PR TITLE
Add more status codes for dreamevacuum

### DIFF
--- a/miio/integrations/vacuum/dreame/dreamevacuum_miot.py
+++ b/miio/integrations/vacuum/dreame/dreamevacuum_miot.py
@@ -227,7 +227,13 @@ class DeviceStatus(FormattableEnum):
     GoCharging = 5
     Charging = 6
     Mopping = 7
-    ManualSweeping = 13
+    Drying = 8
+    Washing = 9
+    ReturningWashing = 10
+    Building = 11
+    SweepingAndMopping = 12
+    ChargingComplete = 13
+    Upgrading = 14
 
 
 class WaterFlow(FormattableEnum):


### PR DESCRIPTION
Complete device status, I'am just not sur for `ChargingComplete = 13`, on my model (L10S ultra) it's Charging Complete, I hope it's same for all model