### PR TITLE
Add specification for yeelink.light.lamp2

### DIFF
--- a/miio/integrations/yeelight/light/specs.yaml
+++ b/miio/integrations/yeelight/light/specs.yaml
@@ -138,6 +138,10 @@ yeelink.light.lamp1:
   night_light: False
   color_temp: [2700, 5000]
   supports_color: False
+yeelink.light.lamp2:
+  night_light: False
+  color_temp: [2500, 4800]
+  supports_color: False
 yeelink.light.lamp4:
   night_light: False
   color_temp: [2600, 5000]


### PR DESCRIPTION
Based on Xiaomi Mi Desk Lamp Pro which reports `yeelink.light.lamp2`.

```
Model: yeelink.light.lamp2
Hardware version: esp32
Firmware version: 2.1.7_0042
```

Fixes #1756