### PR TITLE
Replace pytz with stdlib zoneinfo

### DIFF
--- a/miio/integrations/roborock/vacuum/tests/test_vacuum.py
+++ b/miio/integrations/roborock/vacuum/tests/test_vacuum.py
@@ -1,6 +1,7 @@
 import datetime
 from unittest import TestCase
 from unittest.mock import patch
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -16,7 +17,7 @@ from ..vacuum import (
     MopMode,
     WaterFlow,
 )
-from ..vacuumcontainers import VacuumStatus
+from ..vacuumcontainers import Timer, VacuumStatus
 
 
 class DummyRoborockProtocol(DummyMiIOProtocol):
@@ -507,6 +508,63 @@ class TestVacuum(TestCase):
 
     def test_set_waterflow(self):
         self.device.set_waterflow(WaterFlow.High)
+
+    def test_timer_with_timezone(self):
+        tz = ZoneInfo("Europe/Berlin")
+        data = ["1488667794112", "on", ["30 8 * * 1,2,3,4,5", ["start_clean", ""]]]
+        timer = Timer(data, timezone=tz)
+        assert timer.id == "1488667794112"
+        assert timer.enabled is True
+        assert timer.cron == "30 8 * * 1,2,3,4,5"
+        assert timer.next_schedule.tzinfo is not None
+
+    def test_timer_disabled(self):
+        tz = ZoneInfo("UTC")
+        data = ["1488667777661", "off", ["49 21 * * 3,4,5,6", ["start_clean", ""]]]
+        timer = Timer(data, timezone=tz)
+        assert timer.enabled is False
+
+    def test_timer_ts(self):
+        tz = ZoneInfo("UTC")
+        data = ["1488667794112", "on", ["0 0 * * *", ["start_clean", ""]]]
+        timer = Timer(data, timezone=tz)
+        assert timer.ts is not None
+
+    def test_timer_ts_non_numeric_id(self):
+        tz = ZoneInfo("UTC")
+        data = ["valetudo-timer", "on", ["0 0 * * *", ["start_clean", ""]]]
+        timer = Timer(data, timezone=tz)
+        assert timer.ts is None
+
+    def test_timer_list(self):
+        timer_data = [
+            ["1488667794112", "on", ["30 8 * * 1,2,3,4,5", ["start_clean", ""]]],
+            ["1488667777661", "off", ["49 21 * * 3,4,5,6", ["start_clean", ""]]],
+        ]
+        with patch.object(self.device, "send") as mock_send:
+            mock_send.side_effect = lambda cmd, *a, **kw: (
+                [{"olson": "Europe/Berlin", "posix": "CET-1CEST,M3.5.0,M10.5.0/3"}]
+                if cmd == "get_timezone"
+                else timer_data
+            )
+            timers = self.device.timer()
+        assert len(timers) == 2
+        assert timers[0].enabled is True
+        assert timers[1].enabled is False
+
+    def test_configure_wifi_with_timezone(self):
+        with patch.object(self.device, "send", return_value=["ok"]) as mock_send:
+            self.device.configure_wifi("MySSID", "secret", timezone="UTC")
+            call_params = mock_send.call_args[0][1]
+        assert call_params["tz"] == "UTC"
+        assert call_params["gmt_offset"] == 0.0
+
+    def test_configure_wifi_with_offset_timezone(self):
+        with patch.object(self.device, "send", return_value=["ok"]) as mock_send:
+            self.device.configure_wifi("MySSID", "secret", timezone="Asia/Shanghai")
+            call_params = mock_send.call_args[0][1]
+        assert call_params["tz"] == "Asia/Shanghai"
+        assert call_params["gmt_offset"] == 8.0
 
 
 class DummyVacuumS7(DummyVacuum):

--- a/miio/integrations/roborock/vacuum/vacuum.py
+++ b/miio/integrations/roborock/vacuum/vacuum.py
@@ -9,10 +9,9 @@ import pathlib
 import time
 from enum import Enum
 from typing import Any
-
-import click
 from zoneinfo import ZoneInfo
 
