### PR TITLE
add json decode quirk for xiaomi e10

### DIFF
--- a/miio/protocol.py
+++ b/miio/protocol.py
@@ -187,9 +187,7 @@ class EncryptionAdapter(Adapter):
                 b'"value":00', b'"value":0'
             ),
             # fix double commas for xiaomi.vacuum.b112, fw: 2.2.4_0049
-            lambda decrypted_bytes: decrypted_bytes.replace(
-                b',,', b','
-            ),
+            lambda decrypted_bytes: decrypted_bytes.replace(b",,", b","),
         ]
 
         for i, quirk in enumerate(decrypted_quirks):

--- a/miio/protocol.py
+++ b/miio/protocol.py
@@ -186,6 +186,10 @@ class EncryptionAdapter(Adapter):
             lambda decrypted_bytes: decrypted_bytes.replace(
                 b'"value":00', b'"value":0'
             ),
+            # fix double commas for xiaomi.vacuum.b112, fw: 2.2.4_0049
+            lambda decrypted_bytes: decrypted_bytes.replace(
+                b',,', b','
+            ),
         ]
 
         for i, quirk in enumerate(decrypted_quirks):


### PR DESCRIPTION
Device:

Model: xiaomi.vacuum.b112
Hardware version: esp32
Firmware version: 2.2.4_0049

Fixes decode JSON error:
```
miiocli genericmiot --ip <IP> --token <TOKEN> status
Running command status
ERROR:miio.protocol:Unable to parse json 'b'{"id":4,"result":[{"did":"sweep:mop-hours","siid":7,"piid":15,"code":0,"value":180},{"did":"sweep:time-zone","siid":7,"piid":20,"code":0,"value":-7200},{"did":"sweep:cur-lang","siid":7,"piid":21,"code":0,"value":"ZH_CN"},{"did":"sweep:cleaning-time","siid":7,"piid":22,"code":0,"value":0},{"did":"sweep:cleaning-area","siid":7,"piid":23,"code":0,"value":0},,{"did":"sweep:consumablesinfo","siid":7,"piid":48,"code":0,"value":"[99_357,98_177,98_177,100_180]"},{"did":"sweep:charge-pose","siid":7,"piid":49,"code":0,"value":"[0,0]"},{"did":"order:all-enable-count","siid":8,"piid":18,"code":0,"value":"hello"},{"did":"point-zone:target-point","siid":9,"piid":5,"code":0,"value":"0,0"}],"exe_time":40}'': Expecting value: line 1 column 358 (char 357)
ERROR:miio.click_common:Exception: Unable to parse message payload
```