### PR TITLE
Replace flake8, bandit, isort, pyupgrade with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v6.0.0
+  rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # v6.0.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer
@@ -12,14 +12,14 @@ repos:
   - id: check-ast
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.15.20
+  rev: c59bba8fb259db0fec2bbb77ad8ba51ea7341b56  # v0.15.20
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]
     - id: ruff-format
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v2.1.0
+  rev: d2823d321df3af8f878f7ee3414dc94d037145b9  # v2.1.0
   hooks:
   - id: mypy
     additional_dependencies: [types-attrs, types-PyYAML, types-requests, types-pytz, types-croniter, types-freezegun]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,54 +12,14 @@ repos:
   - id: check-ast
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  # Ruff version.
   rev: v0.7.1
   hooks:
-    # Run the linter.
     - id: ruff
-      args: [--fix]
-    # Run the formatter.
+      args: [--fix, --exit-non-zero-on-fix]
     - id: ruff-format
-
-- repo: https://github.com/pre-commit/mirrors-isort
-  rev: v5.10.1
-  hooks:
-  - id: isort
-    additional_dependencies: [toml]
-
-#- repo: https://github.com/PyCQA/doc8
-#  rev: v1.1.1
-#  hooks:
-#  - id: doc8
-#    additional_dependencies: [myst-parser]
-
-# - repo: https://github.com/myint/docformatter
-#  rev: v1.7.5
-#  hooks:
-#    - id: docformatter
-#      args: [--in-place, --wrap-summaries, '88', --wrap-descriptions, '88', --black
-
-- repo: https://github.com/pycqa/flake8
-  rev: 7.0.0
-  hooks:
-  - id: flake8
-    additional_dependencies: [flake8-docstrings, flake8-bugbear, flake8-builtins, flake8-print, flake8-pytest-style, flake8-return, flake8-simplify, flake8-annotations]
-
-- repo: https://github.com/PyCQA/bandit
-  rev: 1.7.7
-  hooks:
-  - id: bandit
-    args: [-x, 'tests', -x, '**/test_*.py']
-
 
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.8.0
   hooks:
   - id: mypy
     additional_dependencies: [types-attrs, types-PyYAML, types-requests, types-pytz, types-croniter, types-freezegun]
-
-- repo: https://github.com/asottile/pyupgrade
-  rev: v3.15.0
-  hooks:
-  - id: pyupgrade
-    args: ['--py311-plus']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v6.0.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer
@@ -12,14 +12,14 @@ repos:
   - id: check-ast
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.7.1
+  rev: v0.15.20
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]
     - id: ruff-format
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.8.0
+  rev: v2.1.0
   hooks:
   - id: mypy
     additional_dependencies: [types-attrs, types-PyYAML, types-requests, types-pytz, types-croniter, types-freezegun]

--- a/docs/examples/push_server/gateway_alarm_trigger.py
+++ b/docs/examples/push_server/gateway_alarm_trigger.py
@@ -8,7 +8,7 @@ _LOGGER = logging.getLogger(__name__)
 logging.basicConfig(level="INFO")
 
 gateway_ip = "192.168.1.IP"
-token = "TokenTokenToken"  # nosec
+token = "TokenTokenToken"  # noqa: S105
 
 
 async def asyncio_demo(loop):

--- a/docs/examples/push_server/gateway_button_press.py
+++ b/docs/examples/push_server/gateway_button_press.py
@@ -8,7 +8,7 @@ _LOGGER = logging.getLogger(__name__)
 logging.basicConfig(level="INFO")
 
 gateway_ip = "192.168.1.IP"
-token = "TokenTokenToken"  # nosec
+token = "TokenTokenToken"  # noqa: S105
 button_sid = "lumi.123456789abcdef"
 
 

--- a/miio/click_common.py
+++ b/miio/click_common.py
@@ -31,7 +31,7 @@ def validate_ip(ctx, param, value):
         ipaddress.ip_address(value)
         return value
     except ValueError as ex:
-        raise click.BadParameter(f"Invalid IP: {ex}")
+        raise click.BadParameter(f"Invalid IP: {ex}") from ex
 
 
 def validate_token(ctx, param, value):

--- a/miio/cloud.py
+++ b/miio/cloud.py
@@ -103,10 +103,10 @@ class CloudInterface:
         try:
             from micloud import MiCloud  # noqa: F811
             from micloud.micloudexception import MiCloudAccessDenied
-        except ImportError:
+        except ImportError as ex:
             raise CloudException(
                 "You need to install 'micloud' package to use cloud interface"
-            )
+            ) from ex
 
         self._micloud: MiCloud = MiCloud(username=self.username, password=self.password)
         try:  # login() can either return False or raise an exception on failure
@@ -165,9 +165,9 @@ def cloud(ctx: click.Context, username, password):
     """Cloud commands."""
     try:
         import micloud  # noqa: F401
-    except ImportError:
+    except ImportError as ex:
         _LOGGER.error("micloud is not installed, no cloud access available")
-        raise CloudException("install micloud for cloud access")
+        raise CloudException("install micloud for cloud access") from ex
 
     ctx.obj = CloudInterface(username=username, password=password)
     if ctx.invoked_subcommand is None:

--- a/miio/device.py
+++ b/miio/device.py
@@ -329,7 +329,7 @@ class Device(metaclass=DeviceGroupMeta):
         try:
             act = self.actions()[name]
         except KeyError:
-            raise ValueError(f"Unable to find action '{name}'")
+            raise ValueError(f"Unable to find action '{name}'") from None
 
         if params is None:
             return act.method()
@@ -346,7 +346,7 @@ class Device(metaclass=DeviceGroupMeta):
         try:
             setting = self.settings()[name]
         except KeyError:
-            raise ValueError(f"Unable to find setting '{name}'")
+            raise ValueError(f"Unable to find setting '{name}'") from None
 
         params = params if params is not None else []
 

--- a/miio/devtools/pcapparser.py
+++ b/miio/devtools/pcapparser.py
@@ -51,7 +51,7 @@ def read_payloads_from_file(file, tokens: list[str]):
             try:
                 decrypted = Message.parse(data, token=bytes.fromhex(token))
                 break
-            except BaseException:  # noqa: B036
+            except BaseException:  # noqa: B036, S112
                 continue
 
         if decrypted is None:

