### PR TITLE
Various fixes to roborockvacuum

### DIFF
--- a/miio/descriptorcollection.py
+++ b/miio/descriptorcollection.py
@@ -106,7 +106,12 @@ class DescriptorCollection(UserDict, Generic[T]):
         if prop.access & AccessFlags.Write and prop.setter is None:
             raise ValueError(f"Neither setter or setter_name was defined for {prop}")
 
-        self._handle_constraints(prop)
+        try:
+            self._handle_constraints(prop)
+        except (
+            Exception
+        ) as ex:  # TODO: temporary hack as this should not cause I/O nor fail
+            _LOGGER.error("Adding constraints failed: %s", ex)
 
     def _handle_constraints(self, prop: PropertyDescriptor) -> None:
         """Set attribute-based constraints for the descriptor."""

--- a/miio/descriptorcollection.py
+++ b/miio/descriptorcollection.py
@@ -1,5 +1,6 @@
 import logging
 from collections import UserDict
+from enum import Enum
 from inspect import getmembers
 from typing import TYPE_CHECKING, Generic, TypeVar, cast
 
@@ -121,7 +122,11 @@ class DescriptorCollection(UserDict, Generic[T]):
                 retrieve_choices_function = getattr(
                     self._device, prop.choices_attribute
                 )
