### PR TITLE
Suppress 'found an unsupported model' warning

### DIFF
--- a/miio/device.py
+++ b/miio/device.py
@@ -138,15 +138,6 @@ class Device(metaclass=DeviceGroupMeta):
             devinfo = DeviceInfo(self.send("miIO.info"))
             self._info = devinfo
             _LOGGER.debug("Detected model %s", devinfo.model)
-            cls = self.__class__.__name__
-            # Ignore bases and generic classes
-            bases = ["Device", "MiotDevice", "GenericMiot"]
-            if devinfo.model not in self.supported_models and cls not in bases:
-                _LOGGER.warning(
-                    "Found an unsupported model '%s' for class '%s'. If this is working for you, please open an issue at https://github.com/rytilahti/python-miio/",
-                    devinfo.model,
-                    cls,
-                )
 
             return devinfo
         except PayloadDecodeException as ex:


### PR DESCRIPTION
This is not needed anymore, as #1845 reports on missing identifiers and roborocks are covered by a wildcard matcher in devicefactory.

The original reason for adding this warning was to gather a list of devices that we should add to the supported devices list for devicefactory, but I think we are well covered now at least for roborock (closing the issues below, other integrations need to be adapted to use wildcards where feasible).

Closes #1843
Closes #1840
Closes #1833
Closes #1820
Closes #1797
Closes #1652