### PR TITLE
Allow gatt-access for miotproperties

### DIFF
--- a/miio/miot_models.py
+++ b/miio/miot_models.py
@@ -197,6 +197,7 @@ class MiotProperty(MiotBaseModel):
 
     range: Optional[List[int]] = Field(alias="value-range")
     choices: Optional[List[MiotEnumValue]] = Field(alias="value-list")
+    gatt_access: Optional[List[Any]] = Field(alias="gatt-access")
 
     # TODO: currently just used to pass the data for miiocli
     #       there must be a better way to do this..


### PR DESCRIPTION
Seen for `cuco.plug.v3`, contents unknown:
```
{
  "iid": 1,
  "type": "urn:miot-spec-v2:property:power-consumption:0000002F:cuco-v3:1",
  "description": "Power Consumption",
  "format": "uint16",
  "access": [
      "read",
      "notify"
  ],
  "value-range": [
      0,
      65535,
      1
  ],
  "gatt-access": []
},
```

Fixes #1721