--- a/miio/devtools/simulators/common.py
+++ b/miio/devtools/simulators/common.py
@@ -33,7 +33,7 @@ def did_and_mac_for_model(model):
 
     These identifiers allow making a simulated device unique for testing.
     """
-    m = md5()  # nosec
+    m = md5()  # noqa: S324
     m.update(model.encode())
     digest = m.hexdigest()[:12]
     did = int(digest[:8], base=16)

--- a/miio/devtools/simulators/miotsimulator.py
+++ b/miio/devtools/simulators/miotsimulator.py
@@ -30,18 +30,18 @@ def create_random(values):
 
     if values["choices"] is not None:
         choices = values["choices"]
-        choice = choices[random.randint(0, len(choices) - 1)]  # nosec
+        choice = choices[random.randint(0, len(choices) - 1)]  # noqa: S311
         _LOGGER.debug("Got enum %r for %s", choice, piid)
         return choice.value
 
     if values["range"] is not None:
         range = values["range"]
-        value = random.randint(range[0], range[1])  # nosec
+        value = random.randint(range[0], range[1])  # noqa: S311
         _LOGGER.debug("Got value %r from %s for piid %s", value, range, piid)
         return value
 
     if values["format"] == bool:
-        value = bool(random.randint(0, 1))  # nosec
+        value = bool(random.randint(0, 1))  # noqa: S311
         _LOGGER.debug("Got bool %r for piid %s", value, piid)
         return value
 
@@ -277,13 +277,13 @@ def miot_simulator(file, model):
             dev = SimulatedDeviceModel.parse_obj(schema)
         except Exception as ex:
             # this is far from optimal, but considering this is a developer tool it can be fixed later
-            fn = f"/tmp/pythonmiio_unparseable_{model}.json"  # nosec
+            fn = f"/tmp/pythonmiio_unparseable_{model}.json"  # noqa: S108
             with open(fn, "w") as f:
                 json.dump(schema, f, indent=4)
             _LOGGER.error("Unable to parse the schema, see %s: %s", fn, ex)
             return
 
     loop = asyncio.get_event_loop()
-    random.seed(1)  # nosec
+    random.seed(1)  # noqa: S311
     loop.run_until_complete(main(dev, model=model))
     loop.run_forever()

--- a/miio/extract_tokens.py
+++ b/miio/extract_tokens.py
@@ -34,7 +34,7 @@ def read_android_yeelight(db) -> Iterator[DeviceConfig]:
     devicelist = xml.find(".//set[@name='deviceList']")
     if not devicelist:
         _LOGGER.warning("Unable to find deviceList")
-        return []
+        return
 
     for dev_elem in list(devicelist):
         dev = json.loads(dev_elem.text)

--- a/miio/extract_tokens.py
+++ b/miio/extract_tokens.py
@@ -82,7 +82,7 @@ class BackupDatabaseReader:
         key = bytes.fromhex(keystring)
         cipher = Cipher(
             algorithms.AES(key),
-            modes.ECB(),  # nosec
+            modes.ECB(),  # noqa: S305
             backend=default_backend(),
         )
         decryptor = cipher.decryptor()

--- a/miio/integrations/airdog/airpurifier/airpurifier_airdog.py
+++ b/miio/integrations/airdog/airpurifier/airpurifier_airdog.py
@@ -119,7 +119,9 @@ class AirDogX3(Device):
         )
         values = self.get_properties(properties, max_properties=10)
 
-        return AirDogStatus(defaultdict(lambda: None, zip(properties, values, strict=False)))
+        return AirDogStatus(
+            defaultdict(lambda: None, zip(properties, values, strict=False))
+        )
 
     @command(default_output=format_output("Powering on"))
     def on(self):

--- a/miio/integrations/airdog/airpurifier/airpurifier_airdog.py
+++ b/miio/integrations/airdog/airpurifier/airpurifier_airdog.py
@@ -119,7 +119,7 @@ class AirDogX3(Device):
         )
         values = self.get_properties(properties, max_properties=10)
 
-        return AirDogStatus(defaultdict(lambda: None, zip(properties, values)))
+        return AirDogStatus(defaultdict(lambda: None, zip(properties, values, strict=False)))
 
     @command(default_output=format_output("Powering on"))
     def on(self):

--- a/miio/integrations/cgllc/airmonitor/airqualitymonitor.py
+++ b/miio/integrations/cgllc/airmonitor/airqualitymonitor.py
@@ -199,7 +199,7 @@ class AirQualityMonitor(Device):
             return AirQualityMonitorStatus(defaultdict(lambda: None, values))
         else:
             return AirQualityMonitorStatus(
-                defaultdict(lambda: None, zip(properties, values))
+                defaultdict(lambda: None, zip(properties, values, strict=False))
             )
 
     @command(default_output=format_output("Powering on"))

--- a/miio/integrations/cgllc/airmonitor/test_airqualitymonitor_miot.py
+++ b/miio/integrations/cgllc/airmonitor/test_airqualitymonitor_miot.py
@@ -45,7 +45,7 @@ class DummyAirQualityMonitorCGDN1(DummyMiotDevice, AirQualityMonitorCGDN1):
         super().__init__(*args, **kwargs)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def airqualitymonitorcgdn1(request):
     request.cls.device = DummyAirQualityMonitorCGDN1()
 

--- a/miio/integrations/chuangmi/camera/chuangmi_camera.py
+++ b/miio/integrations/chuangmi/camera/chuangmi_camera.py
@@ -200,7 +200,7 @@ class ChuangmiCamera(Device):
 
         values = self.get_properties(properties)
 
-        return CameraStatus(dict(zip(properties, values)))
+        return CameraStatus(dict(zip(properties, values, strict=False)))
 
     @command(default_output=format_output("Power on"))
     def on(self):

--- a/miio/integrations/chuangmi/plug/chuangmi_plug.py
+++ b/miio/integrations/chuangmi/plug/chuangmi_plug.py
@@ -119,7 +119,9 @@ class ChuangmiPlug(Device):
                 properties.append("load_power")
                 values.append(load_power[0] * 0.01)
 
-        return ChuangmiPlugStatus(defaultdict(lambda: None, zip(properties, values, strict=False)))
+        return ChuangmiPlugStatus(
+            defaultdict(lambda: None, zip(properties, values, strict=False))
+        )
 
     @command(default_output=format_output("Powering on"))
     def on(self):

--- a/miio/integrations/chuangmi/plug/chuangmi_plug.py
+++ b/miio/integrations/chuangmi/plug/chuangmi_plug.py
@@ -119,7 +119,7 @@ class ChuangmiPlug(Device):
                 properties.append("load_power")
                 values.append(load_power[0] * 0.01)
 
-        return ChuangmiPlugStatus(defaultdict(lambda: None, zip(properties, values)))
+        return ChuangmiPlugStatus(defaultdict(lambda: None, zip(properties, values, strict=False)))
 
     @command(default_output=format_output("Powering on"))
     def on(self):

--- a/miio/integrations/chuangmi/remote/chuangmi_ir.py
+++ b/miio/integrations/chuangmi/remote/chuangmi_ir.py
@@ -170,7 +170,7 @@ class ChuangmiIr(Device):
             play_method = self.play_pronto
 
         try:
-            converted_command_args = [t(v) for v, t in zip(command_args, arg_types)]
+            converted_command_args = [t(v) for v, t in zip(command_args, arg_types, strict=False)]
         except Exception as ex:
             raise ValueError("Invalid command arguments") from ex
 

--- a/miio/integrations/chuangmi/remote/chuangmi_ir.py
+++ b/miio/integrations/chuangmi/remote/chuangmi_ir.py
@@ -170,7 +170,9 @@ class ChuangmiIr(Device):
             play_method = self.play_pronto
 
         try:
-            converted_command_args = [t(v) for v, t in zip(command_args, arg_types, strict=False)]
+            converted_command_args = [
+                t(v) for v, t in zip(command_args, arg_types, strict=False)
+            ]
         except Exception as ex:
             raise ValueError("Invalid command arguments") from ex
 

--- a/miio/integrations/chuangmi/remote/test_chuangmi_ir.py
+++ b/miio/integrations/chuangmi/remote/test_chuangmi_ir.py
@@ -64,7 +64,7 @@ class TestChuangmiIr(TestCase):
         for args in test_data["test_raw_ok"]:
             with self.subTest():
                 self.device._reset_state()
-                self.assertTrue(self.device.play_raw(*args["in"]))
+                assert self.device.play_raw(*args["in"])
                 self.assertSequenceEqual(
                     self.device.state["last_ir_played"], args["out"]
                 )
@@ -84,7 +84,7 @@ class TestChuangmiIr(TestCase):
         for args in test_data["test_pronto_ok"]:
             with self.subTest():
                 self.device._reset_state()
-                self.assertTrue(self.device.play_pronto(*args["in"]))
+                assert self.device.play_pronto(*args["in"])
                 self.assertSequenceEqual(
                     self.device.state["last_ir_played"], args["out"]
                 )
@@ -99,7 +99,7 @@ class TestChuangmiIr(TestCase):
                 continue
             with self.subTest():
                 self.device._reset_state()
-                self.assertTrue(self.device.play(*args["in"]))
+                assert self.device.play(*args["in"])
                 self.assertSequenceEqual(
                     self.device.state["last_ir_played"], args["out"]
                 )
@@ -112,7 +112,7 @@ class TestChuangmiIr(TestCase):
             for args in tests:
                 with self.subTest():
                     command = "{}:{}".format(type_, ":".join(map(str, args["in"])))
-                    self.assertTrue(self.device.play(command))
+                    assert self.device.play(command)
                     self.assertSequenceEqual(
                         self.device.state["last_ir_played"], args["out"]
                     )

--- a/miio/integrations/chunmi/cooker/cooker.py
+++ b/miio/integrations/chunmi/cooker/cooker.py
@@ -629,7 +629,7 @@ class Cooker(Device):
                 values_count,
             )
 
-        return CookerStatus(defaultdict(lambda: None, zip(properties, values)))
+        return CookerStatus(defaultdict(lambda: None, zip(properties, values, strict=False)))
 
     @command(
         click.argument("profile", type=str),

--- a/miio/integrations/chunmi/cooker/cooker.py
+++ b/miio/integrations/chunmi/cooker/cooker.py
@@ -629,7 +629,9 @@ class Cooker(Device):
                 values_count,
             )
 
-        return CookerStatus(defaultdict(lambda: None, zip(properties, values, strict=False)))
+        return CookerStatus(
+            defaultdict(lambda: None, zip(properties, values, strict=False))
+        )
 
     @command(
         click.argument("profile", type=str),

--- a/miio/integrations/chunmi/cooker_multi/cooker_multi.py
+++ b/miio/integrations/chunmi/cooker_multi/cooker_multi.py
@@ -359,7 +359,7 @@ class MultiCooker(Device):
                 values_count,
             )
 
-        return CookerStatus(defaultdict(lambda: None, zip(properties, values)))
+        return CookerStatus(defaultdict(lambda: None, zip(properties, values, strict=False)))
 
     @command(
         click.argument("profile", type=str, required=True),

--- a/miio/integrations/chunmi/cooker_multi/cooker_multi.py
+++ b/miio/integrations/chunmi/cooker_multi/cooker_multi.py
@@ -359,7 +359,9 @@ class MultiCooker(Device):
                 values_count,
             )
 
-        return CookerStatus(defaultdict(lambda: None, zip(properties, values, strict=False)))
+        return CookerStatus(
+            defaultdict(lambda: None, zip(properties, values, strict=False))
+        )
 
     @command(
         click.argument("profile", type=str, required=True),

--- a/miio/integrations/deerma/humidifier/airhumidifier_mjjsq.py
+++ b/miio/integrations/deerma/humidifier/airhumidifier_mjjsq.py
@@ -152,7 +152,9 @@ class AirHumidifierMjjsq(Device):
         )
         values = self.get_properties(properties, max_properties=1)
 
-        return AirHumidifierStatus(defaultdict(lambda: None, zip(properties, values, strict=False)))
+        return AirHumidifierStatus(
+            defaultdict(lambda: None, zip(properties, values, strict=False))
+        )
 
     @command(default_output=format_output("Powering on"))
     def on(self):

--- a/miio/integrations/deerma/humidifier/airhumidifier_mjjsq.py
+++ b/miio/integrations/deerma/humidifier/airhumidifier_mjjsq.py
@@ -152,7 +152,7 @@ class AirHumidifierMjjsq(Device):
         )
         values = self.get_properties(properties, max_properties=1)
 
-        return AirHumidifierStatus(defaultdict(lambda: None, zip(properties, values)))
+        return AirHumidifierStatus(defaultdict(lambda: None, zip(properties, values, strict=False)))
 
     @command(default_output=format_output("Powering on"))
     def on(self):

--- a/miio/integrations/deerma/humidifier/tests/test_airhumidifier_jsqs.py
+++ b/miio/integrations/deerma/humidifier/tests/test_airhumidifier_jsqs.py
@@ -35,9 +35,9 @@ class DummyAirHumidifierJsqs(DummyMiotDevice, AirHumidifierJsqs):
         super().__init__(*args, **kwargs)
 
 
-@pytest.fixture()
+@pytest.fixture
 def dev(request):
-    yield DummyAirHumidifierJsqs()
+    return DummyAirHumidifierJsqs()
 
 
 def test_on(dev):

--- a/miio/integrations/dmaker/airfresh/airfresh_t2017.py
+++ b/miio/integrations/dmaker/airfresh/airfresh_t2017.py
@@ -248,7 +248,9 @@ class AirFreshA1(Device):
         )
         values = self.get_properties(properties, max_properties=15)
 
-        return AirFreshStatus(defaultdict(lambda: None, zip(properties, values, strict=False)))
+        return AirFreshStatus(
+            defaultdict(lambda: None, zip(properties, values, strict=False))
+        )
 
     @command(default_output=format_output("Powering on"))
     def on(self):

--- a/miio/integrations/dmaker/airfresh/airfresh_t2017.py
+++ b/miio/integrations/dmaker/airfresh/airfresh_t2017.py
@@ -248,7 +248,7 @@ class AirFreshA1(Device):
         )
         values = self.get_properties(properties, max_properties=15)
 
-        return AirFreshStatus(defaultdict(lambda: None, zip(properties, values)))
+        return AirFreshStatus(defaultdict(lambda: None, zip(properties, values, strict=False)))
 
     @command(default_output=format_output("Powering on"))
     def on(self):

--- a/miio/integrations/dmaker/fan/fan.py
+++ b/miio/integrations/dmaker/fan/fan.py
@@ -138,7 +138,7 @@ class FanP5(Device):
         properties = AVAILABLE_PROPERTIES[self.model]
         values = self.get_properties(properties, max_properties=15)
 
-        return FanStatusP5(dict(zip(properties, values)))
+        return FanStatusP5(dict(zip(properties, values, strict=False)))
 
     @command(default_output=format_output("Powering on"))
     def on(self):

--- a/miio/integrations/dreame/vacuum/tests/test_dreamevacuum_miot.py
+++ b/miio/integrations/dreame/vacuum/tests/test_dreamevacuum_miot.py
@@ -101,12 +101,12 @@ class DummyDreameF9VacuumMiot(DummyMiotDevice, DreameVacuum):
         super().__init__(*args, **kwargs)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def dummydreame1cvacuum(request):
     request.cls.device = DummyDreame1CVacuumMiot()
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def dummydreamef9vacuum(request):
     request.cls.device = DummyDreameF9VacuumMiot()
 

--- a/miio/integrations/genericmiot/tests/test_status.py
+++ b/miio/integrations/genericmiot/tests/test_status.py
@@ -8,13 +8,13 @@ from ..status import GenericMiotStatus
 
 @pytest.fixture(scope="session")
 def mockdev():
-    yield Mock()
+    return Mock()
 
 
 VALID_RESPONSE = {"code": 0, "did": "valid-response", "piid": 1, "siid": 1, "value": 1}
 
 
-@pytest.mark.parametrize("key", ("did", "piid", "siid", "value", "code"))
+@pytest.mark.parametrize("key", ["did", "piid", "siid", "value", "code"])
 def test_response_with_missing_value(key, mockdev, caplog: pytest.LogCaptureFixture):
     """Verify that property responses without necessary keys are ignored."""
     caplog.set_level(logging.DEBUG)
@@ -27,7 +27,7 @@ def test_response_with_missing_value(key, mockdev, caplog: pytest.LogCaptureFixt
     assert len(status.data) == 1
 
 
-@pytest.mark.parametrize("code", (-123, 123))
+@pytest.mark.parametrize("code", [-123, 123])
 def test_response_with_error_codes(code, mockdev, caplog: pytest.LogCaptureFixture):
     caplog.set_level(logging.WARNING)
 

--- a/miio/integrations/huayi/light/test_huizuo.py
+++ b/miio/integrations/huayi/light/test_huizuo.py
@@ -4,11 +4,16 @@ import pytest
 
 from miio.tests.dummies import DummyMiotDevice
 
-from .huizuo import MODEL_HUIZUO_FANWY  # Fan model extended
-from .huizuo import MODEL_HUIZUO_FANWY2  # Fan model basic
-from .huizuo import MODEL_HUIZUO_PIS123  # Basic model
-from .huizuo import MODEL_HUIZUO_WYHEAT  # Heater model
-from .huizuo import Huizuo, HuizuoLampFan, HuizuoLampHeater, UnsupportedFeatureException
+from .huizuo import (
+    MODEL_HUIZUO_FANWY,  # Fan model extended
+    MODEL_HUIZUO_FANWY2,  # Fan model basic
+    MODEL_HUIZUO_PIS123,  # Basic model
+    MODEL_HUIZUO_WYHEAT,  # Heater model
+    Huizuo,
+    HuizuoLampFan,
+    HuizuoLampHeater,
+    UnsupportedFeatureException,
+)
 
 _INITIAL_STATE = {
     "power": True,
@@ -63,22 +68,22 @@ class DummyHuizuoHeater(DummyMiotDevice, HuizuoLampHeater):
         super().__init__(*args, **kwargs)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def huizuo(request):
     request.cls.device = DummyHuizuo()
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def huizuo_fan(request):
     request.cls.device = DummyHuizuoFan()
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def huizuo_fan2(request):
     request.cls.device = DummyHuizuoFan2()
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def huizuo_heater(request):
     request.cls.device = DummyHuizuoHeater()
 

--- a/miio/integrations/ijai/vacuum/test_pro2vacuum.py
+++ b/miio/integrations/ijai/vacuum/test_pro2vacuum.py
@@ -46,7 +46,7 @@ class DummyPRO2Vacuum(DummyMiotDevice, Pro2Vacuum):
         super().__init__(*args, **kwargs)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def dummypro2vacuum(request):
     request.cls.device = DummyPRO2Vacuum()
 

--- a/miio/integrations/ksmb/walkingpad/walkingpad.py
+++ b/miio/integrations/ksmb/walkingpad/walkingpad.py
@@ -121,7 +121,9 @@ class Walkingpad(Device):
         properties_additional = ["power", "mode", "start_speed", "sensitivity"]
         values_additional = self.get_properties(properties_additional, max_properties=1)
 
-        additional_props = dict(zip(properties_additional, values_additional, strict=False))
+        additional_props = dict(
+            zip(properties_additional, values_additional, strict=False)
+        )
         data.update(additional_props)
 
         return WalkingpadStatus(data)

--- a/miio/integrations/ksmb/walkingpad/walkingpad.py
+++ b/miio/integrations/ksmb/walkingpad/walkingpad.py
@@ -121,7 +121,7 @@ class Walkingpad(Device):
         properties_additional = ["power", "mode", "start_speed", "sensitivity"]
         values_additional = self.get_properties(properties_additional, max_properties=1)
 
-        additional_props = dict(zip(properties_additional, values_additional))
+        additional_props = dict(zip(properties_additional, values_additional, strict=False))
         data.update(additional_props)
 
         return WalkingpadStatus(data)

--- a/miio/integrations/leshow/fan/fan_leshow.py
+++ b/miio/integrations/leshow/fan/fan_leshow.py
@@ -109,7 +109,7 @@ class FanLeshow(Device):
         )
         values = self.get_properties(properties, max_properties=15)
 
-        return FanLeshowStatus(dict(zip(properties, values)))
+        return FanLeshowStatus(dict(zip(properties, values, strict=False)))
 
     @command(default_output=format_output("Powering on"))
     def on(self):

--- a/miio/integrations/lumi/acpartner/airconditioningcompanion.py
+++ b/miio/integrations/lumi/acpartner/airconditioningcompanion.py
@@ -310,13 +310,13 @@ class AirConditioningCompanion(Device):
         """
         try:
             model_bytes = bytes.fromhex(model)