+import click
 from platformdirs import user_cache_dir
 
 from miio.click_common import (

--- a/miio/integrations/roborock/vacuum/vacuum.py
+++ b/miio/integrations/roborock/vacuum/vacuum.py
@@ -11,7 +11,8 @@ from enum import Enum
 from typing import Any
 
 import click
-import pytz
+from zoneinfo import ZoneInfo
+
 from platformdirs import user_cache_dir
 
 from miio.click_common import (
@@ -564,7 +565,7 @@ class RoborockVacuum(Device):
         if not res:
             return timers
 
-        timezone = pytz.timezone(self.timezone())
+        timezone = ZoneInfo(self.timezone())
         for rec in res:
             try:
                 timers.append(Timer(rec, timezone=timezone))
@@ -781,7 +782,7 @@ class RoborockVacuum(Device):
         """Configure the wifi settings."""
         extra_params = {}
         if timezone is not None:
-            now = datetime.datetime.now(pytz.timezone(timezone))
+            now = datetime.datetime.now(ZoneInfo(timezone))
             offset_as_float = now.utcoffset().total_seconds() / 60 / 60
             extra_params["tz"] = timezone
             extra_params["gmt_offset"] = offset_as_float

--- a/miio/integrations/roborock/vacuum/vacuumcontainers.py
+++ b/miio/integrations/roborock/vacuum/vacuumcontainers.py
@@ -3,7 +3,6 @@ from datetime import datetime, time, timedelta
 from enum import IntEnum
 from typing import Any
 from urllib import parse
-
 from zoneinfo import ZoneInfo
 
 from croniter import croniter

--- a/miio/integrations/roborock/vacuum/vacuumcontainers.py
+++ b/miio/integrations/roborock/vacuum/vacuumcontainers.py
@@ -4,8 +4,9 @@ from enum import IntEnum
 from typing import Any
 from urllib import parse
 
+from zoneinfo import ZoneInfo
+
 from croniter import croniter
-from pytz import BaseTzInfo
 
 from miio.device import DeviceStatus
 from miio.devicestatus import sensor, setting
@@ -859,7 +860,7 @@ class Timer(DeviceStatus):
     the creation time.
     """
 
-    def __init__(self, data: list[Any], timezone: BaseTzInfo) -> None:
+    def __init__(self, data: list[Any], timezone: ZoneInfo) -> None:
         # id / timestamp, enabled, ['<cron string>', ['command', 'params']
         # [['1488667794112', 'off', ['49 22 * * 6', ['start_clean', '']]],
         #  ['1488667777661', 'off', ['49 21 * * 3,4,5,6', ['start_clean', '']]
@@ -867,7 +868,7 @@ class Timer(DeviceStatus):
         self.data = data
         self.timezone = timezone
 
-        localized_ts = timezone.localize(self._now())
+        localized_ts = self._now().replace(tzinfo=timezone)
 
         # Initialize croniter to cause an exception on invalid entries (#847)
         self.croniter = croniter(self.cron, start_time=localized_ts)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1983,4 +1983,4 @@ updater = ["netifaces"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "97b5da356be7bf2bda26df0bf1be53c5e6bbaf7041d3f64fe513b5b44e67182a"
+content-hash = "3b909ffa5110db514a311d7fc91287058a86a86e666e51e70f39c26ac2253a7a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ cryptography = ">=35"
 construct = "^2.10.56"
 zeroconf = "^0"
 attrs = "*"
-pytz = "*"
 platformdirs = "*"
 tqdm = "^4"
 micloud = { version = ">=0.6" }


### PR DESCRIPTION
Closes #1825

## Summary

- Remove `pytz` dependency from `pyproject.toml`
- Replace `pytz.timezone()` with `ZoneInfo()` from stdlib `zoneinfo` module (Python 3.9+, now project minimum)
- Replace `timezone.localize(dt)` (pytz-specific) with `dt.replace(tzinfo=timezone)` (standard)
- Update `BaseTzInfo` type annotation to `ZoneInfo`

## Tests

New tests in `TestVacuum`:
- `test_timer_with_timezone` — Timer parses cron and returns a timezone-aware `next_schedule`
- `test_timer_disabled` — Timer respects `off` state
- `test_timer_ts` — Timer creation timestamp is parsed from unix ID
- `test_timer_ts_non_numeric_id` — Non-numeric timer IDs (e.g. valetudo) return `None` for `ts`
- `test_timer_list` — `vacuum.timer()` builds Timer objects via `ZoneInfo`
- `test_configure_wifi_with_timezone` — UTC offset is 0.0 for UTC
- `test_configure_wifi_with_offset_timezone` — UTC offset is 8.0 for Asia/Shanghai

All 47 tests pass.