-                prop.choices = retrieve_choices_function()
+                choices = retrieve_choices_function()
+                if isinstance(choices, dict):
+                    prop.choices = Enum(f"GENERATED_ENUM_{prop.name}", choices)
+                else:
+                    prop.choices = choices
 
             if prop.choices is None:
                 raise ValueError(

--- a/miio/descriptorcollection.py
+++ b/miio/descriptorcollection.py
@@ -13,6 +13,7 @@ from .descriptors import (
     PropertyDescriptor,
     RangeDescriptor,
 )
+from .exceptions import DeviceException
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -107,11 +108,10 @@ class DescriptorCollection(UserDict, Generic[T]):
         if prop.access & AccessFlags.Write and prop.setter is None:
             raise ValueError(f"Neither setter or setter_name was defined for {prop}")
 
+        # TODO: temporary hack as this should not cause I/O nor fail
         try:
             self._handle_constraints(prop)
-        except (
-            Exception
-        ) as ex:  # TODO: temporary hack as this should not cause I/O nor fail
+        except DeviceException as ex:
             _LOGGER.error("Adding constraints failed: %s", ex)
 
     def _handle_constraints(self, prop: PropertyDescriptor) -> None:

--- a/miio/descriptorcollection.py
+++ b/miio/descriptorcollection.py
@@ -42,10 +42,11 @@ class DescriptorCollection(UserDict, Generic[T]):
         2. Going through all members and looking if they have a '_descriptor' attribute set by a decorator
         """
         _LOGGER.debug("Adding descriptors from %s", obj)
+        descriptors_to_add = []
         # 1. Check for existence of _descriptors as DeviceStatus' metaclass collects them already
         if descriptors := getattr(obj, "_descriptors"):  # noqa: B009
             for _name, desc in descriptors.items():
-                self.add_descriptor(desc)
+                descriptors_to_add.append(desc)
 
         # 2. Check if object members have descriptors
         for _name, method in getmembers(obj, lambda o: hasattr(o, "_descriptor")):
@@ -55,7 +56,10 @@ class DescriptorCollection(UserDict, Generic[T]):
                 continue
 
             prop_desc.method = method
-            self.add_descriptor(prop_desc)
+            descriptors_to_add.append(prop_desc)
+
+        for desc in descriptors_to_add:
+            self.add_descriptor(desc)
 
     def add_descriptor(self, descriptor: Descriptor):
         """Add a descriptor to the collection.

--- a/miio/device.py
+++ b/miio/device.py
@@ -139,6 +139,8 @@ class Device(metaclass=DeviceGroupMeta):
             self._info = devinfo
             _LOGGER.debug("Detected model %s", devinfo.model)
 
+            self._initialize_descriptors()
+
             return devinfo
         except PayloadDecodeException as ex:
             raise DeviceInfoUnavailableException(
@@ -153,6 +155,9 @@ class Device(metaclass=DeviceGroupMeta):
         This can be overridden to add additional descriptors to the device.
         If you do so, do not forget to call this method.
         """
+        if self._initialized:
+            return
+
         self._descriptors.descriptors_from_object(self)
 
         # Read descriptors from the status class

--- a/miio/device.py
+++ b/miio/device.py
@@ -139,8 +139,6 @@ class Device(metaclass=DeviceGroupMeta):
             self._info = devinfo
             _LOGGER.debug("Detected model %s", devinfo.model)
 
-            self._initialize_descriptors()
-
             return devinfo
         except PayloadDecodeException as ex:
             raise DeviceInfoUnavailableException(

--- a/miio/integrations/roborock/vacuum/vacuum.py
+++ b/miio/integrations/roborock/vacuum/vacuum.py
@@ -1061,6 +1061,16 @@ class RoborockVacuum(Device):
         """
         return self.send("get_fw_features")
 
+    def _initialize_descriptors(self) -> None:
+        """Initialize device descriptors.
+
+        Overridden to collect descriptors also from the update helper.
+        """
+        if not self._initialized:
+            super()._initialize_descriptors()
+            res = self.status()
+            self._descriptors.descriptors_from_object(res)
+
     @classmethod
     def get_device_group(cls):
         @click.pass_context

--- a/miio/integrations/roborock/vacuum/vacuum.py
+++ b/miio/integrations/roborock/vacuum/vacuum.py
@@ -1066,10 +1066,12 @@ class RoborockVacuum(Device):
 
         Overridden to collect descriptors also from the update helper.
         """
-        if not self._initialized:
-            super()._initialize_descriptors()
-            res = self.status()
-            self._descriptors.descriptors_from_object(res)
+        if self._initialized:
+            return
+
+        super()._initialize_descriptors()
+        res = self.status()
+        self._descriptors.descriptors_from_object(res)
 
     @classmethod
     def get_device_group(cls):

--- a/miio/integrations/roborock/vacuum/vacuumcontainers.py
+++ b/miio/integrations/roborock/vacuum/vacuumcontainers.py
@@ -279,6 +279,17 @@ class VacuumStatus(DeviceStatus):
 
     @property
     @setting(
+        "Fanspeed preset",
+        choices_attribute="fan_speed_presets",
+        setter_name="set_fan_speed_preset",
+        icon="mdi:fan",
+        id=VacuumId.FanSpeedPreset,
+    )
+    def fan_speed_preset(self):
+        return self.data["fan_power"]
+
+    @property
+    @setting(
         "Mop scrub intensity",
         choices=MopIntensity,
         setter_name="set_mop_intensity",

--- a/miio/integrations/roborock/vacuum/vacuumcontainers.py
+++ b/miio/integrations/roborock/vacuum/vacuumcontainers.py
@@ -192,6 +192,7 @@ class VacuumStatus(DeviceStatus):
             self.state_code, f"Unknown state (code: {self.state_code})"
         )
 
+    @property
     @sensor("Vacuum state", id=VacuumId.State)
     def vacuum_state(self) -> VacuumState:
         """Return vacuum state."""

--- a/miio/tests/dummies.py
+++ b/miio/tests/dummies.py
@@ -1,4 +1,4 @@
-from miio import DeviceError
+from miio import DescriptorCollection, DeviceError
 
 
 class DummyMiIOProtocol:
@@ -46,6 +46,8 @@ class DummyDevice:
         self._settings = {}
         self._sensors = {}
         self._actions = {}
+        self._initialized = False
+        self._descriptors = DescriptorCollection(device=self)
         # TODO: ugly hack to check for pre-existing _model
         if getattr(self, "_model", None) is None:
             self._model = "dummy.model"

--- a/miio/tests/test_device.py
+++ b/miio/tests/test_device.py
@@ -182,7 +182,9 @@ def test_supports_miot(mocker):
     assert d.supports_miot() is True
 
 
-@pytest.mark.parametrize("getter_name", ["actions", "settings", "sensors"])
+@pytest.mark.parametrize(
+    "getter_name", ["actions", "settings", "sensors", "descriptors"]
+)
 def test_cached_descriptors(getter_name, mocker, caplog):
     d = Device("127.0.0.1", "68ffffffffffffffffffffffffffffff")
     getter = getattr(d, getter_name)

--- a/miio/tests/test_device.py
+++ b/miio/tests/test_device.py
@@ -143,9 +143,10 @@ def test_init_signature(cls, mocker):
     """Make sure that __init__ of every device-inheriting class accepts the expected
     parameters."""
     mocker.patch("miio.Device.send")
+    mocker.patch("miio.Device.send_handshake")
     parent_init = mocker.spy(Device, "__init__")
     kwargs = {
-        "ip": "IP",
+        "ip": "127.123.123.123",
         "token": None,
         "start_id": 0,
         "debug": False,


### PR DESCRIPTION
* Include descriptors from `status()` response. This performs I/O during the initialization to find out which information is available. Alternative would be changing `updatehelper.py` to collect the descriptors from all embedded updates, unsure what's the best approach.
* Fix exposing vacuum state.
* Expose fan speed presets.

Related to https://github.com/rytilahti/homeassistant-xiaomi-ng/issues/1