-        except ValueError:
-            raise ValueError("Invalid model. A hexadecimal string must be provided")
+        except ValueError as ex:
+            raise ValueError("Invalid model. A hexadecimal string must be provided") from ex
 
         try:
             code_bytes = bytes.fromhex(code)
-        except ValueError:
-            raise ValueError("Invalid code. A hexadecimal string must be provided")
+        except ValueError as ex:
+            raise ValueError("Invalid code. A hexadecimal string must be provided") from ex
 
         if slot < 0 or slot > 134:
             raise ValueError(f"Invalid slot: {slot}")

--- a/miio/integrations/lumi/acpartner/airconditioningcompanion.py
+++ b/miio/integrations/lumi/acpartner/airconditioningcompanion.py
@@ -311,12 +311,16 @@ class AirConditioningCompanion(Device):
         try:
             model_bytes = bytes.fromhex(model)
         except ValueError as ex:
-            raise ValueError("Invalid model. A hexadecimal string must be provided") from ex
+            raise ValueError(
+                "Invalid model. A hexadecimal string must be provided"
+            ) from ex
 
         try:
             code_bytes = bytes.fromhex(code)
         except ValueError as ex:
-            raise ValueError("Invalid code. A hexadecimal string must be provided") from ex
+            raise ValueError(
+                "Invalid code. A hexadecimal string must be provided"
+            ) from ex
 
         if slot < 0 or slot > 134:
             raise ValueError(f"Invalid slot: {slot}")

--- a/miio/integrations/lumi/acpartner/airconditioningcompanionMCN.py
+++ b/miio/integrations/lumi/acpartner/airconditioningcompanionMCN.py
@@ -111,7 +111,7 @@ class AirConditioningCompanionMcn02(Device):
         model: str = MODEL_ACPARTNER_MCN02,
     ) -> None:
         if start_id is None:
-            start_id = random.randint(0, 999)  # nosec
+            start_id = random.randint(0, 999)  # noqa: S311
         super().__init__(
             ip, token, start_id, debug, lazy_discover, timeout=timeout, model=model
         )

--- a/miio/integrations/lumi/acpartner/test_airconditioningcompanion.py
+++ b/miio/integrations/lumi/acpartner/test_airconditioningcompanion.py
@@ -200,7 +200,7 @@ class TestAirConditioningCompanion(TestCase):
         for args in test_data["test_send_ir_code_ok"]:
             with self.subTest():
                 self.device._reset_state()
-                self.assertTrue(self.device.send_ir_code(*args["in"]))
+                assert self.device.send_ir_code(*args["in"])
                 self.assertSequenceEqual(self.device.get_last_ir_played(), args["out"])
 
         for args in test_data["test_send_ir_code_exception"]:
@@ -214,7 +214,7 @@ class TestAirConditioningCompanion(TestCase):
         for args in test_data["test_send_configuration_ok"]:
             with self.subTest():
                 self.device._reset_state()
-                self.assertTrue(self.device.send_configuration(*args["in"]))
+                assert self.device.send_configuration(*args["in"])
                 self.assertSequenceEqual(self.device.get_last_ir_played(), args["out"])
 
 

