### PR TITLE
Minor pretty-printing changes

### DIFF
--- a/miio/cloud.py
+++ b/miio/cloud.py
@@ -55,7 +55,7 @@ class CloudDeviceInfo(BaseModel):
     is_online: bool = Field(alias="isOnline")
     rssi: int
 
-    _raw_data: dict
+    _raw_data: dict = Field(repr=False)
 
     @property
     def is_child(self):

--- a/miio/integrations/genericmiot/status.py
+++ b/miio/integrations/genericmiot/status.py
@@ -115,9 +115,19 @@ class GenericMiotStatus(DeviceStatus):
         return list(super().__dir__()) + list(self._data_by_normalized_name.keys())
 
     def __repr__(self):
+        """Return string representation of the status."""
         s = f"<{self.__class__.__name__}"
         for name, value in self.property_dict().items():
             s += f" {name}={value}"
+        s += ">"
+
+        return s
+
+    def __str__(self):
+        """Return simplified string representation of the status."""
+        s = f"<{self.__class__.__name__}"
+        for name, value in self.property_dict().items():
+            s += f" {name}={value.pretty_value}"
         s += ">"
 
         return s


### PR DESCRIPTION
* Implement `__str__` for genericmiotstatus for prettier printing (prints only the id and the value)
* Don't show raw data in cloud repr