### PR TITLE
Fix incorrect super().__getattr__() use on devicestatus

### DIFF
--- a/miio/click_common.py
+++ b/miio/click_common.py
@@ -329,6 +329,7 @@ def json_output(pretty=False):
                 echo(json.dumps(ex.args[0], indent=indent))
                 return
 
+            # TODO: __json__ is not used anywhere and could be removed
             get_json_data_func = getattr(result, "__json__", None)
             data_variable = getattr(result, "data", None)
             if get_json_data_func is not None:

--- a/miio/tests/test_devicestatus.py
+++ b/miio/tests/test_devicestatus.py
@@ -76,6 +76,24 @@ def test_none():
     assert repr(NoneStatus()) == "<NoneStatus return_none=None>"
 
 
+def test_get_attribute(mocker):
+    """Make sure that __get_attribute__ works as expected."""
+
+    class TestStatus(DeviceStatus):
+        @property
+        def existing_attribute(self):
+            return None
+
+    status = TestStatus()
+    with pytest.raises(AttributeError):
+        _ = status.__missing_attribute
+
+    with pytest.raises(AttributeError):
+        _ = status.__missing_dunder__
+
+    assert status.existing_attribute is None
+
+
 def test_sensor_decorator():
     class DecoratedProps(DeviceStatus):
         @property


### PR DESCRIPTION
Trying to access non-existing attributes causes `Exception: 'super' object has no attribute '__getattr__'` as `object` class does not have that dunder method.