--- a/miio/integrations/nwt/dehumidifier/airdehumidifier.py
+++ b/miio/integrations/nwt/dehumidifier/airdehumidifier.py
@@ -184,7 +184,7 @@ class AirDehumidifier(Device):
         values = self.get_properties(properties, max_properties=1)
 
         return AirDehumidifierStatus(
-            defaultdict(lambda: None, zip(properties, values)), self.info()
+            defaultdict(lambda: None, zip(properties, values, strict=False)), self.info()
         )
 
     @command(default_output=format_output("Powering on"))

--- a/miio/integrations/nwt/dehumidifier/airdehumidifier.py
+++ b/miio/integrations/nwt/dehumidifier/airdehumidifier.py
@@ -184,7 +184,8 @@ class AirDehumidifier(Device):
         values = self.get_properties(properties, max_properties=1)
 
         return AirDehumidifierStatus(
-            defaultdict(lambda: None, zip(properties, values, strict=False)), self.info()
+            defaultdict(lambda: None, zip(properties, values, strict=False)),
+            self.info(),
         )
 
     @command(default_output=format_output("Powering on"))

--- a/miio/integrations/philips/light/ceil.py
+++ b/miio/integrations/philips/light/ceil.py
@@ -90,7 +90,9 @@ class Ceil(Device):
         properties = ["power", "bright", "cct", "snm", "dv", "bl", "ac"]
         values = self.get_properties(properties)
 
-        return CeilStatus(defaultdict(lambda: None, zip(properties, values, strict=False)))
+        return CeilStatus(
+            defaultdict(lambda: None, zip(properties, values, strict=False))
+        )
 
     @command(default_output=format_output("Powering on"))
     def on(self):

--- a/miio/integrations/philips/light/ceil.py
+++ b/miio/integrations/philips/light/ceil.py
@@ -90,7 +90,7 @@ class Ceil(Device):
         properties = ["power", "bright", "cct", "snm", "dv", "bl", "ac"]
         values = self.get_properties(properties)
 
-        return CeilStatus(defaultdict(lambda: None, zip(properties, values)))
+        return CeilStatus(defaultdict(lambda: None, zip(properties, values, strict=False)))
 
     @command(default_output=format_output("Powering on"))
     def on(self):

--- a/miio/integrations/philips/light/philips_bulb.py
+++ b/miio/integrations/philips/light/philips_bulb.py
@@ -92,7 +92,7 @@ class PhilipsWhiteBulb(Device):
         )
         values = self.get_properties(properties)
 
-        return PhilipsBulbStatus(defaultdict(lambda: None, zip(properties, values)))
+        return PhilipsBulbStatus(defaultdict(lambda: None, zip(properties, values, strict=False)))
 
     @command(default_output=format_output("Powering on"))
     def on(self):

--- a/miio/integrations/philips/light/philips_bulb.py
+++ b/miio/integrations/philips/light/philips_bulb.py
@@ -92,7 +92,9 @@ class PhilipsWhiteBulb(Device):
         )
         values = self.get_properties(properties)
 
-        return PhilipsBulbStatus(defaultdict(lambda: None, zip(properties, values, strict=False)))
+        return PhilipsBulbStatus(
+            defaultdict(lambda: None, zip(properties, values, strict=False))
+        )
 
     @command(default_output=format_output("Powering on"))
     def on(self):

--- a/miio/integrations/philips/light/philips_eyecare.py
+++ b/miio/integrations/philips/light/philips_eyecare.py
@@ -104,7 +104,7 @@ class PhilipsEyecare(Device):
         ]
         values = self.get_properties(properties)
 
-        return PhilipsEyecareStatus(defaultdict(lambda: None, zip(properties, values)))
+        return PhilipsEyecareStatus(defaultdict(lambda: None, zip(properties, values, strict=False)))
 
     @command(default_output=format_output("Powering on"))
     def on(self):

--- a/miio/integrations/philips/light/philips_eyecare.py
+++ b/miio/integrations/philips/light/philips_eyecare.py
@@ -104,7 +104,9 @@ class PhilipsEyecare(Device):
         ]
         values = self.get_properties(properties)
 
-        return PhilipsEyecareStatus(defaultdict(lambda: None, zip(properties, values, strict=False)))
+        return PhilipsEyecareStatus(
+            defaultdict(lambda: None, zip(properties, values, strict=False))
+        )
 
     @command(default_output=format_output("Powering on"))
     def on(self):

--- a/miio/integrations/philips/light/philips_moonlight.py
+++ b/miio/integrations/philips/light/philips_moonlight.py
@@ -141,7 +141,7 @@ class PhilipsMoonlight(Device):
         values = self.get_properties(properties)
 
         return PhilipsMoonlightStatus(
-            defaultdict(lambda: None, zip(properties, values))
+            defaultdict(lambda: None, zip(properties, values, strict=False))
         )
 
     @command(default_output=format_output("Powering on"))

--- a/miio/integrations/philips/light/philips_rwread.py
+++ b/miio/integrations/philips/light/philips_rwread.py
@@ -99,7 +99,7 @@ class PhilipsRwread(Device):
         )
         values = self.get_properties(properties)
 
-        return PhilipsRwreadStatus(defaultdict(lambda: None, zip(properties, values)))
+        return PhilipsRwreadStatus(defaultdict(lambda: None, zip(properties, values, strict=False)))
 
     @command(default_output=format_output("Powering on"))
     def on(self):

--- a/miio/integrations/philips/light/philips_rwread.py
+++ b/miio/integrations/philips/light/philips_rwread.py
@@ -99,7 +99,9 @@ class PhilipsRwread(Device):
         )
         values = self.get_properties(properties)
 
-        return PhilipsRwreadStatus(defaultdict(lambda: None, zip(properties, values, strict=False)))
+        return PhilipsRwreadStatus(
+            defaultdict(lambda: None, zip(properties, values, strict=False))
+        )
 
     @command(default_output=format_output("Powering on"))
     def on(self):

--- a/miio/integrations/pwzn/relay/pwzn_relay.py
+++ b/miio/integrations/pwzn/relay/pwzn_relay.py
@@ -110,7 +110,7 @@ class PwznRelay(Device):
         ).copy()
         values = self.get_properties(properties)
 
-        return PwznRelayStatus(defaultdict(lambda: None, zip(properties, values)))
+        return PwznRelayStatus(defaultdict(lambda: None, zip(properties, values, strict=False)))
 
     @command(
         click.argument("number", type=int),

--- a/miio/integrations/pwzn/relay/pwzn_relay.py
+++ b/miio/integrations/pwzn/relay/pwzn_relay.py
@@ -110,7 +110,9 @@ class PwznRelay(Device):
         ).copy()
         values = self.get_properties(properties)
 
-        return PwznRelayStatus(defaultdict(lambda: None, zip(properties, values, strict=False)))
+        return PwznRelayStatus(
+            defaultdict(lambda: None, zip(properties, values, strict=False))
+        )
 
     @command(
         click.argument("number", type=int),

--- a/miio/integrations/roborock/vacuum/vacuum_cli.py
+++ b/miio/integrations/roborock/vacuum/vacuum_cli.py
@@ -19,14 +19,13 @@ from miio.click_common import (
     validate_token,
 )
 from miio.device import Device, UpdateState
+from miio.discovery import Discovery
 from miio.exceptions import DeviceInfoUnavailableException
 from miio.miioprotocol import MiIOProtocol
 from miio.updater import OneShotServer
 
 from .vacuum import CarpetCleaningMode, Consumable, RoborockVacuum, TimerState
 from .vacuum_tui import VacuumTUI
-
-from miio.discovery import Discovery
 
 _LOGGER = logging.getLogger(__name__)
 pass_dev = click.make_pass_decorator(Device, ensure=True)

--- a/miio/integrations/roidmi/vacuum/tests/test_roidmivacuum_miot.py
+++ b/miio/integrations/roidmi/vacuum/tests/test_roidmivacuum_miot.py
@@ -65,7 +65,7 @@ class DummyRoidmiVacuumMiot(DummyMiotDevice, RoidmiVacuumMiot):
         super().__init__(*args, **kwargs)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def dummyroidmivacuum(request):
     request.cls.device = DummyRoidmiVacuumMiot()
 
@@ -200,7 +200,7 @@ class DummyRoidmiVacuumMiot2(DummyMiotDevice, RoidmiVacuumMiot):
         super().__init__(*args, **kwargs)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def dummyroidmivacuum2(request):
     request.cls.device = DummyRoidmiVacuumMiot2()
 

--- a/miio/integrations/shuii/humidifier/airhumidifier_jsq.py
+++ b/miio/integrations/shuii/humidifier/airhumidifier_jsq.py
@@ -188,7 +188,9 @@ class AirHumidifierJsq(Device):
                 values,
             )
 
-        return AirHumidifierStatus({k: v for k, v in zip(properties, values, strict=False)})
+        return AirHumidifierStatus(
+            {k: v for k, v in zip(properties, values, strict=False)}
+        )
 
     @command(default_output=format_output("Powering on"))
     def on(self):

--- a/miio/integrations/shuii/humidifier/airhumidifier_jsq.py
+++ b/miio/integrations/shuii/humidifier/airhumidifier_jsq.py
@@ -188,7 +188,7 @@ class AirHumidifierJsq(Device):
                 values,
             )
 
-        return AirHumidifierStatus({k: v for k, v in zip(properties, values)})
+        return AirHumidifierStatus({k: v for k, v in zip(properties, values, strict=False)})
 
     @command(default_output=format_output("Powering on"))
     def on(self):

--- a/miio/integrations/tinymu/toiletlid/toiletlid.py
+++ b/miio/integrations/tinymu/toiletlid/toiletlid.py
@@ -94,7 +94,7 @@ class Toiletlid(Device):
         values = self.get_properties(properties)
 
         color = self.get_ambient_light()
-        return ToiletlidStatus(dict(zip(properties, values), ambient_light=color))
+        return ToiletlidStatus(dict(zip(properties, values, strict=False), ambient_light=color))
 
     @command(default_output=format_output("Nozzle clean"))
     def nozzle_clean(self):

--- a/miio/integrations/tinymu/toiletlid/toiletlid.py
+++ b/miio/integrations/tinymu/toiletlid/toiletlid.py
@@ -94,7 +94,9 @@ class Toiletlid(Device):
         values = self.get_properties(properties)
 
         color = self.get_ambient_light()
