### PR TITLE
Roborock: Add WiFi signal strength sensor

### DIFF
--- a/miio/integrations/roborock/vacuum/vacuum.py
+++ b/miio/integrations/roborock/vacuum/vacuum.py
@@ -47,6 +47,7 @@ from .vacuumcontainers import (
     CarpetModeStatus,
     CleaningDetails,
     CleaningSummary,
+    ConnectivityStatus,
     ConsumableStatus,
     DNDStatus,
     MapList,
@@ -155,6 +156,7 @@ class RoborockVacuum(Device):
         self._map_enum_cache = None
         self._status_helper = UpdateHelper(self.vacuum_status)
         self._status_helper.add_update_method("consumables", self.consumable_status)
+        self._status_helper.add_update_method("connectivity", self.connectivity_status)
         self._status_helper.add_update_method("dnd_status", self.dnd_status)
         self._status_helper.add_update_method("clean_history", self.clean_history)
         self._status_helper.add_update_method("last_clean", self.last_clean_details)
@@ -619,6 +621,11 @@ class RoborockVacuum(Device):
         # {'result': [{'enabled': 1, 'start_minute': 0, 'end_minute': 0,
         #  'start_hour': 22, 'end_hour': 8}], 'id': 1}
         return DNDStatus(self.send("get_dnd_timer")[0])
+
+    @command()
+    def connectivity_status(self) -> ConnectivityStatus:
+        """Returns WiFi connectivity information."""
+        return ConnectivityStatus(self.info(skip_cache=True))
 
     @command(
         click.argument("start_hr", type=int),

--- a/miio/integrations/roborock/vacuum/vacuumcontainers.py
+++ b/miio/integrations/roborock/vacuum/vacuumcontainers.py
@@ -8,6 +8,7 @@ from croniter import croniter
 from pytz import BaseTzInfo
 
 from miio.device import DeviceStatus
+from miio.deviceinfo import DeviceInfo
 from miio.devicestatus import sensor, setting
 from miio.identifiers import VacuumId, VacuumState
 from miio.utils import pretty_seconds, pretty_time
@@ -1062,3 +1063,20 @@ class MopDryerSettings(DeviceStatus):
     def dry_time(self) -> timedelta:
         """Return mop dry time."""
         return pretty_seconds(self.data["on"]["dry_time"])
+
+
+class ConnectivityStatus(DeviceStatus):
+    def __init__(self, info: DeviceInfo) -> None:
+        self.info = info
+
+    @property
+    @sensor(
+        "Wifi Signal Strengh",
+        unit="dBm",
+        icon="mdi:wifi-strength-2",  # TODO: Make this dynamic?
+        device_class="signal_strength",
+        entity_category="diagnostic",
+    )
+    def total_duration(self) -> timedelta:
+        """Total cleaning duration."""
+        return self.info.accesspoint["rssi"]


### PR DESCRIPTION
Re: https://github.com/rytilahti/python-miio/pull/1914#discussion_r1531240944

All I have is Q Revo and S7 (both cloud connected); I don't know about other devices.

Options include:

 - Store prior `info()` failures and skip this if it fails
 - Only call `add_update_method(connectivity_status)` if the WiFi strength sensor is enabled in HA (requires a more complex refactor)
 - Move this sensor to a separate feature in the base class, independent of status classes and everything else (would decouple async work, and may make it easier to implement the previous bullet)