### PR TITLE
Use normalized property names for genericmiotstatus

### DIFF
--- a/miio/miot_models.py
+++ b/miio/miot_models.py
@@ -139,6 +139,15 @@ class MiotBaseModel(BaseModel):
             return f"{self.service.name}:{self.urn.name}"  # type: ignore
         return "unitialized"
 
+    @property
+    def normalized_name(self) -> str:
+        """Return a normalized name.
+
+        This returns a normalized :meth:`name` that can be used as a python identifier,
+        currently meaning that ':' and '-' are replaced with '_'.
+        """
+        return self.name.replace(":", "_").replace("-", "_")
+
 
 class MiotAction(MiotBaseModel):
     """Action presentation for miot."""
@@ -300,7 +309,7 @@ class MiotProperty(MiotBaseModel):
             desc = EnumSettingDescriptor(
                 id=self.name,
                 name=self.description,
-                property=self.name,
+                property=self.normalized_name,
                 unit=self.unit,
                 choices=choices,
                 extras=self.extras,
@@ -318,7 +327,7 @@ class MiotProperty(MiotBaseModel):
             desc = NumberSettingDescriptor(
                 id=self.name,
                 name=self.description,
-                property=self.name,
+                property=self.normalized_name,
                 min_value=self.range[0],
                 max_value=self.range[1],
                 step=self.range[2],
@@ -335,7 +344,7 @@ class MiotProperty(MiotBaseModel):
         return BooleanSettingDescriptor(
             id=self.name,
             name=self.description,
-            property=self.name,
+            property=self.normalized_name,
             unit=self.unit,
             extras=self.extras,
             type=bool,
@@ -346,7 +355,7 @@ class MiotProperty(MiotBaseModel):
         return SensorDescriptor(
             id=self.name,
             name=self.description,
-            property=self.name,
+            property=self.normalized_name,
             type=self.format,
             extras=self.extras,
         )
@@ -407,6 +416,15 @@ class MiotService(BaseModel):
     def name(self) -> str:
         """Return service name."""
         return self.urn.name
+
+    @property
+    def normalized_name(self) -> str:
+        """Return normalized service name.
+
+        This returns a normalized :meth:`name` that can be used as a python identifier,
+        currently meaning that ':' and '-' are replaced with '_'.
+        """
+        return self.urn.name.replace(":", "_").replace("-", "_")
 
     class Config:
         extra = "forbid"

--- a/miio/tests/test_miot_models.py
+++ b/miio/tests/test_miot_models.py
@@ -226,6 +226,7 @@ def test_entity_names(entity_type):
         entity_to_test.normalized_name
         == f"{_normalize_name(serv.name)}_{_normalize_name(plain_name)}"
     )
+    assert entity_to_test.normalized_name.isidentifier() is True
 
 
 def test_event():

--- a/miio/tests/test_miot_models.py
+++ b/miio/tests/test_miot_models.py
@@ -214,8 +214,18 @@ def test_entity_names(entity_type):
     entities = getattr(serv, entity_type)
     assert len(entities) == 1
     entity_to_test = entities[0]
+    plain_name = entity_to_test.plain_name
 
-    assert entity_to_test.name == f"{serv.name}:{entity_to_test.plain_name}"
+    assert entity_to_test.name == f"{serv.name}:{plain_name}"
+
+    def _normalize_name(x):
+        return x.replace("-", "_").replace(":", "_")
+
+    # normalized_name should be a valid python identifier based on the normalized service name and normalized plain name
+    assert (
+        entity_to_test.normalized_name
+        == f"{_normalize_name(serv.name)}_{_normalize_name(plain_name)}"
+    )
 
 
 def test_event():


### PR DESCRIPTION
This changes the way genericmiotstatus properties are accessed to use normalized names (e.g., light:on = light_on, brush-cleaner:brush-life-level = brush_cleaner_brush_life_level) to make them valid python identifiers, and thus directly accessible using the regular attribute access.

`__dir__()` is now also implemented for GenericMiotStatus to enable autocompleting these names for easier repling.

Example using `mijia.vacuum.v2`:
```
In [7]: for name in sorted(status.property_dict().keys()):
   ...:     print(name)
   ...: 
alarm:alarm
alarm:volume
battery:battery-level
battery:charging-state
brush-cleaner:brush-left-time
brush-cleaner:brush-life-level
clean-record:clean-area
clean-record:clean-time
clean-record:total-clean-area
clean-record:total-clean-count
clean-record:total-clean-time
filter:filter-left-time
filter:filter-life-level
language:language
...

In [8]: status.<tab>
            alarm_alarm                    brush_cleaner_brush_left_time  clean_record_total_clean_area   
            alarm_volume                   brush_cleaner_brush_life_level clean_record_total_clean_count  
            battery_battery_level          clean_record_clean_area        clean_record_total_clean_time  >
            battery_charging_state         clean_record_clean_time        data                            

In [9]: status.clean_record_total_clean_count
Out[9]: 30506

```