### PR TITLE
add specs for yeelink.light.colorb

### DIFF
--- a/miio/integrations/yeelight/light/specs.yaml
+++ b/miio/integrations/yeelight/light/specs.yaml
@@ -110,6 +110,10 @@ yeelink.light.color7:
   night_light: False
   color_temp: [1700, 6500]
   supports_color: True
+yeelink.light.colora:
+  night_light: False
+  color_temp: [1700, 6500]
+  supports_color: True
 yeelink.light.colorb:
   night_light: False
   color_temp: [1700, 6500]


### PR DESCRIPTION
Found an unsupported model 'yeelink.light.colora' for class 'Yeelight'

Model: yeelink.light.colora
Hardware version: esp8266
Firmware version: 2.0.8_0009
