### PR TITLE
Make Device.sensors() only return read-only descriptors

### DIFF
--- a/miio/device.py
+++ b/miio/device.py
@@ -299,7 +299,7 @@ class Device(metaclass=DeviceGroupMeta):
             {
                 k: v
                 for k, v in self.descriptors().items()
-                if isinstance(v, PropertyDescriptor) and v.access & AccessFlags.Read
+                if v.access == AccessFlags.Read
             },
             device=self,
         )


### PR DESCRIPTION
This was incorrectly returning also readable settings, this changes the behavior to conform with the docstring.