### PR TITLE
Add deprecation warnings for main module imports

### DIFF
--- a/miio/__init__.py
+++ b/miio/__init__.py
@@ -85,4 +85,32 @@ from miio.push_server import EventInfo, PushServer
 
 from miio.discovery import Discovery
 
+
+def __getattr__(name):
+    """Create deprecation warnings on classes that are going away."""
+    from warnings import warn
+
+    current_globals = globals()
+
+    def _is_miio_integration(x):
+        """Return True if miio.integrations is in the module 'path'."""
+        module_ = current_globals[x]
+        if "miio.integrations" in str(module_):
+            return True
+
+        return False
+
+    deprecated_module_mapping = {
+        str(x): current_globals[x] for x in current_globals if _is_miio_integration(x)
+    }
+    if new_module := deprecated_module_mapping.get(name):
+        warn(
+            f"Importing {name} directly from 'miio' is deprecated, import {new_module} or use DeviceFactory.create() instead",
+            DeprecationWarning,
+        )
+        return globals()[new_module.__name__]
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 __version__ = version("python-miio")

--- a/miio/tests/test_miio.py
+++ b/miio/tests/test_miio.py
@@ -1,0 +1,16 @@
+"""Tests for the main module."""
+import pytest
+
+import miio
+
+
+@pytest.mark.parametrize(
+    ("old_name", "new_name"),
+    [("RoborockVacuum", "miio.integrations.roborock.vacuum.vacuum.RoborockVacuum")],
+)
+def test_deprecation_warning(old_name, new_name):
+    """Check that deprecation warning gets emitted for deprecated imports."""
+    with pytest.deprecated_call(
+        match=rf"Importing {old_name} directly from 'miio' is deprecated, import <class '{new_name}'> or use DeviceFactory.create\(\) instead"
+    ):
+        miio.__getattr__(old_name)


### PR DESCRIPTION
This instructs users to use direct imports or to use `DeviceFactory.create()` instead of importing directly through the `miio` module.

Fixes #1696