### PR TITLE
Pull 'unit' up to the descriptor base class

### DIFF
--- a/miio/descriptors.py
+++ b/miio/descriptors.py
@@ -36,7 +36,6 @@ class AccessFlags(Flag):
         s += "r" if self & AccessFlags.Read else "-"
         s += "w" if self & AccessFlags.Write else "-"
         s += "x" if self & AccessFlags.Execute else "-"
-        s += ""
         return s
 
 
@@ -50,12 +49,14 @@ class Descriptor:
     name: str
     #: Type of the property, if applicable.
     type: Optional[type] = None
+    #: Unit of the property, if applicable.
+    unit: Optional[str] = None
     #: Name of the attribute in the status container that contains the value, if applicable.
     status_attribute: Optional[str] = None
     #: Additional data related to this descriptor.
     extras: Dict = attr.ib(factory=dict, repr=False)
     #: Access flags (read, write, execute) for the described item.
-    access: AccessFlags = attr.ib(default=AccessFlags.Read | AccessFlags.Write)
+    access: AccessFlags = attr.ib(default=AccessFlags(0))
 
 
 @attr.s(auto_attribs=True)
@@ -94,8 +95,6 @@ class PropertyDescriptor(Descriptor):
     status_attribute: str
     #: Sensors are read-only and settings are (usually) read-write.
     access: AccessFlags = attr.ib(default=AccessFlags.Read)
-    #: Optional human-readable unit of the property.
-    unit: Optional[str] = None
 
     #: Constraint type defining the allowed values for an integer property.
     constraint: PropertyConstraint = attr.ib(default=PropertyConstraint.Unset)

--- a/miio/tests/test_descriptors.py
+++ b/miio/tests/test_descriptors.py
@@ -1,0 +1,101 @@
+from enum import Enum
+
+import pytest
+
+from miio.descriptors import (
+    AccessFlags,
+    ActionDescriptor,
+    Descriptor,
+    EnumDescriptor,
+    PropertyConstraint,
+    PropertyDescriptor,
+)
+
+COMMON_FIELDS = {
+    "id": "test",
+    "name": "Test",
+    "type": int,
+    "status_attribute": "test",
+    "unit": "unit",
+    "extras": {"test": "test"},
+}
+
+
+def test_accessflags():
+    """Test that accessflags str representation is correct."""
+    assert str(AccessFlags(AccessFlags.Read)) == "r--"
+    assert str(AccessFlags(AccessFlags.Write)) == "-w-"
+    assert str(AccessFlags(AccessFlags.Execute)) == "--x"
+    assert str(AccessFlags(AccessFlags.Read | AccessFlags.Write)) == "rw-"
+
+
+@pytest.mark.parametrize(
+    ("class_", "access"),
+    [
+        pytest.param(Descriptor, AccessFlags(0), id="base class (no access)"),
+        pytest.param(ActionDescriptor, AccessFlags.Execute, id="action (execute)"),
+        pytest.param(
+            PropertyDescriptor, AccessFlags.Read, id="regular property (read)"
+        ),
+    ],
+)
+def test_descriptor(class_, access):
+    """Test that the common descriptor has the expected API."""
+    desc = class_(**COMMON_FIELDS)
+    assert desc.id == "test"
+    assert desc.name == "Test"
+    assert desc.type == int
+    assert desc.status_attribute == "test"
+    assert desc.extras == {"test": "test"}
+    assert desc.access == access
+
+
+def test_actiondescriptor():
+    """Test that an action descriptor has the expected API."""
+    desc = ActionDescriptor(id="test", name="Test", extras={"test": "test"})
+    assert desc.id == "test"
+    assert desc.name == "Test"
+    assert desc.method_name is None
+    assert desc.type is None
+    assert desc.status_attribute is None
+    assert desc.inputs is None
+    assert desc.extras == {"test": "test"}
+    assert desc.access == AccessFlags.Execute
+
+
+def test_propertydescriptor():
+    """Test that a property descriptor has the expected API."""
+    desc = PropertyDescriptor(
+        id="test",
+        name="Test",
+        type=int,
+        status_attribute="test",
+        unit="unit",
+        extras={"test": "test"},
+    )
+    assert desc.id == "test"
+    assert desc.name == "Test"
+    assert desc.type == int
+    assert desc.status_attribute == "test"
+    assert desc.unit == "unit"
+    assert desc.extras == {"test": "test"}
+    assert desc.access == AccessFlags.Read
+
+
+def test_enumdescriptor():
+    """Test that an enum descriptor has the expected API."""
+
+    class TestChoices(Enum):
+        One = 1
+        Two = 2
+
+    desc = EnumDescriptor(**COMMON_FIELDS, choices=TestChoices)
+    assert desc.id == "test"
+    assert desc.name == "Test"
+    assert desc.type == int
+    assert desc.status_attribute == "test"
+    assert desc.unit == "unit"
+    assert desc.extras == {"test": "test"}
+    assert desc.access == AccessFlags.Read
+    assert desc.constraint == PropertyConstraint.Choice
+    assert desc.choices == TestChoices


### PR DESCRIPTION
As this is used by all but actions, it belongs to the base class. This also adds tests to the descriptors that were previously missing.