### PR TITLE
Raise InvalidTokenException on invalid token

### DIFF
--- a/miio/exceptions.py
+++ b/miio/exceptions.py
@@ -2,6 +2,10 @@ class DeviceException(Exception):
     """Exception wrapping any communication errors with the device."""
 
 
+class InvalidTokenException(DeviceException):
+    """Exception raised when invalid token is detected."""
+
+
 class PayloadDecodeException(DeviceException):
     """Exception for failures in payload decoding.
 

--- a/miio/miioprotocol.py
+++ b/miio/miioprotocol.py
@@ -13,7 +13,12 @@ from typing import Any, Dict, List, Optional
 
 import construct
 
-from .exceptions import DeviceError, DeviceException, RecoverableError
+from .exceptions import (
+    DeviceError,
+    DeviceException,
+    InvalidTokenException,
+    RecoverableError,
+)
 from .protocol import Message
 
 _LOGGER = logging.getLogger(__name__)
@@ -219,7 +224,7 @@ class MiIOProtocol:
             except KeyError:
                 return payload
         except construct.core.ChecksumError as ex:
-            raise DeviceException(
+            raise InvalidTokenException(
                 "Got checksum error which indicates use "
                 "of an invalid token. "
                 "Please check your token!"


### PR DESCRIPTION
Invalid checksum raises now a more specialized `InvalidTokenException`. This will allow downstreams to request the user to check the token.