### PR TITLE
Prettier settings and status for genericmiot

### DIFF
--- a/miio/device.py
+++ b/miio/device.py
@@ -88,6 +88,7 @@ class Device(metaclass=DeviceGroupMeta):
         self._info: Optional[DeviceInfo] = None
         self._actions: Optional[Dict[str, ActionDescriptor]] = None
         timeout = timeout if timeout is not None else self.timeout
+        self._debug = debug
         self._protocol = MiIOProtocol(
             ip, token, start_id, debug, lazy_discover, timeout
         )


### PR DESCRIPTION
Group status information and settings based on the service for more readable output.
This also adds dumping of extras when `-dd` is given.
The examples below show the current state using a simulated `deerma.humidifier.jsq4`.

Status: 
![image](https://user-images.githubusercontent.com/3705853/212496794-5c49471e-bb56-471f-abbd-a90ef9247029.png)

Status with `-dd`:
![image](https://user-images.githubusercontent.com/3705853/212496964-b95e6f14-0664-4645-89ff-c0ad312664f6.png)


Settings:
![image](https://user-images.githubusercontent.com/3705853/212496830-a5c4c5b0-cbfc-46d1-be50-d3606286660a.png)
