### PR TITLE
dreamevacuum: don't crash on missing property values

### DIFF
--- a/miio/integrations/dreame/vacuum/dreamevacuum_miot.py
+++ b/miio/integrations/dreame/vacuum/dreamevacuum_miot.py
@@ -508,7 +508,7 @@ class DreameVacuum(MiotDevice):
 
         return DreameVacuumStatus(
             {
-                prop["did"]: prop["value"] if prop["code"] == 0 else None
+                prop["did"]: prop.get("value") if prop.get("code") == 0 else None
                 for prop in self.get_properties_for_mapping(max_properties=10)
             },
             self.model,


### PR DESCRIPTION
Do not crash if the dreamevacuum property does not contain a value.

Fixes #1822