-        return ToiletlidStatus(dict(zip(properties, values, strict=False), ambient_light=color))
+        return ToiletlidStatus(
+            dict(zip(properties, values, strict=False), ambient_light=color)
+        )
 
     @command(default_output=format_output("Nozzle clean"))
     def nozzle_clean(self):

--- a/miio/integrations/viomi/vacuum/tests/test_viomivacuum.py
+++ b/miio/integrations/viomi/vacuum/tests/test_viomivacuum.py
@@ -97,9 +97,9 @@ class DummyViomiVacuum(DummyDevice, ViomiVacuum):
         super().__init__(args, kwargs)
 
 
-@pytest.fixture()
+@pytest.fixture
 def dev(request):
-    yield DummyViomiVacuum()
+    return DummyViomiVacuum()
 
 
 class TestViomiVacuumStatus:

--- a/miio/integrations/viomi/vacuum/viomivacuum.py
+++ b/miio/integrations/viomi/vacuum/viomivacuum.py
@@ -687,7 +687,7 @@ class ViomiVacuum(Device):
 
         values = self.get_properties(properties)
 
-        status = ViomiVacuumStatus(defaultdict(lambda: None, zip(properties, values)))
+        status = ViomiVacuumStatus(defaultdict(lambda: None, zip(properties, values, strict=False)))
         status.embed("consumables", self.consumable_status())
         status.embed("dnd", self.dnd_status())
 
@@ -820,7 +820,7 @@ class ViomiVacuum(Device):
         results = self.send("get_curpos", [])
         positions = []
         # Group result 4 by 4
-        for res in [i for i in zip(*(results[i::4] for i in range(4)))]:
+        for res in [i for i in zip(*(results[i::4] for i in range(4)), strict=False)]:
             # ignore type require for mypy error
             # "ViomiPositionPoint" gets multiple values for keyword argument "plan_multiplicator"
             positions.append(

--- a/miio/integrations/viomi/vacuum/viomivacuum.py
+++ b/miio/integrations/viomi/vacuum/viomivacuum.py
@@ -687,7 +687,9 @@ class ViomiVacuum(Device):
 
         values = self.get_properties(properties)
 
-        status = ViomiVacuumStatus(defaultdict(lambda: None, zip(properties, values, strict=False)))
+        status = ViomiVacuumStatus(
+            defaultdict(lambda: None, zip(properties, values, strict=False))
+        )
         status.embed("consumables", self.consumable_status())
         status.embed("dnd", self.dnd_status())
 

--- a/miio/integrations/viomi/viomidishwasher/test_viomidishwasher.py
+++ b/miio/integrations/viomi/viomidishwasher/test_viomidishwasher.py
@@ -125,8 +125,8 @@ class TestViomiDishwasher(TestCase):
         assert self.device._is_running() is True
         assert SystemStatus.ThermistorError in self.state().errors
         assert SystemStatus.InsufficientWaterSoftener in self.state().errors
-        self.assertIsInstance(self.state().air_refresh_interval, int)
-        self.assertIsInstance(self.state().temperature, int)
+        assert isinstance(self.state().air_refresh_interval, int)
+        assert isinstance(self.state().temperature, int)
 
     def test_child_lock(self):
         self.device.on()  # ensure on
@@ -160,14 +160,14 @@ class TestViomiDishwasher(TestCase):
             second=0, microsecond=0
         )
         self.device.schedule(enough_time, Program.Quick)
-        self.assertIsInstance(self.state().schedule, datetime)
+        assert isinstance(self.state().schedule, datetime)
         assert self.state().schedule == enough_time
 
     def test_freshdry_interval(self):
         self.device.on()  # ensure on
         assert self.is_on() is True
 
-        self.assertIsInstance(self.state().air_refresh_interval, int)
+        assert isinstance(self.state().air_refresh_interval, int)
 
         self.device.airrefresh(8)
         assert self.state().air_refresh_interval == 8

--- a/miio/integrations/viomi/viomidishwasher/viomidishwasher.py
+++ b/miio/integrations/viomi/viomidishwasher/viomidishwasher.py
@@ -273,7 +273,7 @@ class ViomiDishwasher(Device):
 
         values = self.get_properties(properties, max_properties=1)
 
-        return ViomiDishwasherStatus(defaultdict(lambda: None, zip(properties, values)))
+        return ViomiDishwasherStatus(defaultdict(lambda: None, zip(properties, values, strict=False)))
 
     # FIXME: Change these to use the ViomiDishwasherStatus once we can query multiple properties at once (or cache?).
     def _is_on(self) -> bool:

--- a/miio/integrations/viomi/viomidishwasher/viomidishwasher.py
+++ b/miio/integrations/viomi/viomidishwasher/viomidishwasher.py
@@ -273,7 +273,9 @@ class ViomiDishwasher(Device):
 
         values = self.get_properties(properties, max_properties=1)
 
-        return ViomiDishwasherStatus(defaultdict(lambda: None, zip(properties, values, strict=False)))
+        return ViomiDishwasherStatus(
+            defaultdict(lambda: None, zip(properties, values, strict=False))
+        )
 
     # FIXME: Change these to use the ViomiDishwasherStatus once we can query multiple properties at once (or cache?).
     def _is_on(self) -> bool:

--- a/miio/integrations/xiaomi/aircondition/test_airconditioner_miot.py
+++ b/miio/integrations/xiaomi/aircondition/test_airconditioner_miot.py
@@ -60,7 +60,7 @@ class DummyAirConditionerMiot(DummyMiotDevice, AirConditionerMiot):
         super().__init__(*args, **kwargs)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def airconditionermiot(request):
     request.cls.device = DummyAirConditionerMiot()
 

--- a/miio/integrations/yeelight/dual_switch/test_yeelight_dual_switch.py
+++ b/miio/integrations/yeelight/dual_switch/test_yeelight_dual_switch.py
@@ -28,7 +28,7 @@ class DummyYeelightDualControlModule(DummyMiotDevice, YeelightDualControlModule)
         super().__init__(*args, **kwargs)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def switch(request):
     request.cls.device = DummyYeelightDualControlModule()
 

--- a/miio/integrations/yeelight/light/tests/test_yeelight.py
+++ b/miio/integrations/yeelight/light/tests/test_yeelight.py
@@ -240,24 +240,12 @@ class TestYeelightLightColor(TestCase):
         assert len(status.lights) == 1
         assert status.is_on is False
         assert status.is_on == status.lights[0].is_on
-        assert (
-            status.brightness == 100
-        )
-        assert (
-            status.brightness == status.lights[0].brightness
-        )
-        assert (
-            status.color_mode == YeelightMode.ColorTemperature
-        )
-        assert (
-            status.color_mode == status.lights[0].color_mode
-        )
-        assert (
-            status.color_temp == 3584
-        )
-        assert (
-            status.color_temp == status.lights[0].color_temp
-        )
+        assert status.brightness == 100
+        assert status.brightness == status.lights[0].brightness
+        assert status.color_mode == YeelightMode.ColorTemperature
+        assert status.color_mode == status.lights[0].color_mode
+        assert status.color_temp == 3584
+        assert status.color_temp == status.lights[0].color_temp
         assert status.rgb is None
         assert status.rgb == status.lights[0].rgb
         assert status.hsv is None
@@ -265,18 +253,10 @@ class TestYeelightLightColor(TestCase):
         # following are tested in set mode tests
         # assert status.rgb == 16711680
         # assert status.hsv == (359, 100, 100)
-        assert (
-            status.color_flowing is False
-        )
-        assert (
-            status.color_flowing == status.lights[0].color_flowing
-        )
-        assert (
-            status.color_flow_params is None
-        )
-        assert (
-            status.color_flow_params == status.lights[0].color_flow_params
-        )
+        assert status.color_flowing is False
+        assert status.color_flowing == status.lights[0].color_flowing
+        assert status.color_flow_params is None
+        assert status.color_flow_params == status.lights[0].color_flow_params
         # color_flow_params will be tested after future implementation
         # assert status.color_flow_params == "0,0,1000,1,16711680,100,1000,1,65280,100,1000,1,255,100" and status.color_flow_params == status.lights[0].color_flow_params
         assert status.moonlight_mode is None
@@ -381,24 +361,12 @@ class TestYeelightLightCeilingV1(TestCase):
         assert len(status.lights) == 1
         assert status.is_on is False
         assert status.is_on == status.lights[0].is_on
-        assert (
-            status.brightness == 100
-        )
-        assert (
-            status.brightness == status.lights[0].brightness
-        )
-        assert (
-            status.color_mode == YeelightMode.ColorTemperature
-        )
-        assert (
-            status.color_mode == status.lights[0].color_mode
-        )
-        assert (
-            status.color_temp == 3584
-        )
-        assert (
-            status.color_temp == status.lights[0].color_temp
-        )
+        assert status.brightness == 100
+        assert status.brightness == status.lights[0].brightness
+        assert status.color_mode == YeelightMode.ColorTemperature
+        assert status.color_mode == status.lights[0].color_mode
+        assert status.color_temp == 3584
+        assert status.color_temp == status.lights[0].color_temp
         assert status.rgb is None
         assert status.rgb == status.lights[0].rgb
         assert status.hsv is None
@@ -406,18 +374,10 @@ class TestYeelightLightCeilingV1(TestCase):
         # following are tested in set mode tests
         # assert status.rgb == 16711680
         # assert status.hsv == (359, 100, 100)
-        assert (
-            status.color_flowing is False
-        )
-        assert (
-            status.color_flowing == status.lights[0].color_flowing
-        )
-        assert (
-            status.color_flow_params is None
-        )
-        assert (
-            status.color_flow_params == status.lights[0].color_flow_params
-        )
+        assert status.color_flowing is False
+        assert status.color_flowing == status.lights[0].color_flowing
+        assert status.color_flow_params is None
+        assert status.color_flow_params == status.lights[0].color_flow_params
         # color_flow_params will be tested after future implementation
         # assert status.color_flow_params == "0,0,1000,1,16711680,100,1000,1,65280,100,1000,1,255,100" and status.color_flow_params == status.lights[0].color_flow_params
         assert status.moonlight_mode is True
