### PR TITLE
Add parent reference to embedded containers

### DIFF
--- a/miio/devicestatus.py
+++ b/miio/devicestatus.py
@@ -39,6 +39,7 @@ class _StatusMeta(type):
         cls._sensors: Dict[str, SensorDescriptor] = {}
         cls._settings: Dict[str, SettingDescriptor] = {}
 
+        cls._parent: Optional["DeviceStatus"] = None
         cls._embedded: Dict[str, "DeviceStatus"] = {}
 
         descriptor_map = {
@@ -117,6 +118,7 @@ class DeviceStatus(metaclass=_StatusMeta):
         other_name = str(other.__class__.__name__)
 
         self._embedded[other_name] = other
+        other._parent = self  # type: ignore[attr-defined]
 
         for name, sensor in other.sensors().items():
             final_name = f"{other_name}__{name}"

--- a/miio/tests/test_devicestatus.py
+++ b/miio/tests/test_devicestatus.py
@@ -270,6 +270,7 @@ def test_embed():
     main.embed(sub)
     sensors = main.sensors()
     assert len(sensors) == 2
+    assert sub._parent == main
 
     assert getattr(main, sensors["main_sensor"].property) == "main"
     assert getattr(main, sensors["SubStatus__sub_sensor"].property) == "sub"


### PR DESCRIPTION
Allows embedded containers to access data from other embeddeds or the main status.