### PR TITLE
Fix access to embedded status containers

### DIFF
--- a/miio/devicestatus.py
+++ b/miio/devicestatus.py
@@ -5,6 +5,7 @@ from enum import Enum
 from typing import (
     Callable,
     Dict,
+    Iterable,
     Optional,
     Type,
     Union,
@@ -124,10 +125,22 @@ class DeviceStatus(metaclass=_StatusMeta):
             final_name = f"{other_name}__{name}"
             self._settings[final_name] = attr.evolve(setting, property=final_name)
 
+    def __dir__(self) -> Iterable[str]:
+        """Overridden to include properties from embedded containers."""
+        return (
+            list(super().__dir__())
+            + list(self._embedded)
+            + list(self._sensors)
+            + list(self._settings)
+        )
+
     def __getattr__(self, item):
         """Overridden to lookup properties from embedded containers."""
         if item.startswith("__") and item.endswith("__"):
             return super().__getattribute__(item)
+
+        if item in self._embedded:
+            return self._embedded[item]
 
         embed, prop = item.split("__", maxsplit=1)
         if not embed or not prop:

--- a/miio/tests/test_devicestatus.py
+++ b/miio/tests/test_devicestatus.py
@@ -278,3 +278,7 @@ def test_embed():
         repr(main)
         == "<MainStatus main_sensor=main SubStatus=<SubStatus sub_sensor=sub>>"
     )
+
+    # Test that __dir__ is implemented correctly
+    assert "SubStatus" in dir(main)
+    assert "SubStatus__sub_sensor" in dir(main)

--- a/miio/tests/test_devicestatus.py
+++ b/miio/tests/test_devicestatus.py
@@ -279,6 +279,9 @@ def test_embed():
         == "<MainStatus main_sensor=main SubStatus=<SubStatus sub_sensor=sub>>"
     )
 
+    # Test attribute access to the sub status
+    assert isinstance(main.SubStatus, SubStatus)
+
     # Test that __dir__ is implemented correctly
     assert "SubStatus" in dir(main)
     assert "SubStatus__sub_sensor" in dir(main)


### PR DESCRIPTION
Also, implement `__dir__` to enable autocompletion for attributes of embedded containers.

Example:
```
In [1]: from miio import RoborockVacuum
   ...: vac = RoborockVacuum("x", "x")
   ...: stat = vac.status()

In [2]: stat.DNDStatus
Out[2]: <DNDStatus enabled=True end=08:00:00 start=22:00:00>

In [3]: stat.DNDStatus<tab>
                       DNDStatus          DNDStatus__end    
                       DNDStatus__enabled DNDStatus__start  

```