### PR TITLE
Add MIoT support for Xiaomi Robot Vacuum S40C EU

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.9"]
         os: [ubuntu-latest, macos-latest, windows-latest]
+        exclude:
+          - python-version: "pypy3.9"
+            os: windows-latest
 
     steps:
       - uses: "actions/checkout@v4"

--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ Use `miiocli genericmiot --help` for more available commands.
 
 **Note, using this integration requires you to use the git version until [version 0.6.0](https://github.com/rytilahti/python-miio/issues/1114) is released.**
 
+Some MIoT devices also have dedicated integrations built on top of the same protocol.
+For example, `xiaomi.vacuum.e101gb` (Xiaomi Robot Vacuum S40C EU) is supported through
+the `XiaomiVacuumE101GB` integration and `DeviceFactory.create()`.
+
 ## Controlling older (miIO) devices
 
 Older devices are mainly supported by their corresponding modules (e.g.,
@@ -237,6 +241,7 @@ While all MIoT devices are supported through the `genericmiot`
 integration, this library supports also the following devices:
 
 * Xiaomi Mi Robot Vacuum V1, S4, S4 MAX, S5, S5 MAX, S6 Pure, M1S, S7
+* Xiaomi Robot Vacuum S40C EU (`xiaomi.vacuum.e101gb`)
 * Xiaomi Mi Home Air Conditioner Companion
 * Xiaomi Mi Smart Air Conditioner A (xiaomi.aircondition.mc1, mc2, mc4, mc5)
 * Xiaomi Mi Air Purifier 2, 3H, 3C, 4, Pro, Pro H, 4 Pro (zhimi.airpurifier.m2, mb3, mb4, mb5, v7, vb2, va2), 4 Lite

--- a/miio/__init__.py
+++ b/miio/__init__.py
@@ -83,6 +83,7 @@ from miio.integrations.viomi.vacuum import ViomiVacuum
 from miio.integrations.viomi.viomidishwasher import ViomiDishwasher
 from miio.integrations.xiaomi.aircondition.airconditioner_miot import AirConditionerMiot
 from miio.integrations.xiaomi.repeater.wifirepeater import WifiRepeater
+from miio.integrations.xiaomi.vacuum.vacuum_miot import XiaomiVacuumE101GB
 from miio.integrations.xiaomi.wifispeaker.wifispeaker import WifiSpeaker
 from miio.integrations.yeelight.dual_switch import YeelightDualControlModule
 from miio.integrations.yeelight.light import Yeelight

--- a/miio/integrations/xiaomi/vacuum/__init__.py
+++ b/miio/integrations/xiaomi/vacuum/__init__.py
@@ -1,0 +1,3 @@
+from .vacuum_miot import XiaomiVacuumE101GB, XiaomiVacuumE101GBStatus
+
+__all__ = ["XiaomiVacuumE101GB", "XiaomiVacuumE101GBStatus"]

--- a/miio/integrations/xiaomi/vacuum/test_vacuum_miot.py
+++ b/miio/integrations/xiaomi/vacuum/test_vacuum_miot.py
@@ -1,0 +1,207 @@
+from datetime import timedelta
+from unittest import TestCase
+
+import pytest
+
+from miio import XiaomiVacuumE101GB
+from miio.tests.dummies import DummyMiotDevice
+
+from .vacuum_miot import (
+    XIAOMI_VACUUM_E101GB,
+    Consumable,
+    FanSpeed,
+    VacuumStatus,
+    WaterLevel,
+)
+
+_INITIAL_STATE = {
+    "status": 9,
+    "fault": 100008,
+    "battery_level": 100,
+    "mode": 2,
+    "water_level": 1,
+    "mop_status": False,
+    "zone_ids": "",
+    "room_information": (
+        '{"rooms":[{"id":3,"name":""},{"id":4,"name":""}],"map_uid":2}'
+    ),
+    "cleaning_area": 700,
+    "cleaning_time": 540,
+    "main_brush_life_level": 97,
+    "main_brush_left_time": 290,
+    "side_brush_life_level": 96,
+    "side_brush_left_time": 280,
+    "filter_life_level": 94,
+    "filter_left_time": 260,
+}
+
+
+class DummyXiaomiVacuumE101GB(DummyMiotDevice, XiaomiVacuumE101GB):
+    def __init__(self, *args, **kwargs):
+        self._model = XIAOMI_VACUUM_E101GB
+        self.state = _INITIAL_STATE
+        self.return_values = {
+            "action": lambda x: x,
+            "set_properties": lambda x: x,
+        }
+        super().__init__(*args, **kwargs)
+
+
+class DummyXiaomiVacuumE101GBDeviceDid(DummyXiaomiVacuumE101GB):
+    def get_properties(
+        self, properties, *, property_getter="get_prop", max_properties=None
+    ):
+        response = []
+        for prop in properties:
+            key = prop["did"]
+            response.append(
+                {
+                    "did": "1171712073",
+                    "siid": prop["siid"],
+                    "piid": prop["piid"],
+                    "code": 0,
+                    "value": _INITIAL_STATE[key],
+                }
+            )
+        return response
+
+
+class DummyXiaomiVacuumE101GBUnexpected(DummyXiaomiVacuumE101GB):
+    def get_properties(
+        self, properties, *, property_getter="get_prop", max_properties=None
+    ):
+        return [
+            {
+                "did": None,
+                "code": 0,
+                "value": 123,
+            }
+        ]
+
+
+class DummyXiaomiVacuumE101GBEmptyRoomInfo(DummyXiaomiVacuumE101GB):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.state = {
+            prop["did"]: prop["value"] for prop in self.state if prop["did"] != "room_information"
+        }
+        self.state["room_information"] = ""
+        self.state = [{"did": k, "value": v, "code": 0} for k, v in self.state.items()]
+
+
+@pytest.fixture(scope="function")
+def dummy_xiaomi_vacuum(request):
+    request.cls.device = DummyXiaomiVacuumE101GB()
+
+
+@pytest.mark.usefixtures("dummy_xiaomi_vacuum")
+class TestXiaomiVacuumE101GB(TestCase):
+    def test_status(self):
+        status = self.device.status()
+        assert status.status == VacuumStatus.Charged
+        assert status.error_code == _INITIAL_STATE["fault"]
+        assert status.battery == _INITIAL_STATE["battery_level"]
+        assert status.fan_speed == FanSpeed.Basic
+        assert status.water_level == WaterLevel.Level1
+        assert status.mop_status is False
+        assert status.cleaning_area == _INITIAL_STATE["cleaning_area"]
+        assert status.cleaning_time == timedelta(
+            seconds=_INITIAL_STATE["cleaning_time"]
+        )
+        assert status.main_brush_life_level == _INITIAL_STATE["main_brush_life_level"]
+        assert status.main_brush_left_time == timedelta(
+            hours=_INITIAL_STATE["main_brush_left_time"]
+        )
+        assert status.side_brush_life_level == _INITIAL_STATE["side_brush_life_level"]
+        assert status.side_brush_left_time == timedelta(
+            hours=_INITIAL_STATE["side_brush_left_time"]
+        )
+        assert status.filter_life_level == _INITIAL_STATE["filter_life_level"]
+        assert status.filter_left_time == timedelta(
+            hours=_INITIAL_STATE["filter_left_time"]
+        )
+
+    def test_fan_speed_presets(self):
+        presets = self.device.fan_speed_presets()
+        for item in FanSpeed:
+            assert presets[item.name] == item.value
+
+    def test_set_fan_speed(self):
+        self.device.set_fan_speed(FanSpeed.Strong)
+        assert self.device.status().fan_speed == FanSpeed.Strong
+
+    def test_set_fan_speed_preset(self):
+        self.device.set_fan_speed_preset(FanSpeed.FullSpeed.value)
+        assert self.device.status().fan_speed == FanSpeed.FullSpeed
+
+        with pytest.raises(ValueError):
+            self.device.set_fan_speed_preset(99)
+
+    def test_set_water_level(self):
+        self.device.set_water_level(WaterLevel.Level3)
+        assert self.device.status().water_level == WaterLevel.Level3
+
+    def test_action_payloads(self):
+        assert self.device.start()["aiid"] == 1
+        assert self.device.stop()["aiid"] == 2
+        assert self.device.home()["aiid"] == 3
+        assert self.device.pause()["aiid"] == 7
+        assert self.device.resume()["aiid"] == 8
+        assert self.device.find()["siid"] == 6
+
+    def test_room_and_zone_payloads(self):
+        room = self.device.start_room_sweep("12,13")
+        assert room["aiid"] == 16
+        assert room["in"] == [{"piid": 15, "value": "12,13"}]
+
+        zone = self.device.start_zone_sweep("1,2,3,4")
+        assert zone["aiid"] == 37
+        assert zone["in"] == [{"piid": 12, "value": "1,2,3,4"}]
+
+    def test_consumable_resets(self):
+        assert self.device.reset_main_brush_life()["siid"] == 12
+        assert self.device.reset_side_brush_life()["siid"] == 13
+        assert self.device.reset_filter_life()["siid"] == 14
+        assert self.device.consumable_reset(Consumable.Filter)["siid"] == 14
+
+    def test_room_helpers(self):
+        assert self.device.zone_ids() == ""
+        assert self.device.room_information()["map_uid"] == 2
+        assert self.device.room_ids() == [3, 4]
+
+    def test_room_information_empty(self):
+        assert DummyXiaomiVacuumE101GBEmptyRoomInfo().room_information() == {}
+
+    def test_get_room_configs(self):
+        payload = self.device.get_room_configs("3,4")
+        assert payload["aiid"] == 11
+        assert payload["in"] == [{"piid": 15, "value": "3,4"}]
+
+    def test_get_zone_configs(self):
+        payload = self.device.get_zone_configs("1,2")
+        assert payload["aiid"] == 10
+        assert payload["in"] == [{"piid": 12, "value": "1,2"}]
+
+    def test_consumable_resets_all_variants(self):
+        assert self.device.consumable_reset(Consumable.MainBrush)["siid"] == 12
+        assert self.device.consumable_reset(Consumable.SideBrush)["siid"] == 13
+        assert self.device.consumable_reset(Consumable.Filter)["siid"] == 14
+
+    def test_water_level_presets(self):
+        presets = self.device.water_level_presets()
+        for item in WaterLevel:
+            assert presets[item.name] == item.value
+
+
+def test_xiaomi_vacuum_model():
+    XiaomiVacuumE101GB(model=XIAOMI_VACUUM_E101GB)
+
+
+def test_status_maps_response_without_request_did():
+    status = DummyXiaomiVacuumE101GBDeviceDid().status()
+    assert status.status == VacuumStatus.Charged
+    assert status.battery == 100
+
+
+def test_status_ignores_unexpected_property_response():
+    assert DummyXiaomiVacuumE101GBUnexpected()._get_properties_for_keys(["status"]) == {}

--- a/miio/integrations/xiaomi/vacuum/test_vacuum_miot.py
+++ b/miio/integrations/xiaomi/vacuum/test_vacuum_miot.py
@@ -83,7 +83,9 @@ class DummyXiaomiVacuumE101GBEmptyRoomInfo(DummyXiaomiVacuumE101GB):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.state = {
-            prop["did"]: prop["value"] for prop in self.state if prop["did"] != "room_information"
+            prop["did"]: prop["value"]
+            for prop in self.state
+            if prop["did"] != "room_information"
         }
         self.state["room_information"] = ""
         self.state = [{"did": k, "value": v, "code": 0} for k, v in self.state.items()]
@@ -204,4 +206,6 @@ def test_status_maps_response_without_request_did():
 
 
 def test_status_ignores_unexpected_property_response():
-    assert DummyXiaomiVacuumE101GBUnexpected()._get_properties_for_keys(["status"]) == {}
+    assert (
+        DummyXiaomiVacuumE101GBUnexpected()._get_properties_for_keys(["status"]) == {}
+    )

--- a/miio/integrations/xiaomi/vacuum/test_vacuum_miot.py
+++ b/miio/integrations/xiaomi/vacuum/test_vacuum_miot.py
@@ -91,7 +91,7 @@ class DummyXiaomiVacuumE101GBEmptyRoomInfo(DummyXiaomiVacuumE101GB):
         self.state = [{"did": k, "value": v, "code": 0} for k, v in self.state.items()]
 
 
-@pytest.fixture()
+@pytest.fixture
 def dummy_xiaomi_vacuum(request):
     request.cls.device = DummyXiaomiVacuumE101GB()
 

--- a/miio/integrations/xiaomi/vacuum/test_vacuum_miot.py
+++ b/miio/integrations/xiaomi/vacuum/test_vacuum_miot.py
@@ -91,7 +91,7 @@ class DummyXiaomiVacuumE101GBEmptyRoomInfo(DummyXiaomiVacuumE101GB):
         self.state = [{"did": k, "value": v, "code": 0} for k, v in self.state.items()]
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture()
 def dummy_xiaomi_vacuum(request):
     request.cls.device = DummyXiaomiVacuumE101GB()
 

--- a/miio/integrations/xiaomi/vacuum/vacuum_miot.py
+++ b/miio/integrations/xiaomi/vacuum/vacuum_miot.py
@@ -1,0 +1,363 @@
+import json
+import logging
+from datetime import timedelta
+from enum import Enum
+
+import click
+
+from miio.click_common import EnumType, command, format_output
+from miio.miot_device import DeviceStatus, MiotDevice, MiotMapping
+
+_LOGGER = logging.getLogger(__name__)
+
+XIAOMI_VACUUM_E101GB = "xiaomi.vacuum.e101gb"
+
+_MAPPING: MiotMapping = {
+    "status": {"siid": 2, "piid": 2},
+    "fault": {"siid": 2, "piid": 3},
+    "cleaning_area": {"siid": 2, "piid": 6},
+    "cleaning_time": {"siid": 2, "piid": 7},
+    "mode": {"siid": 2, "piid": 9},
+    "water_level": {"siid": 2, "piid": 10},
+    "mop_status": {"siid": 2, "piid": 11},
+    "zone_ids": {"siid": 2, "piid": 12},
+    "room_information": {"siid": 2, "piid": 16},
+    "battery_level": {"siid": 3, "piid": 1},
+    "main_brush_life_level": {"siid": 12, "piid": 1},
+    "main_brush_left_time": {"siid": 12, "piid": 2},
+    "side_brush_life_level": {"siid": 13, "piid": 1},
+    "side_brush_left_time": {"siid": 13, "piid": 2},
+    "filter_life_level": {"siid": 14, "piid": 1},
+    "filter_left_time": {"siid": 14, "piid": 2},
+    "start": {"siid": 2, "aiid": 1},
+    "stop": {"siid": 2, "aiid": 2},
+    "home": {"siid": 2, "aiid": 3},
+    "pause": {"siid": 2, "aiid": 7},
+    "resume": {"siid": 2, "aiid": 8},
+    "get_zone_configs": {"siid": 2, "aiid": 10},
+    "get_room_configs": {"siid": 2, "aiid": 11},
+    "set_zone": {"siid": 2, "aiid": 12},
+    "set_room_clean_configs": {"siid": 2, "aiid": 13},
+    "start_vacuum_room_sweep": {"siid": 2, "aiid": 16},
+    "start_zone_sweep": {"siid": 2, "aiid": 37},
+    "find": {"siid": 6, "aiid": 1},
+    "reset_main_brush_life": {"siid": 12, "aiid": 1},
+    "reset_side_brush_life": {"siid": 13, "aiid": 1},
+    "reset_filter_life": {"siid": 14, "aiid": 1},
+}
+
+_MAPPINGS: dict[str, MiotMapping] = {XIAOMI_VACUUM_E101GB: _MAPPING}
+
+_STATUS_KEYS = [
+    "status",
+    "fault",
+    "battery_level",
+    "mode",
+    "water_level",
+    "mop_status",
+    "cleaning_area",
+    "cleaning_time",
+    "main_brush_life_level",
+    "main_brush_left_time",
+    "side_brush_life_level",
+    "side_brush_left_time",
+    "filter_life_level",
+    "filter_left_time",
+]
+
+
+class VacuumStatus(Enum):
+    Idle = 1
+    Charging = 2
+    BreakCharging = 3
+    Sweeping = 4
+    Paused = 5
+    GoCharging = 6
+    GoWash = 7
+    Remote = 8
+    Charged = 9
+    BuildingMap = 10
+    Updating = 11
+    MultiTaskStationWorking = 12
+    MultiTaskRecharge = 13
+    StationWorking = 14
+    Error = 15
+    SweepingAndMopping = 16
+    Mopping = 17
+    MappingPause = 18
+    GoChargeBreak = 19
+    WashBreak = 20
+    GoChargeBuildingMap = 21
+    StationAssistingCleaning = 22
+    StationAssistingCleaned = 23
+    GoChargeInStationAssistingCleaning = 24
+
+
+class FanSpeed(Enum):
+    Silent = 1
+    Basic = 2
+    Strong = 3
+    FullSpeed = 4
+
+
+class WaterLevel(Enum):
+    Off = 0
+    Level1 = 1
+    Level2 = 2
+    Level3 = 3
+
+
+class Consumable(Enum):
+    MainBrush = "main_brush"
+    SideBrush = "side_brush"
+    Filter = "filter"
+
+
+class XiaomiVacuumE101GBStatus(DeviceStatus):
+    """Container for Xiaomi Robot Vacuum S40C / E101GB status."""
+
+    def __init__(self, data):
+        self.data = data
+
+    @property
+    def battery(self) -> int:
+        return self.data["battery_level"]
+
+    @property
+    def status(self) -> VacuumStatus:
+        return VacuumStatus(self.data["status"])
+
+    @property
+    def error_code(self) -> int:
+        return int(self.data["fault"])
+
+    @property
+    def fan_speed(self) -> FanSpeed:
+        return FanSpeed(self.data["mode"])
+
+    @property
+    def water_level(self) -> WaterLevel:
+        return WaterLevel(self.data["water_level"])
+
+    @property
+    def mop_status(self) -> bool:
+        return bool(self.data["mop_status"])
+
+    @property
+    def cleaning_area(self) -> int:
+        return self.data["cleaning_area"]
+
+    @property
+    def cleaning_time(self) -> timedelta:
+        return timedelta(seconds=self.data["cleaning_time"])
+
+    @property
+    def main_brush_life_level(self) -> int:
+        return self.data["main_brush_life_level"]
+
+    @property
+    def main_brush_left_time(self) -> timedelta:
+        return timedelta(hours=self.data["main_brush_left_time"])
+
+    @property
+    def side_brush_life_level(self) -> int:
+        return self.data["side_brush_life_level"]
+
+    @property
+    def side_brush_left_time(self) -> timedelta:
+        return timedelta(hours=self.data["side_brush_left_time"])
+
+    @property
+    def filter_life_level(self) -> int:
+        return self.data["filter_life_level"]
+
+    @property
+    def filter_left_time(self) -> timedelta:
+        return timedelta(hours=self.data["filter_left_time"])
+
+
+class XiaomiVacuumE101GB(MiotDevice):
+    """Support for Xiaomi Robot Vacuum S40C EU."""
+
+    _mappings = _MAPPINGS
+
+    def _get_properties_for_keys(self, keys: list[str]) -> dict[str, object]:
+        mapping = self._get_mapping()
+        props = [{"did": key, **mapping[key]} for key in keys]
+        key_by_prop_id = {
+            (mapping[key]["siid"], mapping[key]["piid"]): key for key in keys
+        }
+        response = self.get_properties(
+            props, property_getter="get_properties", max_properties=6
+        )
+        values = {}
+        for prop in response:
+            siid = prop.get("siid")
+            piid = prop.get("piid")
+            key = None
+            if siid is not None and piid is not None:
+                key = key_by_prop_id.get((siid, piid))
+            if key is None:
+                key = prop.get("did")
+            if key is None:
+                _LOGGER.debug("Ignoring unexpected property response: %s", prop)
+                continue
+
+            values[key] = prop["value"] if prop["code"] == 0 else None
+
+        return values
+
+    def _action_input(self, piid: int, value: object) -> list[dict[str, object]]:
+        """Create an action payload for a MIoT action input property."""
+        return [{"piid": piid, "value": value}]
+
+    def _get_single_property(self, key: str):
+        """Read a single mapped MIoT property."""
+        return self._get_properties_for_keys([key]).get(key)
+
+    @command(
+        default_output=format_output(
+            "",
+            "Status: {result.status}\n"
+            "Error: {result.error_code}\n"
+            "Battery: {result.battery}%\n"
+            "Fan speed: {result.fan_speed}\n"
+            "Water level: {result.water_level}\n"
+            "Mop mounted: {result.mop_status}\n"
+            "Cleaning area: {result.cleaning_area}\n"
+            "Cleaning time: {result.cleaning_time}\n"
+            "Main brush life: "
+            "{result.main_brush_life_level}% ({result.main_brush_left_time})\n"
+            "Side brush life: "
+            "{result.side_brush_life_level}% ({result.side_brush_left_time})\n"
+            "Filter life: {result.filter_life_level}% ({result.filter_left_time})\n",
+        )
+    )
+    def status(self) -> XiaomiVacuumE101GBStatus:
+        """Return a stable subset of vacuum status.
+
+        The generic MIoT status query for this model is too wide and can time out,
+        so we intentionally query the core properties in small batches.
+        """
+        data = {}
+        for idx in range(0, len(_STATUS_KEYS), 6):
+            data.update(self._get_properties_for_keys(_STATUS_KEYS[idx : idx + 6]))
+
+        return XiaomiVacuumE101GBStatus(data)
+
+    @command()
+    def start(self):
+        return self.call_action_from_mapping("start")
+
+    @command()
+    def stop(self):
+        return self.call_action_from_mapping("stop")
+
+    @command()
+    def pause(self):
+        return self.call_action_from_mapping("pause")
+
+    @command()
+    def resume(self):
+        return self.call_action_from_mapping("resume")
+
+    @command()
+    def home(self):
+        return self.call_action_from_mapping("home")
+
+    @command()
+    def find(self):
+        return self.call_action_from_mapping("find")
+
+    @command(click.argument("room_ids", type=str))
+    def start_room_sweep(self, room_ids: str):
+        """Start cleaning one or more room ids."""
+        return self.call_action_from_mapping(
+            "start_vacuum_room_sweep", params=self._action_input(15, room_ids)
+        )
+
+    @command(click.argument("zone_ids", type=str))
+    def start_zone_sweep(self, zone_ids: str):
+        """Start cleaning one or more zone definitions."""
+        return self.call_action_from_mapping(
+            "start_zone_sweep", params=self._action_input(12, zone_ids)
+        )
+
+    @command(click.argument("room_ids", type=str))
+    def get_room_configs(self, room_ids: str):
+        """Return room config payload for provided room ids."""
+        return self.call_action_from_mapping(
+            "get_room_configs", params=self._action_input(15, room_ids)
+        )
+
+    @command(click.argument("zone_ids", type=str))
+    def get_zone_configs(self, zone_ids: str):
+        """Return zone config payload for provided zone ids."""
+        return self.call_action_from_mapping(
+            "get_zone_configs", params=self._action_input(12, zone_ids)
+        )
+
+    @command()
+    def room_information(self) -> dict:
+        """Return parsed room metadata for the current map."""
+        value = self._get_single_property("room_information")
+        if not value:
+            return {}
+        return json.loads(value)
+
+    @command()
+    def room_ids(self) -> list[int]:
+        """Return available room ids for room-based cleaning."""
+        info = self.room_information()
+        return [room["id"] for room in info.get("rooms", []) if "id" in room]
+
+    @command()
+    def zone_ids(self) -> str:
+        """Return raw zone ids payload advertised by the device."""
+        value = self._get_single_property("zone_ids")
+        return "" if value is None else value
+
+    @command()
+    def reset_main_brush_life(self):
+        return self.call_action_from_mapping("reset_main_brush_life")
+
+    @command()
+    def reset_side_brush_life(self):
+        return self.call_action_from_mapping("reset_side_brush_life")
+
+    @command()
+    def reset_filter_life(self):
+        return self.call_action_from_mapping("reset_filter_life")
+
+    @command(click.argument("consumable", type=Consumable))
+    def consumable_reset(self, consumable: Consumable):
+        if consumable == Consumable.MainBrush:
+            return self.reset_main_brush_life()
+        if consumable == Consumable.SideBrush:
+            return self.reset_side_brush_life()
+        return self.reset_filter_life()
+
+    @command()
+    def fan_speed_presets(self) -> dict[str, int]:
+        return {speed.name: speed.value for speed in FanSpeed}
+
+    @command(click.argument("speed", type=EnumType(FanSpeed)))
+    def set_fan_speed(self, speed: FanSpeed):
+        return self.set_property("mode", speed.value)
+
+    @command(click.argument("speed", type=int))
+    def set_fan_speed_preset(self, speed: int):
+        if speed not in self.fan_speed_presets().values():
+            raise ValueError(
+                "Invalid preset speed "
+                f"{speed}, not in: {self.fan_speed_presets().values()}"
+            )
+        return self.set_property("mode", speed)
+
+    @command()
+    def water_level_presets(self) -> dict[str, int]:
+        return {level.name: level.value for level in WaterLevel}
+
+    @command(click.argument("level", type=EnumType(WaterLevel)))
+    def set_water_level(self, level: WaterLevel):
+        return self.set_property("water_level", level.value)


### PR DESCRIPTION
## Summary

  Add a dedicated MIoT integration for `xiaomi.vacuum.e101gb` (Xiaomi Robot Vacuum S40C EU).

  This model does not work correctly through the legacy `RoborockVacuum` path, but it is locally controllable through MIoT. This change adds a dedicated `MiotDevice`-based implementation instead of relying on `GenericMiot`.

  ## What is included

  - new `XiaomiVacuumE101GB` integration
  - stable `status()` implementation using small `get_properties` batches
  - actions:
    - `start`
    - `stop`
    - `pause`
    - `resume`
    - `home`
    - `find`
    - `start_room_sweep`
    - `start_zone_sweep`
  - room helpers:
    - `room_information`
    - `room_ids`
    - `zone_ids`
    - `get_room_configs`
    - `get_zone_configs`
  - consumable reset actions:
    - main brush
    - side brush
    - filter

  ## Implementation detail

  The device does not always echo the request `did` in property responses and may return the device id instead. Because of that, the integration maps status responses by `(siid, piid)` instead of relying on `did`.

  The generic MIoT status query is also too wide for this device and may time out, so `status()` intentionally reads a smaller, stable subset of properties in batches.

  ## Verified on real hardware

  Tested locally against:

  - model: `xiaomi.vacuum.e101gb`
  - firmware: `4.5.6_0127`

  Verified:
  - status reads correctly
  - `home()` works
  - room metadata is readable
  - `start_room_sweep("3")` starts cleaning
  - `home()` returns the vacuum to the dock afterwards

  ## Tests

  Added unit tests for:
  - status parsing
  - preset setters
  - action payloads
  - room/zone payloads
  - consumable resets
  - response mapping when the device returns device id instead of request `did`