### PR TITLE
Make model keyword-only in all Device subclass constructors

### DIFF
--- a/miio/integrations/dmaker/fan/fan.py
+++ b/miio/integrations/dmaker/fan/fan.py
@@ -112,7 +112,8 @@ class FanP5(Device):
         debug: int = 0,
         lazy_discover: bool = True,
         timeout: Optional[int] = None,
-        model: str = MODEL_FAN_P5,
+        *,
+        model: Optional[str] = MODEL_FAN_P5,
     ) -> None:
         super().__init__(
             ip, token, start_id, debug, lazy_discover, timeout=timeout, model=model

--- a/miio/integrations/dmaker/fan/fan_miot.py
+++ b/miio/integrations/dmaker/fan/fan_miot.py
@@ -467,7 +467,8 @@ class Fan1C(MiotDevice):
         debug: int = 0,
         lazy_discover: bool = True,
         timeout: Optional[int] = None,
-        model: str = MODEL_FAN_1C,
+        *,
+        model: Optional[str] = MODEL_FAN_1C,
     ) -> None:
         super().__init__(
             ip, token, start_id, debug, lazy_discover, timeout=timeout, model=model

--- a/miio/integrations/huayi/light/huizuo.py
+++ b/miio/integrations/huayi/light/huizuo.py
@@ -218,7 +218,8 @@ class Huizuo(MiotDevice):
         debug: int = 0,
         lazy_discover: bool = True,
         timeout: Optional[int] = None,
-        model: str = MODEL_HUIZUO_PIS123,
+        *,
+        model: Optional[str] = MODEL_HUIZUO_PIS123,
     ) -> None:
         if model in MODELS_WITH_FAN_WY:
             self.mapping.update(_ADDITIONAL_MAPPING_FAN_WY)

--- a/miio/integrations/lumi/acpartner/airconditioningcompanion.py
+++ b/miio/integrations/lumi/acpartner/airconditioningcompanion.py
@@ -232,7 +232,8 @@ class AirConditioningCompanion(Device):
         debug: int = 0,
         lazy_discover: bool = True,
         timeout: Optional[int] = None,
-        model: str = MODEL_ACPARTNER_V2,
+        *,
+        model: Optional[str] = MODEL_ACPARTNER_V2,
     ) -> None:
         super().__init__(
             ip, token, start_id, debug, lazy_discover, timeout=timeout, model=model

--- a/miio/integrations/lumi/acpartner/airconditioningcompanionMCN.py
+++ b/miio/integrations/lumi/acpartner/airconditioningcompanionMCN.py
@@ -107,7 +107,8 @@ class AirConditioningCompanionMcn02(Device):
         debug: int = 0,
         lazy_discover: bool = True,
         timeout: Optional[int] = None,
-        model: str = MODEL_ACPARTNER_MCN02,
+        *,
+        model: Optional[str] = MODEL_ACPARTNER_MCN02,
     ) -> None:
         if start_id is None:
             start_id = random.randint(0, 999)  # nosec

--- a/miio/integrations/yeelight/light/yeelight.py
+++ b/miio/integrations/yeelight/light/yeelight.py
@@ -279,6 +279,7 @@ class Yeelight(Device):
         debug: int = 0,
         lazy_discover: bool = True,
         timeout: Optional[int] = None,
+        *,
         model: Optional[str] = None,
     ) -> None:
         super().__init__(

--- a/miio/tests/test_device.py
+++ b/miio/tests/test_device.py
@@ -1,3 +1,4 @@
+import inspect
 import math
 
 import pytest
@@ -160,6 +161,27 @@ def test_init_signature(cls, mocker):
     # as some arguments are passed by inheriting classes using kwargs
     total_args = len(parent_init.call_args.args) + len(parent_init.call_args.kwargs)
     assert total_args == 8
+
+
+@pytest.mark.parametrize("cls", DEVICE_CLASSES)
+def test_model_is_keyword_only(cls: type) -> None:
+    """Ensure 'model' is keyword-only in all Device subclasses.
+
+    The base Device class defines model as keyword-only (after *). Subclasses
+    that make it positional break Liskov substitution and can cause subtle bugs
+    when classes are used interchangeably via DeviceFactory.
+    """
+    sig: inspect.Signature = inspect.signature(cls.__init__)
+    params: dict[str, inspect.Parameter] = dict(sig.parameters)
+
+    if "model" not in params:
+        return
+
+    param: inspect.Parameter = params["model"]
+    assert param.kind == inspect.Parameter.KEYWORD_ONLY, (
+        f"{cls.__name__}.__init__ has 'model' as positional parameter, "
+        f"it should be keyword-only (after *)"
+    )
 
 
 @pytest.mark.parametrize("cls", DEVICE_CLASSES)


### PR DESCRIPTION
The base `Device.__init__` defines `model` as keyword-only (after `*`), but six subclasses had it as positional: FanP5, Fan1C, Huizuo, AirConditioningCompanion, AirConditioningCompanionMcn02, and Yeelight. This breaks Liskov substitution - code that works with the base class signature can't safely substitute these subclasses.

Fixes all six to use `*, model: Optional[str] = ...` matching the base class, and adds `test_model_is_keyword_only` that inspects every Device subclass signature to prevent regressions.

No positional `model` usage was found anywhere in the codebase, so this is a safe change.

Full test suite: 1345 passed (1286 on master + 59 new parametrized `test_model_is_keyword_only` cases). Same pre-existing failures only. Ruff clean.

Addresses #1156