@@ -478,24 +438,12 @@ class TestYeelightLightCeilingV2(TestCase):
         assert len(status.lights) == 2
         assert status.is_on is False
         assert status.is_on == status.lights[0].is_on
-        assert (
-            status.brightness == 100
-        )
-        assert (
-            status.brightness == status.lights[0].brightness
-        )
-        assert (
-            status.color_mode == YeelightMode.ColorTemperature
-        )
-        assert (
-            status.color_mode == status.lights[0].color_mode
-        )
-        assert (
-            status.color_temp == 3584
-        )
-        assert (
-            status.color_temp == status.lights[0].color_temp
-        )
+        assert status.brightness == 100
+        assert status.brightness == status.lights[0].brightness
+        assert status.color_mode == YeelightMode.ColorTemperature
+        assert status.color_mode == status.lights[0].color_mode
+        assert status.color_temp == 3584
+        assert status.color_temp == status.lights[0].color_temp
         assert status.rgb is None
         assert status.rgb == status.lights[0].rgb
         assert status.hsv is None
@@ -503,18 +451,10 @@ class TestYeelightLightCeilingV2(TestCase):
         # following are tested in set mode tests
         # assert status.rgb == 16711680
         # assert status.hsv == (359, 100, 100)
-        assert (
-            status.color_flowing is False
-        )
-        assert (
-            status.color_flowing == status.lights[0].color_flowing
-        )
-        assert (
-            status.color_flow_params is None
-        )
-        assert (
-            status.color_flow_params == status.lights[0].color_flow_params
-        )
+        assert status.color_flowing is False
+        assert status.color_flowing == status.lights[0].color_flowing
+        assert status.color_flow_params is None
+        assert status.color_flow_params == status.lights[0].color_flow_params
         # color_flow_params will be tested after future implementation
         # assert status.color_flow_params == "0,0,1000,1,16711680,100,1000,1,65280,100,1000,1,255,100" and status.color_flow_params == status.lights[0].color_flow_params
         assert status.lights[1].is_on is False

--- a/miio/integrations/yeelight/light/tests/test_yeelight.py
+++ b/miio/integrations/yeelight/light/tests/test_yeelight.py
@@ -238,31 +238,44 @@ class TestYeelightLightColor(TestCase):
         assert status.delay_off == 0
         assert status.music_mode is True
         assert len(status.lights) == 1
-        assert status.is_on is False and status.is_on == status.lights[0].is_on
+        assert status.is_on is False
+        assert status.is_on == status.lights[0].is_on
         assert (
             status.brightness == 100
-            and status.brightness == status.lights[0].brightness
+        )
+        assert (
+            status.brightness == status.lights[0].brightness
         )
         assert (
             status.color_mode == YeelightMode.ColorTemperature
-            and status.color_mode == status.lights[0].color_mode
+        )
+        assert (
+            status.color_mode == status.lights[0].color_mode
         )
         assert (
             status.color_temp == 3584
-            and status.color_temp == status.lights[0].color_temp
         )
-        assert status.rgb is None and status.rgb == status.lights[0].rgb
-        assert status.hsv is None and status.hsv == status.lights[0].hsv
+        assert (
+            status.color_temp == status.lights[0].color_temp
+        )
+        assert status.rgb is None
+        assert status.rgb == status.lights[0].rgb
+        assert status.hsv is None
+        assert status.hsv == status.lights[0].hsv
         # following are tested in set mode tests
         # assert status.rgb == 16711680
         # assert status.hsv == (359, 100, 100)
         assert (
             status.color_flowing is False
-            and status.color_flowing == status.lights[0].color_flowing
+        )
+        assert (
+            status.color_flowing == status.lights[0].color_flowing
         )
         assert (
             status.color_flow_params is None
-            and status.color_flow_params == status.lights[0].color_flow_params
+        )
+        assert (
+            status.color_flow_params == status.lights[0].color_flow_params
         )
         # color_flow_params will be tested after future implementation
         # assert status.color_flow_params == "0,0,1000,1,16711680,100,1000,1,65280,100,1000,1,255,100" and status.color_flow_params == status.lights[0].color_flow_params
@@ -366,31 +379,44 @@ class TestYeelightLightCeilingV1(TestCase):
         assert status.delay_off == 0
         assert status.music_mode is None
         assert len(status.lights) == 1
-        assert status.is_on is False and status.is_on == status.lights[0].is_on
+        assert status.is_on is False
+        assert status.is_on == status.lights[0].is_on
         assert (
             status.brightness == 100
-            and status.brightness == status.lights[0].brightness
+        )
+        assert (
+            status.brightness == status.lights[0].brightness
         )
         assert (
             status.color_mode == YeelightMode.ColorTemperature
-            and status.color_mode == status.lights[0].color_mode
+        )
+        assert (
+            status.color_mode == status.lights[0].color_mode
         )
         assert (
             status.color_temp == 3584
-            and status.color_temp == status.lights[0].color_temp
         )
-        assert status.rgb is None and status.rgb == status.lights[0].rgb
-        assert status.hsv is None and status.hsv == status.lights[0].hsv
+        assert (
+            status.color_temp == status.lights[0].color_temp
+        )
+        assert status.rgb is None
+        assert status.rgb == status.lights[0].rgb
+        assert status.hsv is None
+        assert status.hsv == status.lights[0].hsv
         # following are tested in set mode tests
         # assert status.rgb == 16711680
         # assert status.hsv == (359, 100, 100)
         assert (
             status.color_flowing is False
-            and status.color_flowing == status.lights[0].color_flowing
+        )
+        assert (
+            status.color_flowing == status.lights[0].color_flowing
         )
         assert (
             status.color_flow_params is None
-            and status.color_flow_params == status.lights[0].color_flow_params
+        )
+        assert (
+            status.color_flow_params == status.lights[0].color_flow_params
         )
         # color_flow_params will be tested after future implementation
         # assert status.color_flow_params == "0,0,1000,1,16711680,100,1000,1,65280,100,1000,1,255,100" and status.color_flow_params == status.lights[0].color_flow_params
@@ -450,31 +476,44 @@ class TestYeelightLightCeilingV2(TestCase):
         assert status.delay_off == 0
         assert status.music_mode is None
         assert len(status.lights) == 2
-        assert status.is_on is False and status.is_on == status.lights[0].is_on
+        assert status.is_on is False
+        assert status.is_on == status.lights[0].is_on
         assert (
             status.brightness == 100
-            and status.brightness == status.lights[0].brightness
+        )
+        assert (
+            status.brightness == status.lights[0].brightness
         )
         assert (
             status.color_mode == YeelightMode.ColorTemperature
-            and status.color_mode == status.lights[0].color_mode
+        )
+        assert (
+            status.color_mode == status.lights[0].color_mode
         )
         assert (
             status.color_temp == 3584
-            and status.color_temp == status.lights[0].color_temp
         )
-        assert status.rgb is None and status.rgb == status.lights[0].rgb
-        assert status.hsv is None and status.hsv == status.lights[0].hsv
+        assert (
+            status.color_temp == status.lights[0].color_temp
+        )
+        assert status.rgb is None
+        assert status.rgb == status.lights[0].rgb
+        assert status.hsv is None
+        assert status.hsv == status.lights[0].hsv
         # following are tested in set mode tests
         # assert status.rgb == 16711680
         # assert status.hsv == (359, 100, 100)
         assert (
             status.color_flowing is False
-            and status.color_flowing == status.lights[0].color_flowing
+        )
+        assert (
+            status.color_flowing == status.lights[0].color_flowing
         )
         assert (
             status.color_flow_params is None
-            and status.color_flow_params == status.lights[0].color_flow_params
+        )
+        assert (
+            status.color_flow_params == status.lights[0].color_flow_params
         )
         # color_flow_params will be tested after future implementation
         # assert status.color_flow_params == "0,0,1000,1,16711680,100,1000,1,65280,100,1000,1,255,100" and status.color_flow_params == status.lights[0].color_flow_params

--- a/miio/integrations/yeelight/light/yeelight.py
+++ b/miio/integrations/yeelight/light/yeelight.py
@@ -326,7 +326,7 @@ class Yeelight(Device):
 
         values = self.get_properties(properties)
 
-        return YeelightStatus(dict(zip(properties, values)))
+        return YeelightStatus(dict(zip(properties, values, strict=False)))
 
     @property
     def color_temperature_range(self) -> ValidSettingRange:

--- a/miio/integrations/yunmi/waterpurifier/waterpurifier.py
+++ b/miio/integrations/yunmi/waterpurifier/waterpurifier.py
@@ -145,7 +145,7 @@ class WaterPurifier(Device):
         _props_per_request = 1
         values = self.get_properties(properties, max_properties=_props_per_request)
 
-        return WaterPurifierStatus(dict(zip(properties, values)))
+        return WaterPurifierStatus(dict(zip(properties, values, strict=False)))
 
     @command(default_output=format_output("Powering on"))
     def on(self):

--- a/miio/integrations/yunmi/waterpurifier/waterpurifier_yunmi.py
+++ b/miio/integrations/yunmi/waterpurifier/waterpurifier_yunmi.py
@@ -316,4 +316,4 @@ class WaterPurifierYunmi(Device):
                 val_count,
             )
 
-        return WaterPurifierYunmiStatus(dict(zip(properties, values)))
+        return WaterPurifierYunmiStatus(dict(zip(properties, values, strict=False)))

--- a/miio/integrations/zhimi/airpurifier/airfresh.py
+++ b/miio/integrations/zhimi/airpurifier/airfresh.py
@@ -246,7 +246,7 @@ class AirFresh(Device):
         values = self.get_properties(properties, max_properties=15)
 
         return AirFreshStatus(
-            defaultdict(lambda: None, zip(properties, values)), self.model
+            defaultdict(lambda: None, zip(properties, values, strict=False)), self.model
         )
 
     @command(default_output=format_output("Powering on"))

--- a/miio/integrations/zhimi/airpurifier/airpurifier.py
+++ b/miio/integrations/zhimi/airpurifier/airpurifier.py
@@ -386,7 +386,9 @@ class AirPurifier(Device):
 
         values = self.get_properties(properties, max_properties=15)
 
