### PR TITLE
Added support for Xiaomi Tower Fan (dmaker.fan.p39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ integration, this library supports also the following devices:
 * Xiaomi Philips Zhirui Bedroom Smart Lamp
 * Huayi Huizuo Lamps
 * Xiaomi Universal IR Remote Controller (Chuangmi IR)
-* Xiaomi Mi Smart Pedestal Fan V2, V3, SA1, ZA1, ZA3, ZA4, ZA5 1C, P5, P9, P10, P11, P15, P18, P33, P45
+* Xiaomi Mi Smart Pedestal Fan V2, V3, SA1, ZA1, ZA3, ZA4, ZA5 1C, P5, P9, P10, P11, P15, P18, P33, P39, P45
 * Xiaomi Rosou SS4 Ventilator (leshow.fan.ss4)
 * Xiaomi Mi Air Humidifier V1, CA1, CA4, CB1, MJJSQ, JSQ, JSQ1, JSQ001
 * Xiaomi Mi Water Purifier (Basic support: Turn on & off)

--- a/miio/integrations/dmaker/fan/fan_miot.py
+++ b/miio/integrations/dmaker/fan/fan_miot.py
@@ -24,6 +24,7 @@ MODEL_FAN_P11 = "dmaker.fan.p11"
 MODEL_FAN_P15 = "dmaker.fan.p15"
 MODEL_FAN_P18 = "dmaker.fan.p18"
 MODEL_FAN_P33 = "dmaker.fan.p33"
+MODEL_FAN_P39 = "dmaker.fan.p39"
 MODEL_FAN_P45 = "dmaker.fan.p45"
 MODEL_FAN_1C = "dmaker.fan.1c"
 
@@ -87,6 +88,20 @@ MIOT_MAPPING = {
         "power_off_time": {"siid": 3, "piid": 1},
         "set_move": {"siid": 6, "piid": 1},
     },
+    MODEL_FAN_P39: {
+        # https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:fan:0000A005:dmaker-p39:1
+        "power": {"siid": 2, "piid": 1},
+        "fan_level": {"siid": 2, "piid": 2},
+        "mode": {"siid": 2, "piid": 4},
+        "swing_mode": {"siid": 2, "piid": 5},
+        "swing_mode_angle": {"siid": 2, "piid": 6},
+        "power_off_time": {"siid": 2, "piid": 8},
+        "set_move": {"siid": 2, "piid": 10, "access": ["write"]},
+        "fan_speed": {"siid": 2, "piid": 11},
+        "child_lock": {"siid": 3, "piid": 1},
+        "buzzer": {"siid": 2, "piid": 7},
+        "light": {"siid": 2, "piid": 9},
+    },
     MODEL_FAN_P45: {
         # Source https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:fan:0000A005:dmaker-p45:1
         "power": {"siid": 2, "piid": 1},
@@ -129,6 +144,7 @@ SUPPORTED_ANGLES = {
     MODEL_FAN_P15: [30, 60, 90, 120, 140],  # mapped to P11
     MODEL_FAN_P18: [30, 60, 90, 120, 140],  # mapped to P10
     MODEL_FAN_P33: [30, 60, 90, 120, 140],
+    MODEL_FAN_P39: [30, 60, 90, 120, 140],
     MODEL_FAN_P45: [30, 60, 90, 120, 150],
 }
 

--- a/miio/integrations/dmaker/fan/fan_miot.py
+++ b/miio/integrations/dmaker/fan/fan_miot.py
@@ -24,6 +24,7 @@ MODEL_FAN_P11 = "dmaker.fan.p11"
 MODEL_FAN_P15 = "dmaker.fan.p15"
 MODEL_FAN_P18 = "dmaker.fan.p18"
 MODEL_FAN_P33 = "dmaker.fan.p33"
+MODEL_FAN_P39 = "dmaker.fan.p39"
 MODEL_FAN_P45 = "dmaker.fan.p45"
 MODEL_FAN_1C = "dmaker.fan.1c"
 
@@ -87,6 +88,20 @@ MIOT_MAPPING = {
         "power_off_time": {"siid": 3, "piid": 1},
         "set_move": {"siid": 6, "piid": 1},
     },
+    MODEL_FAN_P39: {
+        # https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:fan:0000A005:dmaker-p39:1
+        "power": {"siid": 2, "piid": 1},
+        "fan_level": {"siid": 2, "piid": 2},
+        "mode": {"siid": 2, "piid": 4},
+        "swing_mode": {"siid": 2, "piid": 5},
+        "swing_mode_angle": {"siid": 2, "piid": 6},
+        "power_off_time": {"siid": 2, "piid": 8},
+        "set_move": {"siid": 2, "piid": 10},
+        "fan_speed": {"siid": 2, "piid": 11},
+        "child_lock": {"siid": 3, "piid": 1},
+        "buzzer": {"siid": 2, "piid": 7},
+        "light": {"siid": 2, "piid": 9},
+    },
     MODEL_FAN_P45: {
         # Source https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:fan:0000A005:dmaker-p45:1
         "power": {"siid": 2, "piid": 1},
@@ -129,6 +144,7 @@ SUPPORTED_ANGLES = {
     MODEL_FAN_P15: [30, 60, 90, 120, 140],  # mapped to P11
     MODEL_FAN_P18: [30, 60, 90, 120, 140],  # mapped to P10
     MODEL_FAN_P33: [30, 60, 90, 120, 140],
+    MODEL_FAN_P39: [30, 60, 90, 120, 140],
     MODEL_FAN_P45: [30, 60, 90, 120, 150],
 }
 

--- a/miio/integrations/dmaker/fan/fan_miot.py
+++ b/miio/integrations/dmaker/fan/fan_miot.py
@@ -24,7 +24,6 @@ MODEL_FAN_P11 = "dmaker.fan.p11"
 MODEL_FAN_P15 = "dmaker.fan.p15"
 MODEL_FAN_P18 = "dmaker.fan.p18"
 MODEL_FAN_P33 = "dmaker.fan.p33"
-MODEL_FAN_P39 = "dmaker.fan.p39"
 MODEL_FAN_P45 = "dmaker.fan.p45"
 MODEL_FAN_1C = "dmaker.fan.1c"
 
@@ -88,20 +87,6 @@ MIOT_MAPPING = {
         "power_off_time": {"siid": 3, "piid": 1},
         "set_move": {"siid": 6, "piid": 1},
     },
-    MODEL_FAN_P39: {
-        # https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:fan:0000A005:dmaker-p39:1
-        "power": {"siid": 2, "piid": 1},
-        "fan_level": {"siid": 2, "piid": 2},
-        "mode": {"siid": 2, "piid": 4},
-        "swing_mode": {"siid": 2, "piid": 5},
-        "swing_mode_angle": {"siid": 2, "piid": 6},
-        "power_off_time": {"siid": 2, "piid": 8},
-        "set_move": {"siid": 2, "piid": 10},
-        "fan_speed": {"siid": 2, "piid": 11},
-        "child_lock": {"siid": 3, "piid": 1},
-        "buzzer": {"siid": 2, "piid": 7},
-        "light": {"siid": 2, "piid": 9},
-    },
     MODEL_FAN_P45: {
         # Source https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:fan:0000A005:dmaker-p45:1
         "power": {"siid": 2, "piid": 1},
@@ -144,7 +129,6 @@ SUPPORTED_ANGLES = {
     MODEL_FAN_P15: [30, 60, 90, 120, 140],  # mapped to P11
     MODEL_FAN_P18: [30, 60, 90, 120, 140],  # mapped to P10
     MODEL_FAN_P33: [30, 60, 90, 120, 140],
-    MODEL_FAN_P39: [30, 60, 90, 120, 140],
     MODEL_FAN_P45: [30, 60, 90, 120, 150],
 }
 

--- a/miio/integrations/dmaker/fan/fan_miot.py
+++ b/miio/integrations/dmaker/fan/fan_miot.py
@@ -96,7 +96,7 @@ MIOT_MAPPING = {
         "swing_mode": {"siid": 2, "piid": 5},
         "swing_mode_angle": {"siid": 2, "piid": 6},
         "power_off_time": {"siid": 2, "piid": 8},
-        "set_move": {"siid": 2, "piid": 10, "access": ["write"]},
+        "set_move": {"siid": 2, "piid": 10},
         "fan_speed": {"siid": 2, "piid": 11},
         "child_lock": {"siid": 3, "piid": 1},
         "buzzer": {"siid": 2, "piid": 7},

--- a/miio/integrations/zhimi/heater/heater_miot.py
+++ b/miio/integrations/zhimi/heater/heater_miot.py
@@ -25,6 +25,22 @@ _MAPPINGS = {
         # Indicator light (siid=7)
         "led_brightness": {"siid": 7, "piid": 3},
     },
+    "zhimi.heater.mc2a": {
+        # Source https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:heater:0000A01A:zhimi-mc2a:1
+        # Heater (siid=2)
+        "power": {"siid": 2, "piid": 1},
+        "target_temperature": {"siid": 2, "piid": 5},
+        # Countdown (siid=3)
+        "countdown_time": {"siid": 3, "piid": 1},
+        # Environment (siid=4)
+        "temperature": {"siid": 4, "piid": 7},
+        # Physical Control Locked (siid=5)
+        "child_lock": {"siid": 5, "piid": 1},
+        # Alarm (siid=6)
+        "buzzer": {"siid": 6, "piid": 1},
+        # Indicator light (siid=7)
+        "led_brightness": {"siid": 7, "piid": 3},
+    },
     "zhimi.heater.za2": {
         # Source https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:heater:0000A01A:zhimi-za2:1
         # Heater (siid=2)
@@ -62,6 +78,10 @@ _MAPPINGS = {
 
 HEATER_PROPERTIES = {
     "zhimi.heater.mc2": {
+        "temperature_range": (18, 28),
+        "delay_off_range": (0, 12 * 3600),
+    },
+    "zhimi.heater.mc2a": {
         "temperature_range": (18, 28),
         "delay_off_range": (0, 12 * 3600),
     },


### PR DESCRIPTION
This PR adds support for Xiaomi Tower Fan (dmaker.fan.p39).
Changes are minimal as the p39 is quite similar to p33.

I own the device myself and can confirm that everything reads and performs as expected.

I would appreciate a quick merge as this is only the first step on my journey to natively integrate both devices into the main "Xiaomi" integration for Home Assistant.

Thanks a lot for the amazing foundation!