### PR TITLE
Add unique_identifier property to miot properties, actions, and events

### DIFF
--- a/miio/tests/test_miot_models.py
+++ b/miio/tests/test_miot_models.py
@@ -21,6 +21,7 @@ from miio.miot_models import (
     URN,
     MiotAccess,
     MiotAction,
+    MiotBaseModel,
     MiotEnumValue,
     MiotEvent,
     MiotFormat,
@@ -349,3 +350,18 @@ def test_get_descriptor_enum_property(read_only, expected):
 def test_property_pretty_value():
     """Test the pretty value conversions."""
     raise NotImplementedError()
+
+
+@pytest.mark.parametrize(
+    ("collection", "id_var"),
+    [("actions", "aiid"), ("properties", "piid"), ("events", "eiid")],
+)
+def test_unique_identifier(collection, id_var):
+    """Test unique identifier for properties, actions, and events."""
+    serv = MiotService.parse_raw(DUMMY_SERVICE)
+    elem: MiotBaseModel = getattr(serv, collection)
+    first = elem[0]
+    assert (
+        first.unique_identifier
+        == f"{first.normalized_name}_{serv.siid}_{getattr(first, id_var)}"
+    )


### PR DESCRIPTION
This allows descriptors to have device-unique identifiers, the format is '<normalized_name>_<siid>_<id>'.

This also changes 'id' of the descriptors to use this identifier in-place of a plain name from the description.