### PR TITLE
Fix flake8 issues (B028)

### DIFF
--- a/devtools/miottemplate.py
+++ b/devtools/miottemplate.py
@@ -27,7 +27,7 @@ class Generator:
     def print_infos(self):
         dev = Device.from_json(self.data)
         click.echo(
-            f"Device '{dev.type}': {dev.description} with {len(dev.services)} services"
+            f"Device {dev.type!r}: {dev.description} with {len(dev.services)} services"
         )
         for serv in dev.services:
             click.echo(f"\n* Service {serv}")

--- a/miio/gateway/devices/subdevice.py
+++ b/miio/gateway/devices/subdevice.py
@@ -175,7 +175,7 @@ class SubDevice:
 
         if not response:
             raise DeviceException(
-                f"Empty response while fetching property '{property}': {response} on model {self.model}"
+                f"Empty response while fetching property {property!r}: {response} on model {self.model}"
             )
 
         return response

--- a/miio/integrations/vacuum/roborock/vacuum_cli.py
+++ b/miio/integrations/vacuum/roborock/vacuum_cli.py
@@ -168,7 +168,7 @@ def reset_consumable(vac: RoborockVacuum, name):
         click.echo("Unexpected state name: %s" % name)
         return
 
-    click.echo(f"Resetting consumable '{name}': {vac.consumable_reset(consumable)}")
+    click.echo(f"Resetting consumable {name!r}: {vac.consumable_reset(consumable)}")
 
 
 @cli.command()

--- a/miio/tests/test_device.py
+++ b/miio/tests/test_device.py
@@ -123,10 +123,10 @@ def test_missing_supported(mocker, caplog, cls, hidden):
 
     if hidden:
         assert "Found an unsupported model" not in caplog.text
-        assert f"for class '{cls.__name__}'" not in caplog.text
+        assert f"for class {cls.__name__!r}" not in caplog.text
     else:
         assert "Found an unsupported model" in caplog.text
-        assert f"for class '{cls.__name__}'" in caplog.text
+        assert f"for class {cls.__name__!r}" in caplog.text
 
 
 @pytest.mark.parametrize("cls", DEVICE_CLASSES)

--- a/miio/tests/test_miot_models.py
+++ b/miio/tests/test_miot_models.py
@@ -91,7 +91,7 @@ def test_format(format, expected_type):
 
         format: MiotFormat
 
-    data = f'{{"format": "{format}"}}'
+    data = f'{{"format": "{format}"}}'  # noqa: B028
     f = Wrapper.parse_raw(data)
     assert f.format == expected_type
 
@@ -119,7 +119,7 @@ def test_action():
 def test_urn():
     """Test the parsing of URN strings."""
     urn_string = "urn:namespace:type:name:41414141:dummy.model:1"
-    example_urn = f'{{"urn": "{urn_string}"}}'
+    example_urn = f'{{"urn": "{urn_string}"}}'  # noqa: B028
 
     class Wrapper(BaseModel):
         """Need to wrap as plain string is not valid json."""


### PR DESCRIPTION
This fixes the recent CI failures for warnings like: `devtools/miottemplate.py:30:13: B028 'dev.type' is manually surrounded by quotes, consider using the `!r` conversion flag.`