-        return AirPurifierStatus(defaultdict(lambda: None, zip(properties, values, strict=False)))
+        return AirPurifierStatus(
+            defaultdict(lambda: None, zip(properties, values, strict=False))
+        )
 
     @command(default_output=format_output("Powering on"))
     def on(self):

--- a/miio/integrations/zhimi/airpurifier/airpurifier.py
+++ b/miio/integrations/zhimi/airpurifier/airpurifier.py
@@ -386,7 +386,7 @@ class AirPurifier(Device):
 
         values = self.get_properties(properties, max_properties=15)
 
-        return AirPurifierStatus(defaultdict(lambda: None, zip(properties, values)))
+        return AirPurifierStatus(defaultdict(lambda: None, zip(properties, values, strict=False)))
 
     @command(default_output=format_output("Powering on"))
     def on(self):

--- a/miio/integrations/zhimi/airpurifier/tests/test_airpurifier_miot.py
+++ b/miio/integrations/zhimi/airpurifier/tests/test_airpurifier_miot.py
@@ -95,7 +95,7 @@ class DummyAirPurifierMiot(DummyMiotDevice, AirPurifierMiot):
         super().__init__(*args, **kwargs)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def airpurifier(request):
     request.cls.device = DummyAirPurifierMiot()
 
@@ -243,7 +243,7 @@ class DummyAirPurifierMiotMB4(DummyAirPurifierMiot):
         super().__init__(*args, **kwargs)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def airpurifierMB4(request):
     request.cls.device = DummyAirPurifierMiotMB4()
 
@@ -313,7 +313,7 @@ class DummyAirPurifierMiotMB5(DummyAirPurifierMiot):
         super().__init__(*args, **kwargs)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def airpurifierVA2(request):
     request.cls.device = DummyAirPurifierMiotVA2()
 

--- a/miio/integrations/zhimi/fan/fan.py
+++ b/miio/integrations/zhimi/fan/fan.py
@@ -260,9 +260,9 @@ class Fan(Device):
 
         # The ZA4 has a countdown timer in minutes
         if self.model in [MODEL_FAN_ZA4]:
-            return FanStatusZA4(dict(zip(properties, values)))
+            return FanStatusZA4(dict(zip(properties, values, strict=False)))
 
-        return FanStatus(dict(zip(properties, values)))
+        return FanStatus(dict(zip(properties, values, strict=False)))
 
     @command(default_output=format_output("Powering on"))
     def on(self):

--- a/miio/integrations/zhimi/heater/heater.py
+++ b/miio/integrations/zhimi/heater/heater.py
@@ -153,7 +153,7 @@ class Heater(Device):
 
         values = self.get_properties(properties, max_properties=_props_per_request)
 
-        return HeaterStatus(dict(zip(properties, values)))
+        return HeaterStatus(dict(zip(properties, values, strict=False)))
 
     @command(default_output=format_output("Powering on"))
     def on(self):

--- a/miio/integrations/zhimi/humidifier/airhumidifier.py
+++ b/miio/integrations/zhimi/humidifier/airhumidifier.py
@@ -349,7 +349,7 @@ class AirHumidifier(Device):
         values = self.get_properties(properties, max_properties=_props_per_request)
 
         return AirHumidifierStatus(
-            defaultdict(lambda: None, zip(properties, values)), self.info()
+            defaultdict(lambda: None, zip(properties, values, strict=False)), self.info()
         )
 
     @command(default_output=format_output("Powering on"))

--- a/miio/integrations/zhimi/humidifier/airhumidifier.py
+++ b/miio/integrations/zhimi/humidifier/airhumidifier.py
@@ -349,7 +349,8 @@ class AirHumidifier(Device):
         values = self.get_properties(properties, max_properties=_props_per_request)
 
         return AirHumidifierStatus(
-            defaultdict(lambda: None, zip(properties, values, strict=False)), self.info()
+            defaultdict(lambda: None, zip(properties, values, strict=False)),
+            self.info(),
         )
 
     @command(default_output=format_output("Powering on"))

--- a/miio/integrations/zhimi/humidifier/tests/test_airhumidifier.py
+++ b/miio/integrations/zhimi/humidifier/tests/test_airhumidifier.py
@@ -295,7 +295,8 @@ def test_set_dry(dev):
 
 
 @pytest.mark.parametrize(
-    ("depth", "expected"), [(-1, 0), (0, 0), (60, 50), (120, 100), (125, 100), (127, None)]
+    ("depth", "expected"),
+    [(-1, 0), (0, 0), (60, 50), (120, 100), (125, 100), (127, None)],
 )
 def test_water_level(dev, depth, expected):
     """Test the water level conversions."""

--- a/miio/integrations/zhimi/humidifier/tests/test_airhumidifier.py
+++ b/miio/integrations/zhimi/humidifier/tests/test_airhumidifier.py
@@ -102,7 +102,7 @@ class DummyAirHumidifier(DummyDevice, AirHumidifier):
     params=[MODEL_HUMIDIFIER_V1, MODEL_HUMIDIFIER_CA1, MODEL_HUMIDIFIER_CB1]
 )
 def dev(request):
-    yield DummyAirHumidifier(model=request.param)
+    return DummyAirHumidifier(model=request.param)
     # TODO add ability to test on a real device
 
 
@@ -295,7 +295,7 @@ def test_set_dry(dev):
 
 
 @pytest.mark.parametrize(
-    "depth,expected", [(-1, 0), (0, 0), (60, 50), (120, 100), (125, 100), (127, None)]
+    ("depth", "expected"), [(-1, 0), (0, 0), (60, 50), (120, 100), (125, 100), (127, None)]
 )
 def test_water_level(dev, depth, expected):
     """Test the water level conversions."""

--- a/miio/integrations/zhimi/humidifier/tests/test_airhumidifier_miot.py
+++ b/miio/integrations/zhimi/humidifier/tests/test_airhumidifier_miot.py
@@ -197,7 +197,8 @@ def test_set_clean_mode(dev):
 
 
 @pytest.mark.parametrize(
-    ("depth", "expected"), [(-1, 0), (0, 0), (60, 50), (120, 100), (125, 100), (127, None)]
+    ("depth", "expected"),
+    [(-1, 0), (0, 0), (60, 50), (120, 100), (125, 100), (127, None)],
 )
 def test_water_level(dev, depth, expected):
     dev.set_property("water_level", depth)

--- a/miio/integrations/zhimi/humidifier/tests/test_airhumidifier_miot.py
+++ b/miio/integrations/zhimi/humidifier/tests/test_airhumidifier_miot.py
@@ -46,9 +46,9 @@ class DummyAirHumidifierMiot(DummyMiotDevice, AirHumidifierMiot):
         super().__init__(*args, **kwargs)
 
 
-@pytest.fixture()
+@pytest.fixture
 def dev(request):
-    yield DummyAirHumidifierMiot()
+    return DummyAirHumidifierMiot()
 
 
 def test_on(dev):
@@ -197,7 +197,7 @@ def test_set_clean_mode(dev):
 
 
 @pytest.mark.parametrize(
-    "depth,expected", [(-1, 0), (0, 0), (60, 50), (120, 100), (125, 100), (127, None)]
+    ("depth", "expected"), [(-1, 0), (0, 0), (60, 50), (120, 100), (125, 100), (127, None)]
 )
 def test_water_level(dev, depth, expected):
     dev.set_property("water_level", depth)

--- a/miio/integrations/zhimi/humidifier/tests/test_airhumidifier_miot_ca6.py
+++ b/miio/integrations/zhimi/humidifier/tests/test_airhumidifier_miot_ca6.py
@@ -44,9 +44,9 @@ class DummyAirHumidifierMiotCA6(DummyMiotDevice, AirHumidifierMiotCA6):
         super().__init__(*args, **kwargs)
 
 
-@pytest.fixture()
+@pytest.fixture
 def dev(request):
-    yield DummyAirHumidifierMiotCA6()
+    return DummyAirHumidifierMiotCA6()
 
 
 def test_on(dev):
@@ -176,7 +176,7 @@ def test_set_clean_mode(dev):
     assert clean_mode() is False
 
 
-@pytest.mark.parametrize("given,expected", [(0, 0), (1, 50), (2, 100)])
+@pytest.mark.parametrize(("given", "expected"), [(0, 0), (1, 50), (2, 100)])
 def test_water_level(dev, given, expected):
     dev.set_property("water_level", given)
     assert dev.status().water_level == expected

--- a/miio/integrations/zimi/powerstrip/powerstrip.py
+++ b/miio/integrations/zimi/powerstrip/powerstrip.py
@@ -173,7 +173,9 @@ class PowerStrip(Device):
         )
         values = self.get_properties(properties)
 
-        return PowerStripStatus(defaultdict(lambda: None, zip(properties, values, strict=False)))
+        return PowerStripStatus(
+            defaultdict(lambda: None, zip(properties, values, strict=False))
+        )
 
     @command(click.argument("power", type=bool))
     def set_power(self, power: bool):

--- a/miio/integrations/zimi/powerstrip/powerstrip.py
+++ b/miio/integrations/zimi/powerstrip/powerstrip.py
@@ -173,7 +173,7 @@ class PowerStrip(Device):
         )
         values = self.get_properties(properties)
 
-        return PowerStripStatus(defaultdict(lambda: None, zip(properties, values)))
+        return PowerStripStatus(defaultdict(lambda: None, zip(properties, values, strict=False)))
 
     @command(click.argument("power", type=bool))
     def set_power(self, power: bool):

--- a/miio/protocol.py
+++ b/miio/protocol.py
@@ -58,7 +58,7 @@ class Utils:
     @staticmethod
     def md5(data: bytes) -> bytes:
         """Calculates a md5 hashsum for the given bytes object."""
-        checksum = hashlib.md5()  # nosec
+        checksum = hashlib.md5()  # noqa: S324
         checksum.update(data)
         return checksum.digest()
 

--- a/miio/push_server/server.py
+++ b/miio/push_server/server.py
@@ -58,7 +58,7 @@ class PushServer:
         """Initialize the class."""
         self._device_ip = device_ip
 
-        self._address = "0.0.0.0"  # nosec
+        self._address = "0.0.0.0"  # noqa: S104
         self._server_ip = None
 
         self._device_id = device_id if device_id is not None else int(FAKE_DEVICE_ID)
