### PR TITLE
Fix hardcoded lumi.gateway module path

### DIFF
--- a/miio/integrations/lumi/gateway/gateway.py
+++ b/miio/integrations/lumi/gateway/gateway.py
@@ -317,8 +317,10 @@ class Gateway(Device):
             return
 
         # Obtain the correct subdevice class
+        # TODO: is there a better way to obtain this information?
         subdevice_cls = getattr(
-            sys.modules["miio.gateway.devices"], model_info.get("class")
+            sys.modules["miio.integrations.lumi.gateway.devices"],
+            model_info.get("class"),
         )
         if subdevice_cls is None:
             subdevice_cls = SubDevice


### PR DESCRIPTION
This hardcoded 'path' broke when the gateway was moved from the main package to its own one under integrations/lumi/gateway.

This should fix #1791 but is untested. @starkillerOG any ideas if there is a better way to do this besides hardcoding the path?