### PR TITLE
Don't log error message when decoding valid discovery packets

### DIFF
--- a/miio/protocol.py
+++ b/miio/protocol.py
@@ -161,6 +161,11 @@ class EncryptionAdapter(Adapter):
 
     def _decode(self, obj, context, path) -> Union[Dict, bytes]:
         """Decrypts the payload using the token stored in the context."""
+        # if there is no payload, decode to 0 bytes. Missing payload is expected for discovery messages.
+        # note that we don't have "token" in the context for discovery replies so we couldn't decode it
+        # anyway.
+        if obj == b"":
+            return b""
         try:
             decrypted = Utils.decrypt(obj, context["_"]["token"])
             decrypted = decrypted.rstrip(b"\x00")

--- a/miio/protocol.py
+++ b/miio/protocol.py
@@ -161,11 +161,9 @@ class EncryptionAdapter(Adapter):
 
     def _decode(self, obj, context, path) -> Union[Dict, bytes]:
         """Decrypts the payload using the token stored in the context."""
-        # if there is no payload, decode to 0 bytes. Missing payload is expected for discovery messages.
-        # note that we don't have "token" in the context for discovery replies so we couldn't decode it
-        # anyway.
-        if obj == b"":
-            return b""
+        # Missing payload is expected for discovery messages.
+        if not obj:
+            return obj
         try:
             decrypted = Utils.decrypt(obj, context["_"]["token"])
             decrypted = decrypted.rstrip(b"\x00")


### PR DESCRIPTION
Fix `Unable to decrypt, returning raw bytes` warning message when decoding Discovery messages. Fixes #1824

I opted for a quick surgical fix here rather than rework the whole message parsing. While separating the Discovery messages from normal data messages is quite easy in the context of miioprotocol, there's a quite bit of uses of the `Message` in other places too. I didn't feel confident in changing those.

Additionally, it doesn't even seem desirable to separate Discovery-Ack and Data messages. It seems useful in some cases to be able to parse any message without knowing ahead of time what kind of data it might contain. (I doesn't really matter right now as the token, i.e. decryption key, must be supplied ahead of time, but it is conceivable that a parser might first match the ID of the reply to the request and then parse the contents. )

Fixes #1824
