### PR TITLE
Add `repeat` param to Roborock segment clean

### DIFF
--- a/miio/integrations/roborock/vacuum/vacuum.py
+++ b/miio/integrations/roborock/vacuum/vacuum.py
@@ -891,12 +891,16 @@ class RoborockVacuum(Device):
         return self.send("resume_segment_clean")
 
     @command(click.argument("segments", type=LiteralParamType(), required=True))
-    def segment_clean(self, segments: List):
+    @command(click.argument("repeat", type=int, required=False, default=1))
+    def segment_clean(self, segments: List, repeat: int = 1):
         """Clean segments.
 
         :param List segments: List of segments to clean: [16,17,18]
+        :param int repeat: Count of iterations
         """
-        return self.send("app_segment_clean", segments)
+        return self.send(
+            "app_segment_clean", [{"segments": segments, "repeat": repeat}]
+        )
 
     @command()
     def get_room_mapping(self):


### PR DESCRIPTION
Hey! This is actuall fix for #1034, for some reason, this issue was closed with sketchy workarounds.

I've added `repeat` prop for `segment_clean` function in `RoborockVacuum`. This represents the count of repeats that the vacuum does in specified segments:

![image](https://user-images.githubusercontent.com/23432278/235858153-9b204aa9-6936-43ae-9a86-8eb4bbc0a9f4.png)

This is done as specified in [XiaomiRobotVacuumProtocol](https://github.com/marcelrv/XiaomiRobotVacuumProtocol/blob/master/segment_clean.md). I've tested this with my Roborock S5 Max and it works well.