### PR TITLE
Pin CI actions to commit hashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
         python-version: ["3.12"]
 
     steps:
-      - uses: "actions/checkout@v4"
-      - uses: "actions/setup-python@v5"
+      - uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5"  # v4.3.1
+      - uses: "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065"  # v5.6.0
         with:
           python-version: "${{ matrix.python-version }}"
       - name: "Install dependencies"
@@ -42,8 +42,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-      - uses: "actions/checkout@v4"
-      - uses: "actions/setup-python@v5"
+      - uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5"  # v4.3.1
+      - uses: "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065"  # v5.6.0
         with:
           python-version: "${{ matrix.python-version }}"
       - name: "Install dependencies"
@@ -54,7 +54,7 @@ jobs:
         run: |
           poetry run pytest --cov miio --cov-report xml
       - name: "Upload coverage to Codecov"
-        uses: "codecov/codecov-action@v4"
+        uses: "codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac"  # v5.5.5
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

Pins all GitHub Actions in `.github/workflows/ci.yml` to exact commit hashes instead of mutable version tags to prevent supply-chain attacks. Version numbers are retained as inline comments for readability.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v4.3.1 |
| `actions/setup-python` | v5 | v5.6.0 |
| `codecov/codecov-action` | v4 | v5.5.5 |

## Test plan

- [x] CI passes with pinned action hashes