### PR TITLE
Make optional deps really optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,8 @@ PyYAML = ">=5,<7"
 
 [tool.poetry.extras]
 docs = ["sphinx", "sphinx_click", "sphinxcontrib-apidoc", "sphinx_rtd_theme", "myst-parser"]
+updater = ["netifaces"]
+backup_extract = ["android_backup"]
 
 [tool.poetry.dev-dependencies]
 pytest = ">=6.2.5"


### PR DESCRIPTION
This assigns groups to netifaces and android_backup dependencies so that they shouldn't be required for building the package (e.g. by installing the git checkout using pip). `PKGINFO` looks like this for them now:
```
Requires-Dist: android_backup (>=0,<1); extra == "backup_extraction"
Requires-Dist: netifaces (>=0,<1); extra == "updater"
```

This allows simpler windows builds, related to #1735
