### PR TITLE
Add support for Dmaker.fan.p39

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ integration, this library supports also the following devices:
 * Xiaomi Philips Zhirui Bedroom Smart Lamp
 * Huayi Huizuo Lamps
 * Xiaomi Universal IR Remote Controller (Chuangmi IR)
-* Xiaomi Mi Smart Pedestal Fan V2, V3, SA1, ZA1, ZA3, ZA4, ZA5 1C, P5, P9, P10, P11, P15, P18, P33
+* Xiaomi Mi Smart Pedestal Fan V2, V3, SA1, ZA1, ZA3, ZA4, ZA5 1C, P5, P9, P10, P11, P15, P18, P33, P39
 * Xiaomi Rosou SS4 Ventilator (leshow.fan.ss4)
 * Xiaomi Mi Air Humidifier V1, CA1, CA4, CB1, MJJSQ, JSQ, JSQ1, JSQ001
 * Xiaomi Mi Water Purifier (Basic support: Turn on & off)

--- a/miio/integrations/dmaker/fan/fan_miot.py
+++ b/miio/integrations/dmaker/fan/fan_miot.py
@@ -95,7 +95,7 @@ MIOT_MAPPING = {
         "swing_mode_angle": {"siid": 2, "piid": 6},
         "fan_speed": {"siid": 2, "piid": 11},
         "light": {"siid": 2, "piid": 9},
-        "buzzer": {"siid": 7, "piid": 2},
+        "buzzer": {"siid": 2, "piid": 7},
         # "device_fault": {"siid": 6, "piid": 2},
         "child_lock": {"siid": 3, "piid": 1},
         "power_off_time": {"siid": 2, "piid": 8},

--- a/miio/integrations/dmaker/fan/fan_miot.py
+++ b/miio/integrations/dmaker/fan/fan_miot.py
@@ -98,7 +98,7 @@ MIOT_MAPPING = {
         "buzzer": {"siid": 2, "piid": 7},
         # "device_fault": {"siid": 6, "piid": 2},
         "child_lock": {"siid": 3, "piid": 1},
-        "power_off_time": {"siid": 2, "piid": 8},
+        "power_off_time": {"siid": 2, "pi q id": 8},
         "set_move": {"siid": 2, "piid": 10},
     },
 }

--- a/miio/integrations/dmaker/fan/fan_miot.py
+++ b/miio/integrations/dmaker/fan/fan_miot.py
@@ -23,6 +23,7 @@ MODEL_FAN_P11 = "dmaker.fan.p11"
 MODEL_FAN_P15 = "dmaker.fan.p15"
 MODEL_FAN_P18 = "dmaker.fan.p18"
 MODEL_FAN_P33 = "dmaker.fan.p33"
+MODEL_FAN_P39 = "dmaker.fan.p39"
 MODEL_FAN_1C = "dmaker.fan.1c"
 
 
@@ -85,8 +86,22 @@ MIOT_MAPPING = {
         "power_off_time": {"siid": 3, "piid": 1},
         "set_move": {"siid": 6, "piid": 1},
     },
+    MODEL_FAN_P39: {
+        # Source https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:fan:0000A005:dmaker-p39:1
+        "power": {"siid": 2, "piid": 1},
+        "fan_level": {"siid": 2, "piid": 2},
+        "mode": {"siid": 2, "piid": 4},
+        "swing_mode": {"siid": 2, "piid": 5},
+        "swing_mode_angle": {"siid": 2, "piid": 6},
+        "fan_speed": {"siid": 2, "piid": 11},
+        "light": {"siid": 2, "piid": 9},
+        "buzzer": {"siid": 7, "piid": 2},
+        # "device_fault": {"siid": 6, "piid": 2},
+        "child_lock": {"siid": 3, "piid": 1},
+        "power_off_time": {"siid": 2, "piid": 8},
+        "set_move": {"siid": 2, "piid": 10},
+    },
 }
-
 
 # These mappings are based on user reports and may not cover all features
 MIOT_MAPPING[MODEL_FAN_P15] = MIOT_MAPPING[MODEL_FAN_P11]  # see #1354

--- a/miio/integrations/dmaker/fan/fan_miot.py
+++ b/miio/integrations/dmaker/fan/fan_miot.py
@@ -98,7 +98,7 @@ MIOT_MAPPING = {
         "buzzer": {"siid": 2, "piid": 7},
         # "device_fault": {"siid": 6, "piid": 2},
         "child_lock": {"siid": 3, "piid": 1},
-        "power_off_time": {"siid": 2, "pi q id": 8},
+        "power_off_time": {"siid": 2, "piid": 8},
         "set_move": {"siid": 2, "piid": 10},
     },
 }


### PR DESCRIPTION
Adds support for fanmiot p39. Already supported by genericmiot but does not expose mode.
Compared to P33 there's a few changes.

### Changes
Added to README and to fan_miot.py

### Source 
https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:fan:0000A005:dmaker-p39:1

### Function test
Tested each command and function with `miiocli`
```  miiocli fanmiot --ip 10.20.30.50 --token 000000000000000000000000 COMMAND ```