### PR TITLE
Do not crash on extranous urn components

### DIFF
--- a/miio/miot_models.py
+++ b/miio/miot_models.py
@@ -18,7 +18,11 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class URN(BaseModel):
-    """Parsed type URN."""
+    """Parsed type URN.
+
+    The expected format is urn:<namespace>:<type>:<name>:<id>:<model>:<version>.
+    All extraneous parts are stored in :ref:`unexpected`.
+    """
 
     namespace: str
     type: str
@@ -26,6 +30,7 @@ class URN(BaseModel):
     internal_id: str
     model: str
     version: int
+    unexpected: Optional[List[str]]
 
     parent_urn: Optional["URN"] = Field(None, repr=False)
 
@@ -38,7 +43,7 @@ class URN(BaseModel):
         if not isinstance(v, str) or ":" not in v:
             raise TypeError("invalid type")
 
-        _, namespace, type, name, id_, model, version = v.split(":")
+        _, namespace, type, name, id_, model, version, *unexpected = v.split(":")
 
         return cls(
             namespace=namespace,
@@ -47,12 +52,16 @@ class URN(BaseModel):
             internal_id=id_,
             model=model,
             version=version,
+            unexpected=unexpected if unexpected else None,
         )
 
     @property
     def urn_string(self) -> str:
         """Return string presentation of the URN."""
-        return f"urn:{self.namespace}:{self.type}:{self.name}:{self.internal_id}:{self.model}:{self.version}"
+        urn = f"urn:{self.namespace}:{self.type}:{self.name}:{self.internal_id}:{self.model}:{self.version}"
+        if self.unexpected is not None:
+            urn = f"{urn}:{':'.join(self.unexpected)}"
+        return urn
 
     def __repr__(self):
         return f"<URN {self.urn_string} parent:{self.parent_urn}>"

--- a/miio/miot_models.py
+++ b/miio/miot_models.py
@@ -21,7 +21,7 @@ class URN(BaseModel):
     """Parsed type URN.
 
     The expected format is urn:<namespace>:<type>:<name>:<id>:<model>:<version>.
-    All extraneous parts are stored in :ref:`unexpected`.
+    All extraneous parts are stored inside *unexpected*.
     """
 
     namespace: str

--- a/miio/tests/test_miot_models.py
+++ b/miio/tests/test_miot_models.py
@@ -116,9 +116,26 @@ def test_action():
     assert act.plain_name == "dummy-action"
 
 
-def test_urn():
+@pytest.mark.parametrize(
+    ("urn_string", "unexpected"),
+    [
+        pytest.param(
+            "urn:namespace:type:name:41414141:dummy.model:1", None, id="regular_urn"
+        ),
+        pytest.param(
+            "urn:namespace:type:name:41414141:dummy.model:1:unexpected",
+            ["unexpected"],
+            id="unexpected_component",
+        ),
+        pytest.param(
+            "urn:namespace:type:name:41414141:dummy.model:1:unexpected:unexpected2",
+            ["unexpected", "unexpected2"],
+            id="multiple_unexpected_components",
+        ),
+    ],
+)
+def test_urn(urn_string, unexpected):
     """Test the parsing of URN strings."""
-    urn_string = "urn:namespace:type:name:41414141:dummy.model:1"
     example_urn = f'{{"urn": "{urn_string}"}}'  # noqa: B028
 
     class Wrapper(BaseModel):
@@ -134,6 +151,7 @@ def test_urn():
     assert urn.internal_id == "41414141"
     assert urn.model == "dummy.model"
     assert urn.version == 1
+    assert urn.unexpected == unexpected
 
     # Check that the serialization works
     assert urn.urn_string == urn_string


### PR DESCRIPTION
Store the unexpected components inside 'unexpected', e.g., urn:miot-spec-v2:service:device-information:00007801:yeelink-sw1:1:0000C809 spotted for `yeelink.switch.sw1`.

Also, miotsimulator now dumps the schema file in case pydantic cannot validate it for easier debugging.