### PR TITLE
Mark xiaomi.wifispeaker.l05g as supported for ChuangmiIr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: "${{ matrix.python-version }}"
       - name: "Install dependencies"
         run: |
-          python -m pip install --upgrade pip poetry
+          python -m pip install --upgrade pip "poetry>=1.3.0,<1.4.0"
           poetry install --extras docs
       - name: "Run pyupgrade"
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: "${{ matrix.python-version }}"
       - name: "Install dependencies"
         run: |
-          python -m pip install --upgrade pip "poetry>=1.3.0,<1.4.0"
+          python -m pip install --upgrade pip poetry
           poetry install --extras docs
       - name: "Run pyupgrade"
         run: |

--- a/miio/integrations/chuangmi/remote/chuangmi_ir.py
+++ b/miio/integrations/chuangmi/remote/chuangmi_ir.py
@@ -30,6 +30,7 @@ class ChuangmiIr(Device):
         "chuangmi.ir.v2",
         "chuangmi.remote.v2",
         "chuangmi.remote.h102a03",
+        "xiaomi.wifispeaker.l05g",
     ]
 
     PRONTO_RE = re.compile(r"^([\da-f]{4}\s?){3,}([\da-f]{4})$", re.IGNORECASE)


### PR DESCRIPTION
Related [issue](https://github.com/rytilahti/python-miio/issues/1803).

The IR control part of the device works properly:

```shell
root@DS718:/# miiocli chuangmiir --ip 192.168.0.241 --token xx learn 32
Learning command into storage key 32
WARNING:miio.device:Found an unsupported model 'xiaomi.wifispeaker.l05g' for class 'ChuangmiIr'. If this is working for you, please open an issue at https://github.com/rytilahti/python-miio/
['ok']
root@DS718:/# miiocli chuangmiir --ip 192.168.0.241 --token xx read 32
Reading infrared command from storage key 32
WARNING:miio.device:Found an unsupported model 'xiaomi.wifispeaker.l05g' for class 'ChuangmiIr'. If this is working for you, please open an issue at https://github.com/rytilahti/python-miio/
{'key': '32', 'code': 'mk1mMwlk0mk4mEsmwBBTWZABlOQAymgB6zGbTUBBZjNpuBDIDMAIWBkc1AkIANATimoHMTYEKgXHAQkB0wGHAyMDpwFymM2AUMDqwCFAiKYzYCcwK3AzoEtAOzm8wCH0HVwB4A4YFvwEamk2mYEhTQDE5pNALnBXeYzKazCYTAA='}
root@DS718:/# miiocli chuangmiir --ip 192.168.0.241 --token xx play 32
Playing the supplied command
WARNING:miio.device:Found an unsupported model 'xiaomi.wifispeaker.l05g' for class 'ChuangmiIr'. If this is working for you, please open an issue at https://github.com/rytilahti/python-miio/
['ok']
```

