### PR TITLE
Introducing python-miio Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Status](https://github.com/rytilahti/python-miio/actions/workflows/ci.yml/badge.
 [![Coverage
 Status](https://codecov.io/gh/rytilahti/python-miio/branch/master/graph/badge.svg?token=lYKWubxkLU)](https://codecov.io/gh/rytilahti/python-miio)
 [![Documentation status](https://readthedocs.org/projects/python-miio/badge/?version=latest)](https://python-miio.readthedocs.io/en/latest/?badge=latest)
-[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20python-miio%20Guru-006BFF)](https://gurubase.io/g/python-miio)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20python--miio%20Guru-006BFF)](https://gurubase.io/g/python-miio)
 
 This library (and its accompanying cli tool, `miiocli`) can be used to control devices using Xiaomi's
 [miIO](https://github.com/OpenMiHome/mihome-binary-protocol/blob/master/doc/PROTOCOL.md)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Status](https://github.com/rytilahti/python-miio/actions/workflows/ci.yml/badge.
 [![Coverage
 Status](https://codecov.io/gh/rytilahti/python-miio/branch/master/graph/badge.svg?token=lYKWubxkLU)](https://codecov.io/gh/rytilahti/python-miio)
 [![Documentation status](https://readthedocs.org/projects/python-miio/badge/?version=latest)](https://python-miio.readthedocs.io/en/latest/?badge=latest)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20python-miio%20Guru-006BFF)](https://gurubase.io/g/python-miio)
 
 This library (and its accompanying cli tool, `miiocli`) can be used to control devices using Xiaomi's
 [miIO](https://github.com/OpenMiHome/mihome-binary-protocol/blob/master/doc/PROTOCOL.md)


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [python-miio Guru](https://gurubase.io/g/python-miio) to Gurubase. python-miio Guru uses the data from this repo and data from the [docs](https://python-miio.readthedocs.io/en/latest/) to answer questions by leveraging the LLM.

In this PR, I showcased the "python-miio Guru", which highlights that python-miio now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable python-miio Guru in Gurubase, just let me know that's totally fine.
