### PR TITLE
Mark xiaomi.repeater.v3 as supported for wifirepeater

### DIFF
--- a/miio/integrations/xiaomi/repeater/wifirepeater.py
+++ b/miio/integrations/xiaomi/repeater/wifirepeater.py
@@ -66,7 +66,7 @@ class WifiRepeaterConfiguration(DeviceStatus):
 class WifiRepeater(Device):
     """Device class for Xiaomi Mi WiFi Repeater 2."""
 
-    _supported_models = ["xiaomi.repeater.v2"]
+    _supported_models = ["xiaomi.repeater.v2", "xiaomi.repeater.v3"]
 
     @command(
         default_output=format_output(
@@ -101,6 +101,22 @@ class WifiRepeater(Device):
         """Turn the WiFi roaming on/off."""
         return self.send(
             "miIO.switch_wifi_explorer", [{"wifi_explorer": int(wifi_roaming)}]
+        )
+
+    @command(
+        click.argument("ssid", type=str),
+        click.argument("password", type=str),
+        default_output=format_output("Updating the accespoint configuration"),
+    )
+    def config_router(self, ssid: str, password: str):
+        """Update the configuration of the accesspoint."""
+        return self.send(
+            "miIO.config_router",
+            {
+                "ssid": ssid,
+                "passwd": password,
+                "uid": 0,
+            }
         )
 
     @command(

--- a/miio/integrations/xiaomi/repeater/wifirepeater.py
+++ b/miio/integrations/xiaomi/repeater/wifirepeater.py
@@ -116,7 +116,7 @@ class WifiRepeater(Device):
                 "ssid": ssid,
                 "passwd": password,
                 "uid": 0,
-            }
+            },
         )
 
     @command(


### PR DESCRIPTION
This includes the config_router action required for xiaomi.repeater.v3 starts repeating.

This is a first approach implementation, if you need changes to accept the PR, please let me know. Hopefully, this does not break any other thing but I haven't checked.

Relevant documentation/references:
* https://github.com/OpenMiHome/mihome-binary-protocol/blob/master/doc/PROTOCOL.md#payloads
* https://github.com/rytilahti/python-miio/issues/1151
* https://github.com/rytilahti/python-miio/issues/1805

For the record, this is a dump of the command result:
```
$ bin/miiocli -d wifirepeater --ip 10.10.10.1 --token TOKEN config_router SSID PASSWORD
INFO:miio.cli:Debug mode active
Setting accesspoint configuration
DEBUG:miio.click_common:Unknown model, trying autodetection. None None
DEBUG:miio.miioprotocol:Got a response: Container: 
    data = Container: 
        data = b'' (total 0)
        value = b'' (total 0)
        offset1 = 32
        offset2 = 32
        length = 0
    header = Container: 
        data = b'!1\x00 \x00\x00\x00\x00STUFF\x00\x00\xSTUFF' (total 16)
        value = Container: 
            length = 32
            unknown = 0
            device_id = unhexlify('DID')
            ts = 1970-01-01 00:18:27
        offset1 = 0
        offset2 = 16
        length = 16
    checksum = b'`STUFFSTUFF' (total 16)
DEBUG:miio.miioprotocol:Discovered 216e335f with ts: 1970-01-01 00:18:27, token: b'TOKEN'
DEBUG:miio.miioprotocol:10.10.10.1:54321 >>: {'id': 1, 'method': 'miIO.info', 'params': []}
DEBUG:miio.miioprotocol:10.10.10.1:54321 (ts: 1970-01-01 00:18:28, id: 1) << {'result': {'life': 1108, 'cfg_time': 1108, 'token': 'TOKEN', 'fw_ver': '3.2.12', 'hw_ver': 'R03', 'uid': 0, 'api_level': 2, 'mcu_fw_ver': '1000', 'wifi_fw_ver': '1.0.0', 'mac': 'MAC', 'model': 'xiaomi.repeater.v3', 'ap': {'rssi': 0, 'ssid': '', 'bssid': '', 'rx': 0, 'tx': 0}, 'sta': {'count': 1, 'ssid': 'SSID', 'hidden': 0, 'assoclist': 'ASSOCLIST;'}, 'netif': {}, 'desc': {'wifi_explorer': 0, 'sn': 'SN/SN', 'color': 100, 'channel': 'release'}}, 'id': 1}
DEBUG:miio.device:Detected model xiaomi.repeater.v3
DEBUG:miio.miioprotocol:10.10.10.1:54321 >>: {'id': 2, 'method': 'miIO.config_router', 'params': {'ssid': SSID, 'passwd': PASSWORD, 'uid': 0}}
DEBUG:miio.miioprotocol:10.10.10.1:54321 (ts: 1970-01-01 00:18:28, id: 2) << {'result': 0, 'id': 2}
0
```

HTH,