### PR TITLE
Handle non-readable miot properties

### DIFF
--- a/miio/integrations/genericmiot/genericmiot.py
+++ b/miio/integrations/genericmiot/genericmiot.py
@@ -145,9 +145,7 @@ class GenericMiotStatus(DeviceStatus):
 
 
 class GenericMiot(MiotDevice):
-    _supported_models = [
-        "*"
-    ]
+    _supported_models = ["*"]
 
     def __init__(
         self,
@@ -270,7 +268,11 @@ class GenericMiot(MiotDevice):
                 continue
             if not prop.access:
                 # some properties are defined only to be used as inputs for actions
-                _LOGGER.debug("%s (%s) reported no access information", prop.name, prop.description)
+                _LOGGER.debug(
+                    "%s (%s) reported no access information",
+                    prop.name,
+                    prop.description,
+                )
                 continue
 
             desc = self._descriptor_for_property(prop)

--- a/miio/integrations/genericmiot/genericmiot.py
+++ b/miio/integrations/genericmiot/genericmiot.py
@@ -145,6 +145,7 @@ class GenericMiotStatus(DeviceStatus):
 
 
 class GenericMiot(MiotDevice):
+    # we support all devices, if not, it is a responsibility of caller to verify that
     _supported_models = ["*"]
 
     def __init__(

--- a/miio/tests/test_miot_models.py
+++ b/miio/tests/test_miot_models.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 
 from miio.miot_models import (
     URN,
+    MiotAccess,
     MiotAction,
     MiotEnumValue,
     MiotEvent,
@@ -206,7 +207,7 @@ def test_property():
     assert prop.piid == 1
     assert prop.urn.type == "property"
     assert prop.format == str
-    assert prop.access == ["read"]
+    assert prop.access == [MiotAccess.Read]
     assert prop.description == "Device Manufacturer"
 
     assert prop.plain_name == "manufacturer"


### PR DESCRIPTION
This PR adapts the genericmiot to expose also the defined write-only properties and converts the earlier warning to a debug message.
Suppressing the warning is likely fine, as the properties without access defined is now considered to be defined for other reasons (e.g., to define input parameters for actions).