@@ -234,7 +234,7 @@ class PushServer:
             sock=udp_socket,
         )
 
-    def _construct_event(  # nosec
+    def _construct_event(
         self,
         event_id: str,
         info: EventInfo,
@@ -253,7 +253,7 @@ class PushServer:
         command = f"{self.server_model}.{info.action}:{source_id}"
         key = f"event.{info.source_model}.{info.event}"
         message_id = 0
-        magic_number = randint(1590161094, 1642025774)  # nosec, min/max taken from packet captures, unknown use
+        magic_number = randint(1590161094, 1642025774)  # noqa: S311  # min/max taken from packet captures, unknown use
 
         if len(command) > 49:
             _LOGGER.error(

--- a/miio/push_server/test_serverprotocol.py
+++ b/miio/push_server/test_serverprotocol.py
@@ -26,7 +26,7 @@ def protocol(mocker, event_loop) -> ServerProtocol:
     proto = ServerProtocol(event_loop, socket, server)
     proto.transport = mocker.Mock()
 
-    yield proto
+    return proto
 
 
 def test_send_ping_ack(protocol: ServerProtocol, mocker):
@@ -114,7 +114,7 @@ def test_datagram_with_known_method(protocol: ServerProtocol, mocker):
 
 
 @pytest.mark.parametrize(
-    "method,err_code", [("unknown_method", ERR_UNSUPPORTED), (None, ERR_INVALID)]
+    ("method", "err_code"), [("unknown_method", ERR_UNSUPPORTED), (None, ERR_INVALID)]
 )
 def test_datagram_with_unknown_method(
     method, err_code, protocol: ServerProtocol, mocker

--- a/miio/tests/conftest.py
+++ b/miio/tests/conftest.py
@@ -4,7 +4,7 @@ from ..device import Device
 from ..devicestatus import DeviceStatus, action, sensor, setting
 
 
-@pytest.fixture()
+@pytest.fixture
 def dummy_status():
     """Fixture for a status class with different sensors and settings."""
 
@@ -34,10 +34,10 @@ def dummy_status():
         def sensor_returning_none(self):
             return None
 
-    yield Status()
+    return Status()
 
 
-@pytest.fixture()
+@pytest.fixture
 def dummy_device(mocker, dummy_status):
     """Returns a very basic device with patched out I/O and a dummy status."""
 
@@ -55,4 +55,4 @@ def dummy_device(mocker, dummy_status):
     patched_status.__annotations__ = {}
     patched_status.__annotations__["return"] = dummy_status
 
-    yield d
+    return d

--- a/miio/tests/dummies.py
+++ b/miio/tests/dummies.py
@@ -14,7 +14,7 @@ class DummyMiIOProtocol:
         try:
             return self.dummy_device.return_values[command](parameters)
         except KeyError:
-            raise DeviceError({"code": -32601, "message": "Method not found."})
+            raise DeviceError({"code": -32601, "message": "Method not found."}) from None
 
 
 class DummyDevice:
@@ -51,7 +51,7 @@ class DummyDevice:
         # TODO: ugly hack to check for pre-existing _model
         if getattr(self, "_model", None) is None:
             self._model = "dummy.model"
-        self.token = "ffffffffffffffffffffffffffffffff"  # nosec
+        self.token = "ffffffffffffffffffffffffffffffff"  # noqa: S105
         self.ip = "192.0.2.1"
 
     def _reset_state(self):

--- a/miio/tests/dummies.py
+++ b/miio/tests/dummies.py
@@ -14,7 +14,9 @@ class DummyMiIOProtocol:
         try:
             return self.dummy_device.return_values[command](parameters)
         except KeyError:
-            raise DeviceError({"code": -32601, "message": "Method not found."}) from None
+            raise DeviceError(
+                {"code": -32601, "message": "Method not found."}
+            ) from None
 
 
 class DummyDevice:

--- a/miio/tests/test_descriptorcollection.py
+++ b/miio/tests/test_descriptorcollection.py
@@ -46,7 +46,7 @@ def test_descriptors_from_status_object(dummy_device):
 
 
 @pytest.mark.parametrize(
-    "cls, params",
+    ("cls", "params"),
     [
         pytest.param(ActionDescriptor, {"method": lambda _: _}, id="action"),
         pytest.param(PropertyDescriptor, {"status_attribute": "foo"}),

--- a/miio/tests/test_deviceinfo.py
+++ b/miio/tests/test_deviceinfo.py
@@ -3,7 +3,7 @@ import pytest
 from miio.deviceinfo import DeviceInfo
 
 
-@pytest.fixture()
+@pytest.fixture
 def info():
     """Example response from Xiaomi Smart WiFi Plug (c&p from deviceinfo ctor)."""
     return DeviceInfo(

--- a/miio/tests/test_miot_models.py
+++ b/miio/tests/test_miot_models.py
@@ -107,7 +107,7 @@ TYPES_FOR_FORMAT = [
 ]
 
 
-@pytest.mark.parametrize("format,expected_type", TYPES_FOR_FORMAT)
+@pytest.mark.parametrize(("format", "expected_type"), TYPES_FOR_FORMAT)
 def test_format(format, expected_type):
     class Wrapper(BaseModel):
         """Need to wrap as plain string is not valid json."""

--- a/miio/tests/test_miotdevice.py
+++ b/miio/tests/test_miotdevice.py
@@ -43,7 +43,7 @@ def test_get_property_by(dev):
 
 
 @pytest.mark.parametrize(
-    "value_type,value",
+    ("value_type", "value"),
     [
         (None, 1),
         (MiotValueType.Int, "1"),
@@ -107,7 +107,7 @@ def test_call_action_by(dev):
 
 
 @pytest.mark.parametrize(
-    "model,expected_mapping,expected_log",
+    ("model", "expected_mapping", "expected_log"),
     [
         ("some.model", {"x": {"y": 1}}, ""),
         ("unknown.model", {"x": {"y": 1}}, "Unable to find mapping"),
@@ -174,7 +174,7 @@ def test_call_action_from_mapping(dev):
 
 
 @pytest.mark.parametrize(
-    "props,included_in_request",
+    ("props", "included_in_request"),
     [
         ({"access": ["read"]}, True),  # read only
         ({"access": ["read", "write"]}, True),  # read-write

--- a/miio/updater.py
+++ b/miio/updater.py
@@ -58,7 +58,7 @@ class OneShotServer:
         with open(file, "rb") as f:
             self.payload = f.read()
             self.server.payload = self.payload
-            self.md5 = hashlib.md5(self.payload).hexdigest()  # nosec
+            self.md5 = hashlib.md5(self.payload).hexdigest()  # noqa: S324
             _LOGGER.info(f"Using local {file} (md5: {self.md5})")
 
     @staticmethod
@@ -104,5 +104,5 @@ class OneShotServer:
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)
-    upd = OneShotServer("/tmp/test")  # nosec
+    upd = OneShotServer("/tmp/test")  # noqa: S108
     upd.serve_once()

--- a/poetry.lock
+++ b/poetry.lock
@@ -1983,4 +1983,4 @@ updater = ["netifaces"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "36c6770ec380f4e83d46f0174fcb33e84cef9f6cfbcc3ea060f193bd11e4dec8"
+content-hash = "97b5da356be7bf2bda26df0bf1be53c5e6bbaf7041d3f64fe513b5b44e67182a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ updater = ["netifaces"]
 backup_extract = ["android_backup"]
 crcmod = ["crcmod"]
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = ">=6.2.5"
 pytest-cov = "*"
 pytest-mock = "*"
@@ -79,29 +79,6 @@ docformatter = "*"
 mypy = {version = "*", markers = "platform_python_implementation == 'CPython'"}
 coverage = {extras = ["toml"], version = "*"}
 
-
-[tool.isort]
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-line_length = 88
-forced_separate = "miio.discover"
-known_first_party = "miio"
-known_third_party = [
-  "attr",
-  "click",
-  "construct",
-  "croniter",
-  "cryptography",
-  "netifaces",
-  "platformdirs",
-  "pytest",
-  "pytz",
-  "setuptools",
-  "tqdm",
-  "zeroconf"
-]
 
 
 [tool.coverage.run]
@@ -137,7 +114,14 @@ ignore-path-errors = ["docs/index.rst;D000"]
 target-version = "py311"
 
 [tool.ruff.lint]
-select = ["UP", "F401"]
+select = ["UP", "F", "B", "S", "PT", "I"]
+ignore = [
+  "PT011",  # pytest.raises() without match= — too many existing cases to fix at once
+]
+
+[tool.ruff.lint.per-file-ignores]
+"**/test_*.py" = ["S101", "S105", "S106", "B018", "B904", "PT009", "PT012", "PT027"]
+"miio/tests/**" = ["S101", "S105", "S106", "B018", "B904", "PT009", "PT012", "PT027"]
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Summary

Consolidates all linting into ruff, removing the redundant standalone tools. Three commits:

**1. Migrate deprecated poetry dev-dependencies section**

Renames `[tool.poetry.dev-dependencies]` to `[tool.poetry.group.dev.dependencies]` to silence the deprecation warning emitted on every poetry invocation.

**2. Replace flake8, bandit, isort, pyupgrade with ruff**

Ruff covers all rules provided by the removed tools via built-in rule sets:

| Removed tool | Ruff rule set |
|---|---|
| flake8 + plugins | `F`, `B`, `PT` |
| bandit | `S` |
| isort | `I` |

Also removes the now-redundant `[tool.isort]` config section and adds `--exit-non-zero-on-fix` to the ruff hook so CI fails when auto-fixes are applied.

**3. Fix violations from expanded ruleset**

- Adds `per-file-ignores` for test files (S101, S105, S106, B018, B904, PT009, PT012, PT027)
- Adds global ignore for PT011 (`pytest.raises()` without `match=`) — too many existing cases to address in this PR
- Fixes B904 in 7 production files (`raise ... from exc/None`)
- Converts `# nosec` (bandit) to `# noqa: Sxxx` (ruff) throughout the codebase

## Test plan

- [ ] All 1421 tests pass
- [ ] `pre-commit run --all-files` runs clean