### PR TITLE
Remove unnecessary partial() wrapper from MiotValueType.Bool

### DIFF
--- a/miio/miot_device.py
+++ b/miio/miot_device.py
@@ -1,6 +1,5 @@
 import logging
 from enum import Enum, member
-from functools import partial
 from typing import Any
 
 import click
@@ -12,7 +11,6 @@ from .exceptions import DeviceException
 _LOGGER = logging.getLogger(__name__)
 
 
-# partial is required here for str2bool, see https://stackoverflow.com/a/40339397
 class MiotValueType(Enum):
     def _str2bool(x):
         """Helper to convert string to boolean."""
@@ -20,7 +18,7 @@ class MiotValueType(Enum):
 
     Int = int
     Float = float
-    Bool = member(partial(_str2bool))
+    Bool = member(_str2bool)
     Str = str
 
 


### PR DESCRIPTION
Updated Bool member assignment to use _str2bool directly for future decorator compatibility.

Fixes #2028 

/usr/local/lib/python3.13/site-packages/miio/miot_device.py:23: **FutureWarning: functools.partial will be a method descriptor in future Python versions; wrap it in enum.member()** if you want to preserve the old behavior Bool = partial(_str2bool)
