### PR TITLE
Use descriptors for default status command cli output

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -244,6 +244,7 @@ The status container should inherit :class:`~miio.devicestatus.DeviceStatus`.
 Doing so ensures that a developer-friendly :meth:`~miio.devicestatus.DeviceStatus.__repr__` based on the defined
 properties is there to help with debugging.
 Furthermore, it allows defining meta information about properties that are especially interesting for end users.
+The ``miiocli`` tool will automatically use the defined information to generate a user-friendly output.
 
 .. note::
 

--- a/miio/click_common.py
+++ b/miio/click_common.py
@@ -306,9 +306,9 @@ def format_output(
             result = kwargs["result"] = func(*args, **kwargs)
             if (
                 not callable(result_msg_fmt)
-                and getattr(result, "cli_output", None) is not None
+                and getattr(result, "__cli_output__", None) is not None
             ):
-                echo(result.cli_output)
+                echo(result.__cli_output__)
             elif result_msg_fmt:
                 if callable(result_msg_fmt):
                     result_msg = result_msg_fmt(**kwargs)

--- a/miio/click_common.py
+++ b/miio/click_common.py
@@ -303,8 +303,13 @@ def format_output(
                     msg = msg_fmt.format(**kwargs)
                 if msg:
                     echo(msg.strip())
-            kwargs["result"] = func(*args, **kwargs)
-            if result_msg_fmt:
+            result = kwargs["result"] = func(*args, **kwargs)
+            if (
+                not callable(result_msg_fmt)
+                and getattr(result, "cli_output", None) is not None
+            ):
+                echo(result.cli_output)
+            elif result_msg_fmt:
                 if callable(result_msg_fmt):
                     result_msg = result_msg_fmt(**kwargs)
                 else:

--- a/miio/devicestatus.py
+++ b/miio/devicestatus.py
@@ -74,6 +74,8 @@ class DeviceStatus(metaclass=_StatusMeta):
         s = f"<{self.__class__.__name__}"
         for prop_tuple in props:
             name, prop = prop_tuple
+            if name.startswith("_"):  # skip internals
+                continue
             try:
                 # ignore deprecation warnings
                 with warnings.catch_warnings(record=True):
@@ -135,7 +137,7 @@ class DeviceStatus(metaclass=_StatusMeta):
         )
 
     @property
-    def cli_output(self) -> str:
+    def __cli_output__(self) -> str:
         """Return a CLI formatted output of the status."""
         out = ""
         for entry in list(self.sensors().values()) + list(self.settings().values()):

--- a/miio/devicestatus.py
+++ b/miio/devicestatus.py
@@ -144,6 +144,10 @@ class DeviceStatus(metaclass=_StatusMeta):
             except KeyError:
                 continue  # skip missing properties
 
+            if value is None:  # skip none values
+                _LOGGER.debug("Skipping %s because it's None", entry.name)
+                continue
+
             if isinstance(entry, SettingDescriptor):
                 out += "[RW] "
 

--- a/miio/integrations/fan/zhimi/fan.py
+++ b/miio/integrations/fan/zhimi/fan.py
@@ -219,26 +219,7 @@ class Fan(Device):
 
     _supported_models = list(AVAILABLE_PROPERTIES.keys())
 
-    @command(
-        default_output=format_output(
-            "",
-            "Power: {result.power}\n"
-            "Battery: {result.battery} %\n"
-            "AC power: {result.ac_power}\n"
-            "Temperature: {result.temperature} °C\n"
-            "Humidity: {result.humidity} %\n"
-            "LED: {result.led}\n"
-            "LED brightness: {result.led_brightness}\n"
-            "Buzzer: {result.buzzer}\n"
-            "Child lock: {result.child_lock}\n"
-            "Speed: {result.speed}\n"
-            "Natural speed: {result.natural_speed}\n"
-            "Direct speed: {result.direct_speed}\n"
-            "Oscillate: {result.oscillate}\n"
-            "Power-off time: {result.delay_off_countdown}\n"
-            "Angle: {result.angle}\n",
-        )
-    )
+    @command()
     def status(self) -> FanStatus:
         """Retrieve properties."""
         properties = AVAILABLE_PROPERTIES[self.model]

--- a/miio/integrations/genericmiot/genericmiot.py
+++ b/miio/integrations/genericmiot/genericmiot.py
@@ -126,7 +126,7 @@ class GenericMiotStatus(DeviceStatus):
         return res
 
     @property
-    def cli_output(self):
+    def __cli_output__(self):
         """Return a CLI printable status."""
         out = ""
         props = self.property_dict()

--- a/miio/integrations/humidifier/zhimi/airhumidifier.py
+++ b/miio/integrations/humidifier/zhimi/airhumidifier.py
@@ -326,28 +326,7 @@ class AirHumidifier(Device):
 
     _supported_models = SUPPORTED_MODELS
 
-    @command(
-        default_output=format_output(
-            "",
-            "Power: {result.power}\n"
-            "Mode: {result.mode}\n"
-            "Temperature: {result.temperature} °C\n"
-            "Humidity: {result.humidity} %\n"
-            "LED brightness: {result.led_brightness}\n"
-            "Buzzer: {result.buzzer}\n"
-            "Child lock: {result.child_lock}\n"
-            "Target humidity: {result.target_humidity} %\n"
-            "Trans level: {result.trans_level}\n"
-            "Speed: {result.motor_speed}\n"
-            "Depth: {result.depth}\n"
-            "Water Level: {result.water_level} %\n"
-            "Water tank attached: {result.water_tank_attached}\n"
-            "Dry: {result.dry}\n"
-            "Use time: {result.use_time}\n"
-            "Hardware version: {result.hardware_version}\n"
-            "Button pressed: {result.button_pressed}\n",
-        )
-    )
+    @command()
     def status(self) -> AirHumidifierStatus:
         """Retrieve properties."""
 

--- a/miio/integrations/vacuum/mijia/pro2vacuum.py
+++ b/miio/integrations/vacuum/mijia/pro2vacuum.py
@@ -272,30 +272,7 @@ class Pro2Vacuum(MiotDevice, VacuumInterface):
 
     _mappings = _MAPPINGS
 
-    @command(
-        default_output=format_output(
-            "",
-            "State: {result.state}\n"
-            "Error: {result.error}\n"
-            "Battery: {result.battery}%\n"
-            "Sweep Mode: {result.sweep_mode}\n"
-            "Sweep Type: {result.sweep_type}\n"
-            "Mop State: {result.mop_state}\n"
-            "Fan speed: {result.fan_speed}\n"
-            "Water level: {result.water_level}\n"
-            "Main Brush Life Level: {result.main_brush_life_level}%\n"
-            "Main Brush Life Time: {result.main_brush_time_left}h\n"
-            "Side Brush Life Level: {result.side_brush_life_level}%\n"
-            "Side Brush Life Time: {result.side_brush_time_left}h\n"
-            "Filter Life Level: {result.filter_life_level}%\n"
-            "Filter Life Time: {result.filter_time_left}h\n"
-            "Mop Life Level: {result.mop_life_level}%\n"
-            "Mop Life Time: {result.mop_time_left}h\n"
-            "Clean Area: {result.clean_area} m^2\n"
-            "Clean Time: {result.clean_time} mins\n"
-            "Current Language: {result.current_language}\n",
-        )
-    )
+    @command()
     def status(self) -> Pro2Status:
         """Retrieve properties."""
         return Pro2Status(

--- a/miio/integrations/vacuum/viomi/viomivacuum.py
+++ b/miio/integrations/vacuum/viomi/viomivacuum.py
@@ -51,7 +51,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import click
 
-from miio.click_common import EnumType, command, format_output
+from miio.click_common import EnumType, command
 from miio.device import Device
 from miio.devicestatus import action, sensor, setting
 from miio.exceptions import DeviceException
@@ -614,38 +614,7 @@ class ViomiVacuum(Device, VacuumInterface):
         self.manual_seqnum = -1
         self._cache: Dict[str, Any] = {"edge_state": None, "rooms": {}, "maps": {}}
 
-    @command(
-        default_output=format_output(
-            "\n",
-            "General\n"
-            "=======\n\n"
-            "Hardware version: {result.hw_info}\n"
-            "State: {result.state}\n"
-            "Working: {result.is_on}\n"
-            "Battery status: {result.error}\n"
-            "Battery: {result.battery}\n"
-            "Charging: {result.charging}\n"
-            "Box type: {result.bin_type}\n"
-            "Fan speed: {result.fanspeed}\n"
-            "Water grade: {result.water_grade}\n"
-            "Mop attached: {result.mop_attached}\n"
-            "Vacuum along the edges: {result.edge_state}\n"
-            "Mop route pattern: {result.route_pattern}\n"
-            "Secondary Cleanup: {result.repeat_cleaning}\n"
-            "Sound Volume: {result.sound_volume}\n"
-            "Clean time: {result.clean_time}\n"
-            "Clean area: {result.clean_area} m²\n"
-            "LED state: {result.led_state}\n"
-            "\n"
-            "Map\n"
-            "===\n\n"
-            "Current map ID: {result.current_map_id}\n"
-            "Remember map: {result.remember_map}\n"
-            "Has map: {result.has_map}\n"
-            "Has new map: {result.has_new_map}\n"
-            "Number of maps: {result.map_number}\n",
-        )
-    )
+    @command()
     def status(self) -> ViomiVacuumStatus:
         """Retrieve properties."""
 

--- a/miio/tests/test_devicestatus.py
+++ b/miio/tests/test_devicestatus.py
@@ -76,7 +76,7 @@ def test_none():
     assert repr(NoneStatus()) == "<NoneStatus return_none=None>"
 
 
-def test_get_attribute(mocker):
+def test_get_attribute():
     """Make sure that __get_attribute__ works as expected."""
 
     class TestStatus(DeviceStatus):
@@ -285,3 +285,39 @@ def test_embed():
     # Test that __dir__ is implemented correctly
     assert "SubStatus" in dir(main)
     assert "SubStatus__sub_sensor" in dir(main)
+
+
+def test_cli_output():
+    """Test the cli output string."""
+
+    class Status(DeviceStatus):
+        @property
+        @sensor("sensor_without_unit")
+        def sensor_without_unit(self) -> int:
+            return 1
+
+        @property
+        @sensor("sensor_with_unit", unit="V")
+        def sensor_with_unit(self) -> int:
+            return 2
+
+        @property
+        @setting("setting_without_unit", setter_name="dummy")
+        def setting_without_unit(self):
+            return 3
+
+        @property
+        @setting("setting_with_unit", unit="V", setter_name="dummy")
+        def setting_with_unit(self):
+            return 4
+
+        @property
+        @sensor("none_sensor")
+        def sensor_returning_none(self):
+            return None
+
+    status = Status()
+    assert (
+        status.__cli_output__
+        == "sensor_without_unit: 1\nsensor_with_unit: 2 V\n[RW] setting_without_unit: 3\n[RW] setting_with_unit: 4 V\n"
+    )


### PR DESCRIPTION
This PR moves to use the descriptors to construct cli output format string, making it unnecessary to manually define it for `status()` commands:
* Settings are prefixed with `[RW]` for visibility
* `None` values are skipped, but logged
* Units are shown where available

Example output from roborock:
```
❯ miiocli roborockvacuum --ip $MIROBO_IP --token $MIROBO_TOKEN status
Running command status
State code: 8
State: Charging
Error code: 0
Error string: No error
Battery: 100 %
Current clean duration: 0:20:11 s
Current clean area: 18.725 m²
Error: False
Main brush used: 9 days, 15:40:14 s
Main brush left: 2 days, 20:19:46 s
Side brush used: 12:18:13 s
Side brush left: 7 days, 19:41:47 s
Filter used: 11:38:16 s
Filter left: 5 days, 18:21:44 s
Sensor dirty used: 11:38:16 s
Sensor dirty left: 18:21:44 s
Total clean duration: 9 days, 15:08:57 s
Total clean area: 12041.43 m²
Total clean count: 697
Do not disturb: True
Do not disturb start: 22:00:00
Do not disturb end: 08:00:00
[RW] Fanspeed: 60 %
```
and from viomi:
```
❯ miiocli viomivacuum --model viomi.vacuum.v8 status
Running command status
Vacuum state: VacuumState.Docked
Device state: ViomiVacuumState.Docked
Mop attached: False
Error code: 2105
Battery: 100 %
Bin type: ViomiBinType.Vacuum
Cleaning time: 0:00:00 s
Cleaning area: 0 m²
Has map: True
New map scanned: False
Is charging: True
Order time?: 0
Start time: 0
Zone data: 0
Mop used: 1 day, 5:00:00 s
Mop left: 6 days, 7:00:00 s
Do not disturb: True
Do not disturb start: 23:00:00
Do not disturb end: 09:00:00
[RW] Vacuum along edges: ViomiEdgeState.Off
[RW] Fan speed: ViomiVacuumSpeed.Standard
[RW] Water grade: ViomiWaterGrade.Low
[RW] Remember map: True
[RW] Cleaning mode: ViomiMode.Vacuum
[RW] Power: False
[RW] LED state: False
[RW] Repeat cleaning active: False
[RW] Sound volume: 1

```