### PR TITLE
Drop PyPy from the CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.9"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:


### PR DESCRIPTION
## Problem

The `pypy3.9` CI job fails because `cryptography>=49` uses `pyo3-ffi v0.29.0` which requires PyPy >= 3.11. There is no version of PyPy that satisfies all dependency constraints simultaneously:

- `cryptography` has no prebuilt wheels for PyPy 3.11+ and source builds require pyo3 >= 0.23
- `pydantic-core` dropped prebuilt PyPy 3.10 wheels in recent versions
- Older `cryptography` versions (43.x) cap out at PyPy 3.10 via pyo3 0.22.2

## Fix

Remove PyPy from the CI matrix. The Rust-based dependency ecosystem (cryptography, pydantic-core) no longer provides a stable PyPy target that works across all supported versions.