### PR TITLE
Implement input parameters for actions

### DIFF
--- a/miio/descriptors.py
+++ b/miio/descriptors.py
@@ -11,7 +11,7 @@ If you are developing an integration, prefer :func:`~miio.devicestatus.sensor`, 
 If needed, you can override the methods listed to add more descriptors to your integration.
 """
 from enum import Enum, auto
-from typing import Callable, Dict, Optional, Type
+from typing import Any, Callable, Dict, List, Optional, Type
 
 import attr
 
@@ -33,6 +33,7 @@ class ActionDescriptor:
     name: str
     method_name: Optional[str] = attr.ib(default=None, repr=False)
     method: Optional[Callable] = attr.ib(default=None, repr=False)
+    inputs: Optional[List[Any]] = attr.ib(default=None, repr=True)
     extras: Dict = attr.ib(factory=dict, repr=False)
 
 

--- a/miio/integrations/genericmiot/genericmiot.py
+++ b/miio/integrations/genericmiot/genericmiot.py
@@ -71,7 +71,10 @@ def pretty_actions(result: Dict[str, ActionDescriptor]):
 
         out += f"\t{desc.id}\t\t{desc.name}"
         if desc.inputs:
-            for idx, param in enumerate(desc.inputs, start=1):
+            for idx, input_ in enumerate(desc.inputs, start=1):
+                param = input_.extras[
+                    "miot_property"
+                ]  # TODO: hack until descriptors get support for descriptions
                 param_desc = f"\n\t\tParameter #{idx}: {param.name} ({param.description}) ({param.format}) {param.pretty_input_constraints}"
                 out += param_desc
 

--- a/miio/integrations/genericmiot/genericmiot.py
+++ b/miio/integrations/genericmiot/genericmiot.py
@@ -238,10 +238,15 @@ class GenericMiot(MiotDevice):
         extras["aiid"] = act.aiid
         extras["miot_action"] = act
 
+        inputs = act.inputs
+        if inputs:
+            # TODO: this is just temporarily here, pending refactoring the descriptor creation into the model
+            inputs = [self._descriptor_for_property(prop) for prop in act.inputs]
+
         return ActionDescriptor(
             id=id_,
             name=act.description,
-            inputs=act.inputs,  # TODO: convert inputs from properties to descriptors
+            inputs=inputs,
             method=call_action,
             extras=extras,
         )

--- a/miio/miot_models.py
+++ b/miio/miot_models.py
@@ -287,7 +287,8 @@ class DeviceModel(BaseModel):
     urn: URN = Field(alias="type")
     services: List[MiotService] = Field(repr=False)
 
-    # internal mappings to simplify accesses to a specific (siid, piid)
+    # internal mappings to simplify accesses
+    _services_by_id: Dict[int, MiotService] = PrivateAttr(default_factory=dict)
     _properties_by_id: Dict[int, Dict[int, MiotProperty]] = PrivateAttr(
         default_factory=dict
     )
@@ -302,6 +303,7 @@ class DeviceModel(BaseModel):
         """
         super().__init__(*args, **kwargs)
         for serv in self.services:
+            self._services_by_id[serv.siid] = serv
             self._properties_by_name[serv.name] = dict()
             self._properties_by_id[serv.siid] = dict()
             for prop in serv.properties:
@@ -312,6 +314,10 @@ class DeviceModel(BaseModel):
     def device_type(self) -> str:
         """Return device type as string."""
         return self.urn.type
+
+    def get_service_by_siid(self, siid: int) -> MiotService:
+        """Return the service for given siid."""
+        return self._services_by_id[siid]
 
     def get_property(self, service: str, prop_name: str) -> MiotProperty:
         """Return the property model for given service and property name."""


### PR DESCRIPTION
This makes the action input parameters accessible through action descriptors.

Here's an excerpt from the actions command for `ijai.vacuum.v3` showing some parameter infos:
```
sweep (sweep)
        sweep:reset-consumable          reset-consumable
                Parameter #1: sweep:consumable-index (consumable-index) (<class 'int'>) choices: 主刷 (1), 边刷 (2), 滤网 (3), 拖布 (4)
        sweep:set-calibration           set-calibration
        sweep:set-room-clean            set-room-clean
                Parameter #1: sweep:clean-room-ids () (<class 'str'>) 
                Parameter #2: sweep:clean-room-mode () (<class 'int'>) choices: 全局 (0), 沿边 (1)
                Parameter #3: sweep:clean-room-oper (clean-room-oper) (<class 'int'>) choices: 停止 (0), 开始 (1), 暂停 (2), 假暂停 (3)
        sweep:set-preference-clean              set-preference-clean
                Parameter #1: sweep:clean-preference (clean-preference) (<class 'str'>) 
                Parameter #2: sweep:clean-current-map (clean-current-map) (<class 'int'>) min: 1, max: 4294967295, step: 1
<--snip-->
language (language)
        language:download-voice         download-voice
                Parameter #1: language:target-voice (target-voice) (<class 'str'>) 
                Parameter #2: language:voice-url (voice-url) (<class 'str'>) 
                Parameter #3: language:voice-mdfive (voice-mdfive) (<class 'str'>) 
        language:get-download-status            get-download-status

```

Example use:
```
❯ miiocli genericmiot --ip 127.0.0.1 --token 00000000000000000000000000000000 call language:download-voice '["target-voice", "voice-url", "voice-mdfive"]'
Running command call
['ok']
```

The simulator is modified to verify the input parameters and return errors if the input is something unexpected:
```
❯ miiocli genericmiot --ip 127.0.0.1 --token 00000000000000000000000000000000 call language:download-voice '[]'
...
ERROR    Exception: {'code': -3, 'error': "Exception <class 'ValueError'>: Invalid parameter count, was expecting 0 params, got 3"}
```

```
❯ miiocli genericmiot --ip 127.0.0.1 --token 00000000000000000000000000000000 call language:download-voice '[1, 2, 3]'
...
ERROR    Exception: {'code': -3, 'error': "Exception <class 'TypeError'>: Param #0: expected string but got <class 'int'>"}
```

This has not been tested with a real device, if you have one and have tested it, feel free to give me a ping!