### PR TITLE
Rename descriptor's 'property' to 'status_attribute'

### DIFF
--- a/miio/descriptors.py
+++ b/miio/descriptors.py
@@ -44,11 +44,17 @@ class AccessFlags(Flag):
 class Descriptor:
     """Base class for all descriptors."""
 
+    #: Unique identifier.
     id: str
+    #: Human readable name.
     name: str
+    #: Type of the property, if applicable.
     type: Optional[type] = None
-    property: Optional[str] = None
+    #: Name of the attribute in the status container that contains the value, if applicable.
+    status_attribute: Optional[str] = None
+    #: Additional data related to this descriptor.
     extras: Dict = attr.ib(factory=dict, repr=False)
+    #: Access flags (read, write, execute) for the described item.
     access: AccessFlags = attr.ib(default=AccessFlags.Read | AccessFlags.Write)
 
 
@@ -56,8 +62,10 @@ class Descriptor:
 class ActionDescriptor(Descriptor):
     """Describes a button exposed by the device."""
 
-    method_name: Optional[str] = attr.ib(default=None, repr=False)
+    # Callable to execute the action.
     method: Optional[Callable] = attr.ib(default=None, repr=False)
+    #: Name of the method in the device class that can be used to execute the action.
+    method_name: Optional[str] = attr.ib(default=None, repr=False)
     inputs: Optional[List[Any]] = attr.ib(default=None, repr=True)
 
     access: AccessFlags = attr.ib(default=AccessFlags.Execute)
@@ -82,10 +90,11 @@ class PropertyDescriptor(Descriptor):
      :meth:`@setting <miio.devicestatus.setting>`for constructing these.
     """
 
-    #: The name of the property to use to access the value from a status container.
-    property: str
+    #: Name of the attribute in the status container that contains the value.
+    status_attribute: str
     #: Sensors are read-only and settings are (usually) read-write.
     access: AccessFlags = attr.ib(default=AccessFlags.Read)
+    #: Optional human-readable unit of the property.
     unit: Optional[str] = None
 
     #: Constraint type defining the allowed values for an integer property.
@@ -93,7 +102,7 @@ class PropertyDescriptor(Descriptor):
     #: Callable to set the value of the property.
     setter: Optional[Callable] = attr.ib(default=None, repr=False)
     #: Name of the method in the device class that can be used to set the value.
-    #: This will be used to bind the setter callable.
+    #: If set, the callable with this name will override the `setter` attribute.
     setter_name: Optional[str] = attr.ib(default=None, repr=False)
 
 
@@ -102,7 +111,9 @@ class EnumDescriptor(PropertyDescriptor):
     """Presents a settable, enum-based value."""
 
     constraint: PropertyConstraint = PropertyConstraint.Choice
+    #: Name of the attribute in the device class that returns the choices.
     choices_attribute: Optional[str] = attr.ib(default=None, repr=False)
+    #: Enum class containing the available choices.
     choices: Optional[Type[Enum]] = attr.ib(default=None, repr=False)
 
 
@@ -110,13 +121,18 @@ class EnumDescriptor(PropertyDescriptor):
 class RangeDescriptor(PropertyDescriptor):
     """Presents a settable, numerical value constrained by min, max, and step.
 
-    If `range_attribute` is set, the named property that should return
-    :class:ValidSettingRange will be used to obtain {min,max}_value and step.
+    If `range_attribute` is set, the named property that should return a
+    :class:`ValidSettingRange` object to override the {min,max}_value and step values.
     """
 
+    #: Minimum value for the property.
     min_value: int
+    #: Maximum value for the property.
     max_value: int
+    #: Step size for the property.
     step: int
+    #: Name of the attribute in the device class that returns the range.
+    #: If set, this will override the individual min/max/step values.
     range_attribute: Optional[str] = attr.ib(default=None)
     type: type = int
     constraint: PropertyConstraint = PropertyConstraint.Range

--- a/miio/integrations/yeelight/light/yeelight.py
+++ b/miio/integrations/yeelight/light/yeelight.py
@@ -364,7 +364,7 @@ class Yeelight(Device):
             settings[LightId.ColorTemperature.value] = RangeDescriptor(
                 name="Color temperature",
                 id=LightId.ColorTemperature.value,
-                property="color_temp",
+                status_attribute="color_temp",
                 setter=self.set_color_temperature,
                 min_value=self.color_temperature_range.min_value,
                 max_value=self.color_temperature_range.max_value,
@@ -376,7 +376,7 @@ class Yeelight(Device):
             settings[LightId.Color.value] = RangeDescriptor(
                 name="Color",
                 id=LightId.Color.value,
-                property="rgb_int",
+                status_attribute="rgb_int",
                 setter=self.set_rgb_int,
                 min_value=1,
                 max_value=0xFFFFFF,

--- a/miio/miot_models.py
+++ b/miio/miot_models.py
@@ -317,7 +317,7 @@ class MiotProperty(MiotBaseModel):
         desc = EnumDescriptor(
             id=self.name,
             name=self.description,
-            property=self.normalized_name,
+            status_attribute=self.normalized_name,
             unit=self.unit,
             choices=choices,
             extras=self.extras,
@@ -336,7 +336,7 @@ class MiotProperty(MiotBaseModel):
         desc = RangeDescriptor(
             id=self.name,
             name=self.description,
-            property=self.normalized_name,
+            status_attribute=self.normalized_name,
             min_value=self.range[0],
             max_value=self.range[1],
             step=self.range[2],
@@ -353,7 +353,7 @@ class MiotProperty(MiotBaseModel):
         return PropertyDescriptor(
             id=self.name,
             name=self.description,
-            property=self.normalized_name,
+            status_attribute=self.normalized_name,
             type=self.format,
             extras=self.extras,
             access=self._miot_access_list_to_access(self.access),

--- a/miio/tests/test_devicestatus.py
+++ b/miio/tests/test_devicestatus.py
@@ -152,7 +152,7 @@ def test_setting_decorator_number(mocker):
     desc = settings["level"]
     assert isinstance(desc, RangeDescriptor)
 
-    assert getattr(d.status(), desc.property) == 1
+    assert getattr(d.status(), desc.status_attribute) == 1
 
     assert desc.name == "Level"
     assert desc.min_value == 0
@@ -200,7 +200,7 @@ def test_setting_decorator_number_range_attribute(mocker):
     desc = settings["level"]
     assert isinstance(desc, RangeDescriptor)
 
-    assert getattr(d.status(), desc.property) == 1
+    assert getattr(d.status(), desc.status_attribute) == 1
 
     assert desc.name == "Level"
     assert desc.min_value == 1
@@ -244,7 +244,7 @@ def test_setting_decorator_enum(mocker):
 
     desc = settings["level"]
     assert isinstance(desc, EnumDescriptor)
-    assert getattr(d.status(), desc.property) == TestEnum.First
+    assert getattr(d.status(), desc.status_attribute) == TestEnum.First
 
     assert desc.name == "Level"
     assert len(desc.choices) == 2
@@ -275,8 +275,8 @@ def test_embed():
     assert len(sensors) == 2
     assert sub._parent == main
 
-    assert getattr(main, sensors["main_sensor"].property) == "main"
-    assert getattr(main, sensors["SubStatus__sub_sensor"].property) == "sub"
+    assert getattr(main, sensors["main_sensor"].status_attribute) == "main"
+    assert getattr(main, sensors["SubStatus__sub_sensor"].status_attribute) == "sub"
 
     with pytest.raises(KeyError):
         main.properties()["nonexisting_sensor"]


### PR DESCRIPTION
This avoids name collision with the property builtin, and is more descriptive.