### PR TITLE
Mark Roborock Q7+ (a40) as supported for roborock

### DIFF
--- a/miio/integrations/roborock/vacuum/vacuum.py
+++ b/miio/integrations/roborock/vacuum/vacuum.py
@@ -74,6 +74,7 @@ ROCKROBO_S7_MAXV = "roborock.vacuum.a27"
 ROCKROBO_S7_PRO_ULTRA = "roborock.vacuum.a62"
 ROCKROBO_Q5 = "roborock.vacuum.a34"
 ROCKROBO_Q7_MAX = "roborock.vacuum.a38"
+ROCKROBO_Q7PLUS = "roborock.vacuum.a40"
 ROCKROBO_G10S = "roborock.vacuum.a46"
 ROCKROBO_G10 = "roborock.vacuum.a29"
 
@@ -102,6 +103,7 @@ SUPPORTED_MODELS = [
     ROCKROBO_S7_PRO_ULTRA,
     ROCKROBO_Q5,
     ROCKROBO_Q7_MAX,
+    ROCKROBO_Q7PLUS,
     ROCKROBO_G10,
     ROCKROBO_G10S,
     ROCKROBO_S6_MAXV,


### PR DESCRIPTION
Added Roborock Q7+ (a40) to `supported_models`