### PR TITLE
Add tests to genericmiot's get_descriptor

### DIFF
--- a/miio/miot_models.py
+++ b/miio/miot_models.py
@@ -280,7 +280,7 @@ class MiotProperty(MiotBaseModel):
 
         # Handle settable booleans
         elif MiotAccess.Write in self.access and self.format == bool:
-            self._create_boolean_setting()
+            return self._create_boolean_setting()
 
         # Fallback to sensors
         return self._create_sensor()

--- a/miio/tests/fixtures/miot/boolean_property.json
+++ b/miio/tests/fixtures/miot/boolean_property.json
@@ -1,0 +1,11 @@
+{
+    "iid": 1,
+    "type": "urn:miot-spec-v2:property:on:00000006:model:1",
+    "description": "Switch",
+    "format": "bool",
+    "access": [
+        "read",
+        "write",
+        "notify"
+    ]
+}

--- a/miio/tests/fixtures/miot/enum_property.json
+++ b/miio/tests/fixtures/miot/enum_property.json
@@ -1,0 +1,26 @@
+{
+  "iid": 4,
+  "type": "urn:miot-spec-v2:property:mode:00000008:model:1",
+  "description": "Mode",
+  "format": "uint8",
+  "access": [
+    "read",
+    "write",
+    "notify"
+  ],
+  "unit": "none",
+  "value-list": [
+    {
+      "value": 1,
+      "description": "Silent"
+    },
+    {
+      "value": 2,
+      "description": "Basic"
+    },
+    {
+      "value": 3,
+      "description": "Strong"
+    }
+  ]
+}

--- a/miio/tests/fixtures/miot/ranged_property.json
+++ b/miio/tests/fixtures/miot/ranged_property.json
@@ -1,0 +1,17 @@
+{
+  "iid": 3,
+  "type": "urn:miot-spec-v2:property:brightness:0000000D:model:1",
+  "description": "Brightness",
+  "format": "uint8",
+  "access": [
+    "read",
+    "write",
+    "notify"
+  ],
+  "unit": "percentage",
+  "value-range": [
+    1,
+    100,
+    1
+  ]
+}

--- a/miio/tests/test_miot_models.py
+++ b/miio/tests/test_miot_models.py
@@ -1,8 +1,18 @@
 """Tests for miot model parsing."""
 
+import json
+from pathlib import Path
+
 import pytest
 from pydantic import BaseModel
 
+from miio.descriptors import (
+    BooleanSettingDescriptor,
+    EnumSettingDescriptor,
+    NumberSettingDescriptor,
+    SensorDescriptor,
+    SettingType,
+)
 from miio.miot_models import (
     URN,
     MiotAccess,
@@ -13,6 +23,14 @@ from miio.miot_models import (
     MiotProperty,
     MiotService,
 )
+
+
+def load_fixture(filename: str) -> str:
+    """Load a fixture."""
+    file = Path(__file__).parent.absolute() / "fixtures" / "miot" / filename
+    with file.open() as f:
+        return json.load(f)
+
 
 DUMMY_SERVICE = """
     {
@@ -229,6 +247,63 @@ def test_property():
     assert prop.description == "Device Manufacturer"
 
     assert prop.plain_name == "manufacturer"
+
+
+@pytest.mark.parametrize(
+    ("read_only", "expected"),
+    [(True, SensorDescriptor), (False, BooleanSettingDescriptor)],
+)
+def test_get_descriptor_bool_property(read_only, expected):
+    """Test that boolean property creates a sensor."""
+    boolean_prop = load_fixture("boolean_property.json")
+    if read_only:
+        boolean_prop["access"].remove("write")
+
+    prop = MiotProperty.parse_obj(boolean_prop)
+    desc = prop.get_descriptor()
+
+    assert isinstance(desc, expected)
+    assert desc.type == bool
+    if not read_only:
+        assert desc.setting_type == SettingType.Boolean
+
+
+@pytest.mark.parametrize(
+    ("read_only", "expected"),
+    [(True, SensorDescriptor), (False, NumberSettingDescriptor)],
+)
+def test_get_descriptor_ranged_property(read_only, expected):
+    """Test value-range descriptors."""
+    ranged_prop = load_fixture("ranged_property.json")
+    if read_only:
+        ranged_prop["access"].remove("write")
+
+    prop = MiotProperty.parse_obj(ranged_prop)
+    desc = prop.get_descriptor()
+
+    assert isinstance(desc, expected)
+    assert desc.type == int
+    if not read_only:
+        assert desc.setting_type == SettingType.Number
+
+
+@pytest.mark.parametrize(
+    ("read_only", "expected"),
+    [(True, SensorDescriptor), (False, EnumSettingDescriptor)],
+)
+def test_get_descriptor_enum_property(read_only, expected):
+    """Test enum descriptors."""
+    enum_prop = load_fixture("enum_property.json")
+    if read_only:
+        enum_prop["access"].remove("write")
+
+    prop = MiotProperty.parse_obj(enum_prop)
+    desc = prop.get_descriptor()
+
+    assert isinstance(desc, expected)
+    assert desc.type == int
+    if not read_only:
+        assert desc.setting_type == SettingType.Enum
 
 
 @pytest.mark.xfail(reason="not implemented")


### PR DESCRIPTION
This ensures that descriptors are created as expected, and fixes a bug where a missing return caused boolean settings not being constructed at all.