### PR TITLE
Make simulators return localhost address for info query

### DIFF
--- a/miio/devtools/simulators/common.py
+++ b/miio/devtools/simulators/common.py
@@ -2,7 +2,7 @@
 from hashlib import md5
 
 
-def create_info_response(model, mac):
+def create_info_response(model, addr, mac):
     """Create a response for miIO.info call using the given model and mac."""
     INFO_RESPONSE = {
         "ap": {"bssid": "FF:FF:FF:FF:FF:FF", "rssi": -68, "ssid": "network"},
@@ -15,7 +15,7 @@ def create_info_response(model, mac):
         "model": model,
         "netif": {
             "gw": "192.168.xxx.x",
-            "localIp": "192.168.xxx.x",
+            "localIp": addr,
             "mask": "255.255.255.0",
         },
         "ot": "otu",

--- a/miio/devtools/simulators/miiosimulator.py
+++ b/miio/devtools/simulators/miiosimulator.py
@@ -139,7 +139,7 @@ async def main(dev):
 
     _ = MiioSimulator(dev=dev, server=server)
     mac = mac_from_model(dev._model)
-    server.add_method("miIO.info", create_info_response(dev._model, mac))
+    server.add_method("miIO.info", create_info_response(dev._model, "127.0.0.1", mac))
 
     transport, proto = await server.start()
 

--- a/miio/devtools/simulators/miotsimulator.py
+++ b/miio/devtools/simulators/miotsimulator.py
@@ -194,7 +194,7 @@ async def main(dev, model):
 
     mac = mac_from_model(model)
     simulator = MiotSimulator(device_model=dev)
-    server.add_method("miIO.info", create_info_response(model, mac))
+    server.add_method("miIO.info", create_info_response(model, "127.0.0.1", mac))
     server.add_method("action", simulator.action)
     server.add_method("get_properties", simulator.get_properties)
     server.add_method("set_properties", simulator.set_properties)
@@ -215,7 +215,7 @@ def miot_simulator(file, model):
     else:
         cloud = MiotCloud()
         # TODO: fix HACK
-        dev = SimulatedDeviceModel.parse_raw(cloud.get_model_schema(model))
+        dev = SimulatedDeviceModel.parse_obj(cloud.get_model_schema(model))
 
     loop = asyncio.get_event_loop()
     random.seed(1)  # nosec


### PR DESCRIPTION
This will make it possible to directly use the data returned by the info query for further uses.