### PR TITLE
Fix json output handling for genericmiot

### DIFF
--- a/miio/devicestatus.py
+++ b/miio/devicestatus.py
@@ -128,6 +128,9 @@ class DeviceStatus(metaclass=_StatusMeta):
         if "__" not in item:
             return super().__getattr__(item)
 
+        if item == "__json__":  # special handling for custom json dunder
+            return None
+
         embed, prop = item.split("__")
         return getattr(self._embedded[embed], prop)
 

--- a/miio/integrations/genericmiot/genericmiot.py
+++ b/miio/integrations/genericmiot/genericmiot.py
@@ -104,6 +104,9 @@ class GenericMiotStatus(DeviceStatus):
         self._model: DeviceModel = dev._miot_model
         self._dev = dev
         self._data = {elem["did"]: elem["value"] for elem in response}
+        # for hardcoded json output.. see click_common.json_output
+        self.data = self._data
+
         self._data_by_siid_piid = {
             (elem["siid"], elem["piid"]): elem["value"] for elem in response
         }
@@ -113,6 +116,10 @@ class GenericMiotStatus(DeviceStatus):
 
         This is overridden to provide access to properties using (siid, piid) tuple.
         """
+        # let devicestatus handle dunder methods
+        if item.startswith("__") and item.endswith("__"):
+            return super().__getattr__(item)
+
         # TODO: find a better way to encode the property information
         serv, prop = item.split(":")
         prop = self._model.get_property(serv, prop)


### PR DESCRIPTION
This fixes the json output for genericmiot.
```
❯ miiocli --output json genericmiot --ip 127.0.0.1 --token 00000000000000000000000000000000 status|jq
{
  "vacuum:status": 6,
  "vacuum:fault": 1139,
  "vacuum:mode": 1,
  "vacuum:sweep-type": 2,
  "vacuum:on": "piid 9",
  "battery:battery-level": 66,
  "alarm:alarm": 1,
  "alarm:volume": 4,
  "sweep:repeat-state": 0,
  "sweep:door-state": 3,
  "sweep:cloth-state": 0,
  "sweep:suction-state": 2,
  "sweep:water-state": 1,
  "sweep:mop-route": 0,
  "sweep:side-brush-life": 53,
  "sweep:side-brush-hours": 21,
  "sweep:main-brush-life": 15,
  "sweep:main-brush-hours": 98,
  "sweep:hypa-life": 93,
  "sweep:hypa-hours": 45,
  "sweep:mop-life": 99,
  "sweep:mop-hours": 35,
  "sweep:time-zone": -81734,
  "sweep:cur-lang": "piid 21",
  "sweep:cleaning-time": 62,
  "sweep:cleaning-area": 708,
  "sweep:multi-prop-vacuum": "piid 45",
  "sweep:tank-shake": 1,
  "sweep:shake-shift": 3,
  "order:all-enable-count": "piid 18",
  "point-zone:target-point": "piid 5",
  "map:remember-state": 0,
  "map:cur-map-id": 1577155194,
  "map:map-num": 5,
  "map:cur-cleaning-path": "piid 5",
  "map:build-map": 0,
  "map:has-new-map": 0,
  "disturb:dnd-enable": 0,
  "disturb:dnd-start-hour": 1,
  "disturb:dnd-start-minute": 4,
  "disturb:dnd-end-hour": 8,
  "disturb:dnd-end-minute": 9,
  "disturb:multi-prop-dnd": "piid 7"
}
```