### PR TITLE
Improve docs on token acquisition and cleanup legacy methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,20 @@ The `miiocli` command allows controlling supported devices from the
 command line, given that you know their IP addresses and tokens.
 
 The simplest way to acquire the tokens is by using the `miiocli cloud` command,
-which fetches them for you from your cloud account using [micloud](https://github.com/Squachen/micloud/).
-Alternatively, see [the docs](https://python-miio.readthedocs.io/en/latest/legacy_token_extraction.html#legacy-token-extraction)
+which fetches them for you from your cloud account using [micloud](https://github.com/Squachen/micloud/):
+
+    miiocli cloud
+    Username: example@example.com
+    Password:
+
+    == name of the device (Device offline ) ==
+        Model: example.device.v1
+        Token: b1946ac92492d2347c6235b4d2611184
+        IP: 192.168.xx.xx (mac: ab:cd:ef:12:34:56)
+        DID: 123456789
+        Locale: cn
+
+Alternatively, [see the docs](https://python-miio.readthedocs.io/en/latest/discovery.html#obtaining-tokens)
 for other ways to obtain them.
 
 After you have your token, you can start controlling the device.
@@ -325,4 +337,5 @@ can find interesting. Feel free to submit more related projects.
 * [Valetudo](https://github.com/Hypfer/Valetudo) (cloud free vacuum firmware)
 * [micloud](https://github.com/Squachen/micloud) (library to access xiaomi cloud services, can be used to obtain device tokens)
 * [micloudfaker](https://github.com/unrelentingtech/micloudfaker) (dummy cloud server, can be used to fix powerstrip status requests when without internet access)
+* [Xiaomi Cloud Tokens Extractor](https://github.com/PiotrMachowski/Xiaomi-cloud-tokens-extractor) (an alternative way to fetch tokens from the cloud)
 * [Your project here? Feel free to open a PR!](https://github.com/rytilahti/python-miio/pulls)

--- a/docs/device_docs/vacuum.rst
+++ b/docs/device_docs/vacuum.rst
@@ -310,4 +310,4 @@ so it is also possible to pass dicts.
    :prog: mirobo
    :show-nested:
 
-:py:class:`API <miio.integrations.roborocok.vacuum>`
+:py:class:`API <miio.integrations.roborock.vacuum>`

--- a/docs/discovery.rst
+++ b/docs/discovery.rst
@@ -71,7 +71,12 @@ as well as the server locale to use for fetching the tokens.
 
     miiocli cloud list
 
-:ref:`Alternatively, see our documentation for other ways to obtain the tokens<legacy_token_extraction>`.
+    Username: example@example.com
+    Password:
+    Locale (all, cn, de, i2, ru, sg, us): all
+
+
+Alternatively, you can try one of the :ref:`legacy ways to obtain the tokens<legacy_token_extraction>`.
 
 You can also access this functionality programatically using :class:`miio.cloud.CloudInterface`.
 

--- a/docs/legacy_token_extraction.rst
+++ b/docs/legacy_token_extraction.rst
@@ -1,5 +1,6 @@
 :orphan:
 
+
 .. _legacy_token_extraction:
 
 Legacy methods for obtaining tokens
@@ -8,15 +9,10 @@ Legacy methods for obtaining tokens
 This page describes several ways to extract device tokens,
 both with and without cloud access.
 
-.. _cloud_tokens:
+.. note::
 
-Tokens from Mi Home Cloud
-=========================
-
-The fastest way to obtain tokens is to use the
-[cloud tokens extractor](https://github.com/PiotrMachowski/Xiaomi-cloud-tokens-extractor) by Piotr Machowski.
-Check out his repository for detailed instructions on installation and execution.
-
+    You generally want to use the :ref:`miiocli cloud command <obtaining_tokens>` to obtain tokens.
+    These methods are listed here just for historical reference and may not work anymore.
 
 .. _logged_tokens:
 
@@ -50,8 +46,8 @@ or database from the Mi Home app.
 The procedure is briefly described below,
 but you may find the following links also useful:
 
-- https://github.com/jghaanstra/com.xiaomi-miio/blob/master/docs/obtain_token.md
-- https://github.com/homeassistantchina/custom_components/blob/master/doc/chuang_mi_ir_remote.md
+* https://github.com/jghaanstra/com.xiaomi-miio/blob/master/docs/obtain_token.md
+* https://github.com/homeassistantchina/custom_components/blob/master/doc/chuang_mi_ir_remote.md
 
 Android
 ~~~~~~~
@@ -109,24 +105,24 @@ Apple
 Create a new unencrypted iOS backup to your computer.
 To do that you've to follow these steps:
 
-- Connect your iOS device to the computer
-- Open iTunes
-- Click on your iOS device (sidebar left or icon on top navigation bar)
-- In the Summary view check the following settings
-    - Automatically Back Up: ``This Computer``
-    - **Disable** ``Encrypt iPhone backup``
-- Click ``Back Up Now``
+#. Connect your iOS device to the computer
+#. Open iTunes
+#. Click on your iOS device (sidebar left or icon on top navigation bar)
+#. In the Summary view check the following settings
+    * Automatically Back Up: ``This Computer``
+    * **Disable** ``Encrypt iPhone backup``
+#. Click ``Back Up Now``
 
 When the backup is finished, download `iBackup Viewer <https://www.imactools.com/iphonebackupviewer/>`_ and follow these steps:
 
-- Open iBackup Viewer
-- Click on your newly created backup
-- Click on the ``Raw Files`` icon (looks like a file tree)
-- On the left column, search for ``AppDomain-com.xiaomi.mihome`` and select it
-- Click on the search icon in the header
-- Enter ``_mihome`` in the search field
-- Select the ``Documents/0123456789_mihome.sqlite`` file (the one with the number prefixed)
-- Click ``Export -> Selected…`` in the header and store the file
+#. Open iBackup Viewer
+#. Click on your newly created backup
+#. Click on the ``Raw Files`` icon (looks like a file tree)
+#. On the left column, search for ``AppDomain-com.xiaomi.mihome`` and select it
+#. Click on the search icon in the header
+#. Enter ``_mihome`` in the search field
+#. Select the ``Documents/0123456789_mihome.sqlite`` file (the one with the number prefixed)
+#. Click ``Export -> Selected…`` in the header and store the file
 
 Now you've exported the SQLite database to your Mac and you can extract the tokens.
 
@@ -149,34 +145,17 @@ Encrypted tokens as `recently introduced on iOS devices <https://github.com/ryti
 For decrypting Android backups the password has to be provided
 to the tool with ``--password <password>``.
 
-*Please feel free to submit pull requests to simplify this procedure!*
-
 .. code-block:: bash
 
     $ miio-extract-tokens backup.ab
     Opened backup/backup.ab
     Extracting to /tmp/tmpvbregact
     Reading tokens from Android DB
-    Gateway
-            Model: lumi.gateway.v3
-            IP address: 192.168.XXX.XXX
-            Token: 91c52a27eff00b954XXX
-            MAC: 28:6C:07:XX:XX:XX
     room1
             Model: yeelink.light.color1
             IP address: 192.168.XXX.XXX
             Token: 4679442a069f09883XXX
             MAC: F0:B4:29:XX:XX:XX
-    room2
-            Model: yeelink.light.color1
-            IP address: 192.168.XXX.XXX
-            Token: 7433ab14222af5792XXX
-            MAC: 28:6C:07:XX:XX:XX
-    Flower Care
-            Model: hhcc.plantmonitor.v1
-            IP address: 134.XXX.XXX.XXX
-            Token: 124f90d87b4b90673XXX
-            MAC: C4:7C:8D:XX:XX:XX
     Mi Robot Vacuum
             Model: rockrobo.vacuum.v1
             IP address: 192.168.XXX.XXX
@@ -213,5 +192,3 @@ Tokens from rooted device
 =========================
 
 If a device is rooted via `dustcloud <https://github.com/dgiese/dustcloud>`_ (e.g. for running the cloud-free control webinterface `Valetudo <https://valetudo.cloud/>`_), the token can be extracted by connecting to the device via SSH and reading the file: :code:`printf $(cat /mnt/data/miio/device.token) | xxd -p`
-
-See also `"How can I get the token from the robots FileSystem?" in the FAQ for Valetudo <https://valetudo.cloud/pages/faq.html#how-can-i-get-the-token-from-the-robots-filesystem>`_.

--- a/miio/__init__.py
+++ b/miio/__init__.py
@@ -27,7 +27,7 @@ from miio.integrations.deerma.humidifier import AirHumidifierJsqs, AirHumidifier
 from miio.integrations.dmaker.airfresh import AirFreshA1, AirFreshT2017
 from miio.integrations.dmaker.fan import Fan1C, FanMiot, FanP5
 from miio.integrations.dreame.vacuum import DreameVacuum
-from miio.integrations.genericmiot import GenericMiot
+from miio.integrations.genericmiot.genericmiot import GenericMiot
 from miio.integrations.huayi.light import (
     Huizuo,
     HuizuoLampFan,

--- a/miio/cloud.py
+++ b/miio/cloud.py
@@ -155,7 +155,7 @@ class CloudInterface:
 
 @click.group(invoke_without_command=True)
 @click.option("--username", prompt=True)
-@click.option("--password", prompt=True)
+@click.option("--password", prompt=True, hide_input=True)
 @click.pass_context
 def cloud(ctx: click.Context, username, password):
     """Cloud commands."""

--- a/miio/descriptors.py
+++ b/miio/descriptors.py
@@ -79,7 +79,7 @@ class PropertyDescriptor(Descriptor):
     access information what types of data is available to display to users.
 
     Prefer :meth:`@sensor <miio.devicestatus.sensor>` or
-     :meth:`@setting <miio.devicestatus.setting>`for constructing these.
+     :meth:`@setting <miio.devicestatus.setting>` for constructing these.
     """
 
     #: The name of the property to use to access the value from a status container.

--- a/miio/devicefactory.py
+++ b/miio/devicefactory.py
@@ -95,7 +95,7 @@ class DeviceFactory:
         """
         dev: Device
         if force_generic_miot:  # TODO: find a better way to handle this.
-            from .integrations.genericmiot import GenericMiot
+            from .integrations.genericmiot.genericmiot import GenericMiot
 
             dev = GenericMiot(host, token, model=model)
             dev.info()

--- a/miio/integrations/genericmiot/__init__.py
+++ b/miio/integrations/genericmiot/__init__.py
@@ -1,3 +1,0 @@
-from .genericmiot import GenericMiot
-
-__all__ = ["GenericMiot"]

--- a/miio/tests/test_miotdevice.py
+++ b/miio/tests/test_miotdevice.py
@@ -3,7 +3,7 @@ from unittest.mock import ANY
 import pytest
 
 from miio import Huizuo, MiotDevice
-from miio.integrations.genericmiot import GenericMiot
+from miio.integrations.genericmiot.genericmiot import GenericMiot
 from miio.miot_device import MiotValueType, _filter_request_fields
 
 MIOT_DEVICES = MiotDevice.__subclasses__()


### PR DESCRIPTION
* add examples
* cleanup the legacy method descriptions a bit
* xref from legacy methods back to the main one

Also, hide the input when typing the password.