### PR TITLE
Fix DeviceGroup compatibility with click >= 8.2.0

### DIFF
--- a/miio/click_common.py
+++ b/miio/click_common.py
@@ -255,11 +255,11 @@ class DeviceGroup(click.MultiCommand):
 
         super().__init__(
             name or device_class.__name__.lower(),
-            invoke_without_command,
-            no_args_is_help,
-            subcommand_metavar,
-            chain,
-            result_callback,
+            invoke_without_command=invoke_without_command,
+            no_args_is_help=no_args_is_help,
+            subcommand_metavar=subcommand_metavar,
+            chain=chain,
+            result_callback=result_callback,
             **attrs,
         )
 


### PR DESCRIPTION
## Summary

- click 8.2.0 inserted a new `commands` positional parameter into `MultiCommand.__init__`, shifting all subsequent positional args by one slot
- This caused `chain=False` to be passed as `subcommand_metavar`, making click try to `" ".join([..., False, ...])` → `TypeError`
- Fix: pass all arguments as keyword args in `DeviceGroup.__init__` — parameter names are unchanged across click versions, so this is fully backwards-compatible

Fixes #2031

## Test plan

- [ ] `miiocli fan` shows help without error with click 8.1.8
- [ ] `miiocli fan` shows help without error with click 8.2.0+