### PR TITLE
Require name for status embedding

### DIFF
--- a/miio/devicestatus.py
+++ b/miio/devicestatus.py
@@ -106,7 +106,7 @@ class DeviceStatus(metaclass=_StatusMeta):
         """
         return self._settings  # type: ignore[attr-defined]
 
-    def embed(self, other: "DeviceStatus"):
+    def embed(self, name: str, other: "DeviceStatus"):
         """Embed another status container to current one.
 
         This makes it easy to provide a single status response for cases where responses
@@ -115,18 +115,16 @@ class DeviceStatus(metaclass=_StatusMeta):
         Internally, this will prepend the name of the other class to the property names,
         and override the __getattribute__ to lookup attributes in the embedded containers.
         """
-        other_name = str(other.__class__.__name__)
-
-        self._embedded[other_name] = other
+        self._embedded[name] = other
         other._parent = self  # type: ignore[attr-defined]
 
-        for name, sensor in other.sensors().items():
-            final_name = f"{other_name}__{name}"
+        for sensor_name, sensor in other.sensors().items():
+            final_name = f"{name}__{sensor_name}"
 
             self._sensors[final_name] = attr.evolve(sensor, property=final_name)
 
-        for name, setting in other.settings().items():
-            final_name = f"{other_name}__{name}"
+        for setting_name, setting in other.settings().items():
+            final_name = f"{name}__{setting_name}"
             self._settings[final_name] = attr.evolve(setting, property=final_name)
 
     def __dir__(self) -> Iterable[str]:

--- a/miio/integrations/roborock/vacuum/vacuum.py
+++ b/miio/integrations/roborock/vacuum/vacuum.py
@@ -338,9 +338,9 @@ class RoborockVacuum(Device, VacuumInterface):
     def status(self) -> VacuumStatus:
         """Return status of the vacuum."""
         status = self.vacuum_status()
-        status.embed(self.consumable_status())
-        status.embed(self.clean_history())
-        status.embed(self.dnd_status())
+        status.embed("consumables", self.consumable_status())
+        status.embed("cleaning_history", self.clean_history())
+        status.embed("dnd", self.dnd_status())
         return status
 
     @command()

--- a/miio/integrations/viomi/viomi/viomivacuum.py
+++ b/miio/integrations/viomi/viomi/viomivacuum.py
@@ -692,8 +692,8 @@ class ViomiVacuum(Device, VacuumInterface):
         values = self.get_properties(properties)
 
         status = ViomiVacuumStatus(defaultdict(lambda: None, zip(properties, values)))
-        status.embed(self.consumable_status())
-        status.embed(self.dnd_status())
+        status.embed("consumables", self.consumable_status())
+        status.embed("dnd", self.dnd_status())
 
         return status
 

--- a/miio/tests/test_devicestatus.py
+++ b/miio/tests/test_devicestatus.py
@@ -267,7 +267,7 @@ def test_embed():
     assert len(main.sensors()) == 1
 
     sub = SubStatus()
-    main.embed(sub)
+    main.embed("SubStatus", sub)
     sensors = main.sensors()
     assert len(sensors) == 2
     assert sub._parent == main


### PR DESCRIPTION
This will remove the magic naming for embedded containers in favor of explicitly naming them.