### PR TITLE
Replace datetime.utcnow + datetime.utcfromtimestamp

### DIFF
--- a/miio/miioprotocol.py
+++ b/miio/miioprotocol.py
@@ -7,7 +7,7 @@ import binascii
 import codecs
 import logging
 import socket
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pprint import pformat as pf
 from typing import Any, Dict, List, Optional
 
@@ -48,7 +48,7 @@ class MiIOProtocol:
 
         self._discovered = False
         # these come from the device, but we initialize them here to make mypy happy
-        self._device_ts: datetime = datetime.utcnow()
+        self._device_ts: datetime = datetime.now(tz=timezone.utc).replace(tzinfo=None)
         self._device_id = b""
 
     def send_handshake(self, *, retry_count=3) -> Message:

--- a/miio/miioprotocol.py
+++ b/miio/miioprotocol.py
@@ -48,7 +48,7 @@ class MiIOProtocol:
 
         self._discovered = False
         # these come from the device, but we initialize them here to make mypy happy
-        self._device_ts: datetime = datetime.now(tz=timezone.utc).replace(tzinfo=None)
+        self._device_ts: datetime = datetime.now(tz=timezone.utc)
         self._device_id = b""
 
     def send_handshake(self, *, retry_count=3) -> Message:

--- a/miio/miot_cloud.py
+++ b/miio/miot_cloud.py
@@ -110,9 +110,9 @@ class MiotCloud:
     def _file_from_cache(self, file, cache_hours=6) -> Dict:
         def _valid_cache():
             expiration = timedelta(hours=cache_hours)
-            if datetime.fromtimestamp(file.stat().st_mtime) + expiration > datetime.now(
-                tz=timezone.utc
-            ).replace(tzinfo=None):
+            if datetime.fromtimestamp(
+                file.stat().st_mtime, tz=timezone.utc
+            ) + expiration > datetime.now(tz=timezone.utc):
                 return True
 
             return False

--- a/miio/miot_cloud.py
+++ b/miio/miot_cloud.py
@@ -1,7 +1,7 @@
 """Module implementing handling of miot schema files."""
 import json
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from operator import attrgetter
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -110,10 +110,9 @@ class MiotCloud:
     def _file_from_cache(self, file, cache_hours=6) -> Dict:
         def _valid_cache():
             expiration = timedelta(hours=cache_hours)
-            if (
-                datetime.fromtimestamp(file.stat().st_mtime) + expiration
-                > datetime.utcnow()
-            ):
+            if datetime.fromtimestamp(file.stat().st_mtime) + expiration > datetime.now(
+                tz=timezone.utc
+            ).replace(tzinfo=None):
                 return True
 
             return False

--- a/miio/protocol.py
+++ b/miio/protocol.py
@@ -143,7 +143,9 @@ class TimeAdapter(Adapter):
         return calendar.timegm(obj.timetuple())
 
     def _decode(self, obj, context, path):
-        return datetime.datetime.utcfromtimestamp(obj)
+        return datetime.datetime.fromtimestamp(obj, tz=datetime.timezone.utc).replace(
+            tzinfo=None
+        )
 
 
 class EncryptionAdapter(Adapter):
@@ -214,7 +216,15 @@ Message = Struct(
             "length" / Rebuild(Int16ub, Utils.get_length),
             "unknown" / Default(Int32ub, 0x00000000),
             "device_id" / Hex(Bytes(4)),
-            "ts" / TimeAdapter(Default(Int32ub, datetime.datetime.utcnow())),
+            "ts"
+            / TimeAdapter(
+                Default(
+                    Int32ub,
+                    datetime.datetime.now(tz=datetime.timezone.utc).replace(
+                        tzinfo=None
+                    ),
+                )
+            ),
         )
     ),
     "checksum"

--- a/miio/protocol.py
+++ b/miio/protocol.py
@@ -143,9 +143,7 @@ class TimeAdapter(Adapter):
         return calendar.timegm(obj.timetuple())
 
     def _decode(self, obj, context, path):
-        return datetime.datetime.fromtimestamp(obj, tz=datetime.timezone.utc).replace(
-            tzinfo=None
-        )
+        return datetime.datetime.fromtimestamp(obj, tz=datetime.timezone.utc)
 
 
 class EncryptionAdapter(Adapter):
@@ -220,9 +218,7 @@ Message = Struct(
             / TimeAdapter(
                 Default(
                     Int32ub,
-                    datetime.datetime.now(tz=datetime.timezone.utc).replace(
-                        tzinfo=None
-                    ),
+                    datetime.datetime.now(tz=datetime.timezone.utc),
                 )
             ),
         )


### PR DESCRIPTION
Starting with Python 3.12, `datetime.utcnow` and `datetime.utcfromtimestamp` will be deprecated.

https://docs.python.org/3.12/library/datetime.html#datetime.datetime.utcnow
https://docs.python.org/3.12/library/datetime.html#datetime.datetime.utcfromtimestamp